### PR TITLE
fix: write final metrics to termination message for reliable progress…

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -326,11 +326,7 @@ def _create_progression_instrumentation(metrics_port: int) -> tuple:
                     _update_progression_metrics(update_dict)
 
         def on_train_end(self, args, state, control, **kwargs) -> None:
-            """Update final progression state with actual completion values.
-
-            Sets training_finished flag to prevent on_step_end from overwriting
-            completion state during post-training evaluation steps.
-            """
+            """Update final progression state and write to termination message."""
             self.training_finished = True
 
             total_steps = state.max_steps if state.max_steps > 0 else None
@@ -344,18 +340,52 @@ def _create_progression_instrumentation(metrics_port: int) -> tuple:
                 else 100
             )
 
-            _update_progression_metrics(
-                {
-                    "currentStep": current_step,
-                    "totalSteps": total_steps,
-                    "currentEpoch": (
-                        float(state.epoch) if hasattr(state, "epoch") and state.epoch else 0.0
-                    ),
-                    "totalEpochs": total_epochs,
-                    "progressPercentage": progress_pct,
-                    "estimatedRemainingSeconds": 0,
-                }
-            )
+            final_metrics = {
+                "currentStep": current_step,
+                "totalSteps": total_steps,
+                "currentEpoch": (
+                    float(state.epoch) if hasattr(state, "epoch") and state.epoch else 0.0
+                ),
+                "totalEpochs": total_epochs,
+                "progressPercentage": progress_pct,
+                "estimatedRemainingSeconds": 0,
+            }
+
+            # Update HTTP server metrics
+            _update_progression_metrics(final_metrics)
+
+            # Write final metrics to termination message for controller capture
+            if state.is_world_process_zero:
+                try:
+                    import json
+
+                    # Hold lock during message construction and file write
+                    # (to prevent race conditions)
+                    with _progression_metrics_lock:
+                        termination_message = {
+                            "progressPercentage": progress_pct,
+                            "estimatedRemainingSeconds": 0,
+                            "currentStep": current_step,
+                            "totalSteps": total_steps,
+                            "currentEpoch": (
+                                float(state.epoch)
+                                if hasattr(state, "epoch") and state.epoch
+                                else 0.0
+                            ),
+                            "totalEpochs": total_epochs,
+                            "trainMetrics": dict(_progression_metrics_state.trainMetrics),
+                            "evalMetrics": dict(_progression_metrics_state.evalMetrics),
+                        }
+
+                        with open("/dev/termination-log", "w") as f:
+                            json.dump(termination_message, f)
+                    print("[Kubeflow] Final metrics written to termination message", flush=True)
+                except Exception as e:
+                    print(
+                        f"[Kubeflow] Warning: Failed to write termination message: {e}. "
+                        f"Controller will fall back to HTTP polling.",
+                        flush=True,
+                    )
 
     def apply_progression_tracking():
         """Patch Trainer.__init__ to inject KubeflowProgressCallback."""


### PR DESCRIPTION
Added termination message write in on_train_end to ensure controller
captures final training metrics even if HTTP server becomes unreachable
or pod terminates before final scrape.

Kubernetes reads /dev/termination-log after container exit, providing
a reliable fallback mechanism for metrics capture that doesn't depend
on pod lifecycle timing or network availability.

Depends on : https://github.com/opendatahub-io/trainer/pull/33#issue-3685974734

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread-safety and error handling for final training-state updates; primary-process write is now guarded and falls back to controller polling with a logged warning on failure.

* **New Features**
  * Final completion notifications now include expanded payload: training and evaluation metrics, progress percentage, step/epoch counts, and estimated remaining time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->