### PR TITLE
feat: Add ODH release workflow and md file

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -1,0 +1,149 @@
+name: ODH Release
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    name: Prepare release
+    if: ${{ github.repository == 'opendatahub-io/kubeflow-sdk' }}
+    runs-on: ubuntu-latest
+    outputs:
+      base-version: ${{ steps.vars.outputs.base-version }}
+      release-version: ${{ steps.vars.outputs.release-version }}
+      is-prerelease: ${{ steps.vars.outputs.is-prerelease }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release version
+        id: vars
+        run: |
+          BASE_VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' kubeflow/__init__.py)
+
+          # Determine release version with -odh suffix
+          # Start at -odh-1 and increment from there
+          RELEASE_VERSION_BASE="v${BASE_VERSION}-odh"
+
+          # Check if this version tag already exists, and find the next available increment
+          INCREMENT=1
+          FINAL_VERSION="${RELEASE_VERSION_BASE}-${INCREMENT}"
+          while git ls-remote --tags origin | grep -q "refs/tags/${FINAL_VERSION}$"; do
+            INCREMENT=$((INCREMENT + 1))
+            FINAL_VERSION="${RELEASE_VERSION_BASE}-${INCREMENT}"
+          done
+
+          echo "base-version=$BASE_VERSION" >> $GITHUB_OUTPUT
+          echo "release-version=$FINAL_VERSION" >> $GITHUB_OUTPUT
+
+          if [[ "$BASE_VERSION" =~ rc[0-9]+$ ]]; then
+            echo "is-prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+          echo "Base version: $BASE_VERSION"
+          echo "Release version: $FINAL_VERSION"
+
+  build:
+    name: Build package
+    needs: [prepare]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup build environment
+        run: |
+          make verify
+
+      - name: Run unit tests
+        run: |
+          make test-python
+
+      - name: Build package
+        run: |
+          uv build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ needs.prepare.outputs.release-version }}
+          path: dist/
+
+  create-tag:
+    name: Create and push tag
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create tag
+        run: |
+          RELEASE_VERSION="${{ needs.prepare.outputs.release-version }}"
+          echo "Creating tag: $RELEASE_VERSION"
+
+          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_VERSION}$"; then
+            echo "Tag $RELEASE_VERSION already exists. Skipping"; exit 0; fi
+          git tag "$RELEASE_VERSION"
+          git push origin "$RELEASE_VERSION"
+
+  github-release:
+    name: Create GitHub Release
+    needs: [prepare, build, create-tag]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ needs.prepare.outputs.release-version }}
+          path: dist/
+      - name: Extract changelog
+        if: needs.prepare.outputs.is-prerelease != 'true'
+        id: changelog
+        run: |
+          BASE_VERSION="${{ needs.prepare.outputs.base-version }}"
+          MAJOR_MINOR=$(echo "$BASE_VERSION" | cut -d. -f1,2)
+          CHANGELOG_FILE="CHANGELOG/CHANGELOG-${MAJOR_MINOR}.md"
+          set -euo pipefail
+          [[ -f "$CHANGELOG_FILE" ]] || { echo "ERROR: $CHANGELOG_FILE not found" >&2; exit 1; }
+          HEADER_REGEX="^# \\[${BASE_VERSION//./\\.}\\]"
+          SECTION=$(sed -n "/$HEADER_REGEX/,\$p" "$CHANGELOG_FILE" | tail -n +2)
+          [[ -n "$SECTION" ]] || { echo "ERROR: No changelog section for $BASE_VERSION in $CHANGELOG_FILE" >&2; exit 1; }
+          NEXT_VERSION=$(echo "$SECTION" | grep -m1 "^# \\[[0-9]" || true)
+          if [[ -n "$NEXT_VERSION" ]]; then
+            CHANGELOG=$(echo "$SECTION" | sed -n "1,/^# \\[[0-9]/p" | sed '1d;$d')
+          else
+            CHANGELOG=$(echo "$SECTION" | sed '1d')
+          fi
+          [[ -n "$CHANGELOG" ]] || { echo "ERROR: Empty changelog body for $BASE_VERSION in $CHANGELOG_FILE" >&2; exit 1; }
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.release-version }}
+          name: ${{ needs.prepare.outputs.release-version }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: ${{ needs.prepare.outputs.is-prerelease == 'true' }}
+          generate_release_notes: false
+          files: |
+            dist/*

--- a/odh-release.md
+++ b/odh-release.md
@@ -1,0 +1,133 @@
+# ODH Midstream Release Process
+
+This document describes the release process for the OpenDataHub (ODH) midstream fork of Kubeflow SDK.
+
+## Prerequisites
+
+- Write permission for the opendatahub-io/kubeflow-sdk repository
+- Access to trigger GitHub Actions workflows
+
+## Versioning Policy
+
+### Base Version
+The base version in `kubeflow/__init__.py` follows upstream Kubeflow SDK versioning (format: `X.Y.Z`).
+
+### ODH Release Version
+ODH releases use the format: `vX.Y.Z-odh-N` where:
+- `X.Y.Z` is the upstream base version
+- `-odh` suffix indicates an ODH midstream release
+- `-N` is an auto-incrementing number starting at 1
+
+**Examples:**
+- First ODH release based on upstream 0.2.0: `v0.2.0-odh-1`
+- Second ODH release (with patches) on same base: `v0.2.0-odh-2`
+- First ODH release based on upstream 0.3.0: `v0.3.0-odh-1`
+
+The release workflow automatically determines the next available `-N` increment.
+
+## Changelog Management
+
+### Changelog Structure
+
+ODH maintains the same changelog structure as upstream:
+
+```markdown
+CHANGELOG/
+├── CHANGELOG-0.1.md    # All 0.1.x releases
+├── CHANGELOG-0.2.md    # All 0.2.x releases
+└── CHANGELOG-0.3.md    # All 0.3.x releases
+```
+
+### Adding ODH-Specific Changes
+
+When making ODH-specific changes, manually add them to the appropriate changelog file and prefix them with `[ODH]` to distinguish from upstream changes.
+
+**Example:**
+
+```markdown
+# [0.2.0](https://github.com/kubeflow/sdk/releases/tag/0.2.0) (2025-11-06)
+
+## New Features
+
+- feat(optimizer): Add get_best_results API to OptimizerClient ([#152](https://github.com/kubeflow/sdk/pull/152)) by @kramaranya
+- **[ODH] feat: Add support for ODH authentication** by @yourname
+
+## Bug Fixes
+
+- fix(ci): Update url for installing docker ([#151](https://github.com/kubeflow/sdk/pull/151)) by @Fiona-Waters
+- **[ODH] fix: Container backend compatibility with ODH clusters** by @yourname
+
+## Maintenance
+
+- chore: Add HPO support to readme ([#141](https://github.com/kubeflow/sdk/pull/141)) by @kramaranya
+- **[ODH] chore: Update documentation for ODH deployment** by @yourname
+```
+
+### Guidelines for ODH Changelog Entries
+
+1. **Prefix with `[ODH]`**: All ODH-specific changes should be clearly marked
+2. **Follow upstream conventions**: Use the same format as upstream (feat/fix/chore prefix)
+3. **Add to appropriate section**: New Features, Bug Fixes, or Maintenance
+4. **Keep it concise**: One line per change, focus on what and why
+
+## Release Process
+
+### 1. Update Changelog (if needed)
+
+If you're releasing ODH-specific changes:
+
+1. Edit the appropriate `CHANGELOG/CHANGELOG-X.Y.md` file
+2. Add your ODH-specific changes with `[ODH]` prefix
+3. Commit and push to `main`:
+   ```bash
+   git add CHANGELOG/CHANGELOG-X.Y.md
+   git commit -m "chore: Update changelog for ODH release"
+   git push origin main
+   ```
+
+### 2. Trigger Release Workflow
+
+The release workflow is **manual-only** to give you full control:
+
+1. Go to [GitHub Actions](https://github.com/opendatahub-io/kubeflow-sdk/actions)
+2. Select the **ODH Release** workflow
+3. Click **Run workflow**
+4. Select the branch to release from (usually `main`)
+5. Click **Run workflow**
+
+### 3. Workflow Steps
+
+The automated workflow will:
+
+1. **Prepare**:
+   - Extract base version from `kubeflow/__init__.py` (e.g., `0.2.0`)
+   - Determine next ODH release version (e.g., `v0.2.0-odh-1`)
+
+2. **Build**:
+   - Set up Python environment
+   - Run tests (`make test-python`)
+   - Build package with `uv build`
+   - Upload build artifacts
+
+3. **Create Tag**:
+   - Create git tag with release version
+   - Push tag to repository
+
+4. **GitHub Release**:
+   - Extract changelog from `CHANGELOG/CHANGELOG-X.Y.md`
+   - Create GitHub release with changelog as release notes
+   - Attach build artifacts to release
+
+### 4. Verification
+
+After the workflow completes:
+
+1. Verify the tag was created:
+   ```bash
+   git fetch --tags
+   git tag -l "v*-odh-*"
+   ```
+
+2. Check the [GitHub Releases page](https://github.com/opendatahub-io/kubeflow-sdk/releases)
+
+3. Verify release notes include both upstream and ODH changes


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds a release workflow for this(ODH midstream) fork of Kubeflow SDK. It includes versioning as discussed (v0.2.0-odh-1 for example) with matching tag. It can only be triggered manually at the moment - we can change that if needed. 

One other thing to mention is the Changelog. We need to decide if it makes sense to include a changelog. Options:
 - we include upstream changelog for that release and manually add our updates clearly showing that they are ours.
 - we add our own ODH-changelog with just our changes and mention that they are on top of upstream version
 - we don't do anything in relation to changelog

If we include the changelog check like it is now in this PR, if we patch release midstream there will be an error as there won't be a changelog for that version upstream.  
BUT based on this implementation if we do a `patch` release it would just be the next ODH release (still based on the same upstream release) so the patch release would be v0.2.0-odh-(+1), rather than v0.2.1 (as the patch wasn't released upstream). Hope this makes sense!

  ## What's Added

  ### 1. ODH Release Workflow (`.github/workflows/odh-release.yaml`)

  A GitHub Actions workflow that automates ODH midstream releases with the following features:

  - **Manual trigger only**: Provides full control over when releases are created
  - **ODH versioning**: Automatically creates releases with format `vX.Y.Z-odh-N` where:
    - `X.Y.Z` is the upstream base version from `kubeflow/__init__.py`
    - `-N` auto-increments starting at 1 (e.g., `v0.2.0-odh-1`, `v0.2.0-odh-2`)
  - **Automated workflow**:
    1. Determines next available ODH version
    2. Runs tests and builds package
    3. Creates and pushes git tag
    4. Creates GitHub release with changelog and artifacts

  ### 2. Release Documentation (`odh-release.md`)

  Comprehensive documentation covering:
  - ODH versioning policy
  - Changelog management with `[ODH]` prefix for midstream-specific changes
  - Step-by-step release process
  - Verification steps

  ## How to Use

  1. Optionally update `CHANGELOG/CHANGELOG-X.Y.md` with ODH-specific changes (prefixed with `[ODH]`)
  2. Go to Actions → "ODH Release" workflow
  3. Click "Run workflow" and select branch
  4. Workflow creates tag and GitHub release automatically

  ## Testing
Successfully tested on my fork.

Fixes #https://issues.redhat.com/browse/RHOAIENG-39311

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow coordinating version selection, build/validation, artifact generation, tag creation, and GitHub release publication.
* **Documentation**
  * Added a release process guide detailing versioning conventions, changelog guidelines, step-by-step release steps, and verification commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->