### PR TITLE
fix: Move RHAI trainer progression annotations to metadata instead of spec

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -234,6 +234,11 @@ class KubernetesBackend(RuntimeBackend):
             pod_template_overrides=pod_template_overrides,
         )
 
+        # Apply RHAI trainer progression tracking annotations to metadata
+        is_rhai_trainer = trainer and isinstance(trainer, get_args(RHAITrainer))
+        if is_rhai_trainer:
+            annotations = rhai_utils.merge_progression_annotations(trainer, annotations)
+
         # Build the TrainJob.
         train_job = models.TrainerV1alpha1TrainJob(
             apiVersion=constants.API_VERSION,
@@ -679,12 +684,6 @@ class KubernetesBackend(RuntimeBackend):
                 if initializer.dataset
                 else None,
                 model=utils.get_model_initializer(initializer.model) if initializer.model else None,
-            )
-
-        # Apply RHAI trainer progression tracking annotations
-        if is_rhai_trainer:
-            trainjob_spec.annotations = rhai_utils.merge_progression_annotations(
-                trainer, trainjob_spec.annotations
             )
 
         return trainjob_spec


### PR DESCRIPTION
To fix the location of RHAI trainer progression tracking annotations (trainer.opendatahub.io/progression-tracking, trainer.opendatahub.io/metrics-port, trainer.opendatahub.io/metrics-poll-interval) from spec.annotations to metadata.annotations.

it was just overlook during this PR merge : https://github.com/opendatahub-io/kubeflow-sdk/pull/30 


Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how progression annotations are applied for RHAI trainers, reorganizing annotation merging to occur at the metadata level.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->