### PR TITLE
fix: remove is_mpi param from get_script_for_python_packages call

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -884,17 +884,12 @@ def get_trainer_cr_from_transformers_trainer(
     # Build the command directly with the wrapped function code
     func_file = os.path.basename(inspect.getfile(trainer.func))
 
-    is_mpi = runtime.trainer.command[0] == "mpirun"
-    if is_mpi:
-        func_file = os.path.join(constants.DEFAULT_MPI_USER_HOME, func_file)
-
     # Install Python packages if required
     install_packages = ""
     if trainer.packages_to_install:
         install_packages = utils.get_script_for_python_packages(
             trainer.packages_to_install,
             trainer.pip_index_urls,
-            is_mpi,
         )
 
     # Build the trainer command with wrapped function code


### PR DESCRIPTION

Fixes #
Fixes a bug introduced during upstream sync where `get_script_for_python_packages()` function signature changed but the call site in `transformers.py` was not updated.

The PR - https://github.com/opendatahub-io/kubeflow-sdk/pull/38 removed is_mpi from get_script_for_python_packages() and updated the call in utils.py line 329, but missed updating transformers.py line 896.

cc: @briangallagher @kramaranya 


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined training function configuration by removing MPI-specific logic from the trainer initialization process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->