### PR TITLE
fix: preserve github workflows from downstream

### DIFF
--- a/.github/workflows/rebase-upstream.yaml
+++ b/.github/workflows/rebase-upstream.yaml
@@ -65,6 +65,12 @@ jobs:
         if: steps.check_upstream.outputs.has_changes == 'true'
         run: |
           git checkout -B sync/upstream-${UPSTREAM_BRANCH} upstream/${UPSTREAM_BRANCH}
+          # Preserve downstream-managed .github directory by restoring it from the downstream branch
+          # This ensures upstream changes never override downstream workflow/issue templates
+          git restore --source=origin/${DOWNSTREAM_BRANCH} --worktree --staged .github || true
+          if ! git diff --quiet --cached; then
+            git commit -m "Preserve downstream .github directory"
+          fi
           git push origin sync/upstream-${UPSTREAM_BRANCH} --force-with-lease
 
       # Open or update a PR into downstream


### PR DESCRIPTION
preserve github workflows from downstream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved upstream sync process to preserve project-specific automation and templates during branch creation from upstream, preventing unintended overwrites.
  * Added conditional preservation step that only runs when relevant changes are detected, reducing unnecessary commits.
  * Ensures a clean, single commit is created when preservation is needed, improving clarity of sync history and reliability of ongoing automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->