### PR TITLE
fix: Preserve downstream-owned files (.github, CHANGELOG, OWNERS)

### DIFF
--- a/.github/workflows/rebase-upstream.yaml
+++ b/.github/workflows/rebase-upstream.yaml
@@ -1,0 +1,187 @@
+name: Sync Upstream
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      downstream_branch:
+        description: Downstream branch to update (destination)
+        required: false
+        default: main
+      upstream_branch:
+        description: Upstream branch to sync from (source)
+        required: false
+        default: main
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      DOWNSTREAM_BRANCH: ${{ inputs.downstream_branch || 'main' }}
+      UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'main' }}
+      HEAD_BRANCH: sync/upstream-${{ inputs.upstream_branch || 'main' }}
+      LABEL: automated-rebase
+
+    steps:
+      - name: Checkout downstream repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DOWNSTREAM_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ secrets.REPO_WORKFLOW_PAT }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote and fetch
+        run: |
+          git remote add upstream https://github.com/kubeflow/sdk || git remote set-url upstream https://github.com/kubeflow/sdk
+          git fetch --prune upstream "${UPSTREAM_BRANCH}"
+          git fetch --prune origin "${DOWNSTREAM_BRANCH}"
+
+      - name: Build/refresh sync branch from downstream base
+        run: |
+          set -euo pipefail
+          git checkout -B "${HEAD_BRANCH}" "origin/${DOWNSTREAM_BRANCH}"
+
+      - name: Rebase onto upstream and preserve owned paths
+        run: |
+          set -euo pipefail
+          git config rerere.enabled true
+          git config advice.skippedCherryPicks false
+          shopt -s globstar nullglob
+
+          OWNED_PATHS=(
+            ".github/**"
+            "CHANGELOG"
+            "OWNERS"
+          )
+          is_owned() {
+            local f="$1"
+            for pat in "${OWNED_PATHS[@]}"; do
+              [[ "$f" == $pat ]] && return 0
+            done
+            return 1
+          }
+
+          REBASE_OK=false
+          if git rebase "upstream/${UPSTREAM_BRANCH}"; then
+            REBASE_OK=true
+          else
+            while true; do
+              mapfile -t CONFLICTS < <(git diff --name-only --diff-filter=U || true)
+              if ((${#CONFLICTS[@]}==0)); then
+                echo "Rebase paused without listed conflicts; aborting for safety."
+                git rebase --abort
+                break
+              fi
+
+              ONLY_OWNED=true
+              for f in "${CONFLICTS[@]}"; do
+                if ! is_owned "$f"; then ONLY_OWNED=false; break; fi
+              done
+
+              if "$ONLY_OWNED"; then
+                echo "Conflicts only in owned paths; keeping downstream versions…"
+                for f in "${CONFLICTS[@]}"; do
+                  if git cat-file -e "origin/${DOWNSTREAM_BRANCH}:${f}" 2>/dev/null; then
+                    git checkout "origin/${DOWNSTREAM_BRANCH}" -- "$f" || true
+                    git add -- "$f"
+                  else
+                    git rm -f -- "$f" || true
+                  fi
+                done
+                if git -c core.editor=true rebase --continue; then
+                  REBASE_OK=true
+                  break
+                fi
+              else
+                echo "Conflicts outside owned paths detected:"
+                printf '  - %s\n' "${CONFLICTS[@]}"
+                echo "Aborting rebase and switching to conflict-PR mode…"
+                git rebase --abort
+                git checkout -B "${HEAD_BRANCH}" "upstream/${UPSTREAM_BRANCH}"
+                # Keep owned paths from downstream even in conflict PR head
+                for p in ".github" "CHANGELOG" "OWNERS"; do
+                  if git cat-file -e "origin/${DOWNSTREAM_BRANCH}:${p}" 2>/dev/null; then
+                    git checkout "origin/${DOWNSTREAM_BRANCH}" -- "$p" || true
+                  elif git ls-tree -r --name-only "origin/${DOWNSTREAM_BRANCH}" | grep -q "^${p%/}/"; then
+                    git checkout "origin/${DOWNSTREAM_BRANCH}" -- "${p%/}" || true
+                  fi
+                done
+                if ! git diff --quiet; then
+                  git add -A
+                  git commit -m "Preserve downstream-owned files on conflict PR"
+                fi
+                REBASE_OK=false
+                break
+              fi
+            done
+          fi
+
+          # Re-pin owned paths when rebase finished on top of downstream base
+          if [ "$REBASE_OK" = true ]; then
+            for p in ".github" "CHANGELOG" "OWNERS"; do
+              if git cat-file -e "origin/${DOWNSTREAM_BRANCH}:${p}" 2>/dev/null; then
+                git checkout "origin/${DOWNSTREAM_BRANCH}" -- "$p" || true
+              elif git ls-tree -r --name-only "origin/${DOWNSTREAM_BRANCH}" | grep -q "^${p%/}/"; then
+                git checkout "origin/${DOWNSTREAM_BRANCH}" -- "${p%/}" || true
+              fi
+            done
+            if ! git diff --quiet; then
+              git add -A
+              git commit -m "Preserve downstream-owned files after rebase"
+            fi
+          fi
+
+      - name: Detect actual changes vs downstream (tree diff)
+        id: diffcheck
+        run: |
+          set -euo pipefail
+          # Use merge-base compare (same view as a PR). If nothing changed, skip push/PR.
+          if git diff --quiet "origin/${DOWNSTREAM_BRANCH}...${HEAD_BRANCH}"; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No actual diff vs downstream; skipping push/PR."
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push sync branch (only if changed)
+        if: steps.diffcheck.outputs.has_changes == 'true'
+        run: |
+          set -euo pipefail
+          git push origin "${HEAD_BRANCH}" --force-with-lease
+
+      - name: Create or update PR (only if changed)
+        if: steps.diffcheck.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="fix: Sync upstream/${UPSTREAM_BRANCH} into ${DOWNSTREAM_BRANCH}"
+          BODY=$'Automated upstream sync rebased onto upstream; downstream-owned files preserved.\n\n- Source: upstream/'"${UPSTREAM_BRANCH}"$'\n- Base: '"${DOWNSTREAM_BRANCH}"
+          PR_NUMBER=$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --head "${HEAD_BRANCH}" \
+            --state open \
+            --label "${LABEL}" \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${PR_NUMBER}" ]; then
+            gh pr edit "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --title "${TITLE}" --body "${BODY}"
+          else
+            gh pr create --repo "${GITHUB_REPOSITORY}" \
+              --base "${DOWNSTREAM_BRANCH}" \
+              --head "${HEAD_BRANCH}" \
+              --title "${TITLE}" \
+              --body "${BODY}" \
+              --label "${LABEL}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare release branch
-    if: ${{ github.repository == 'kubeflow/sdk' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-') && github.actor == 'github-actions[bot]') }}
+    if: ${{ !(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-') && github.actor == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.version }}

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 approvers:
-  - andreyvelich
   - astefanutti
-  - Electronic-Waste
-reviewers:
-  - kramaranya
   - szaher
-emeritus_approvers:
-  - tenzen-y
+  - kramaranya
+  - briangallagher
+  - MStokluska
+  - Fiona-Waters


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced an automated “Sync Upstream” workflow to periodically align branches, creating PRs only when changes are detected and safely handling conflicts.
  * Broadened release workflow conditions to run the prepare step on more repositories when bot-driven pushes occur on release branches.
  * Updated project ownership: refreshed approvers and reviewers; revised emeritus approvers list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->