### PR TITLE
fix: handle PyTorch 2.4+ numpy unpickling errors in RNG state loading

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -17,7 +17,6 @@
 from dataclasses import dataclass, field
 import inspect
 import os
-import pickle
 import textwrap
 from typing import Callable, Optional
 
@@ -179,6 +178,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
     Checkpoint instrumentation code injected into training pods.
     """
     import os
+    import pickle
     import re
     import shutil
     import signal
@@ -191,8 +191,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
     from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER
 
-    # PyTorch 2.4+ fix: Catches numpy unpickling errors and retries with weights_only=False
-    # RNG state files from Transformers Trainer contain numpy types that fail with weights_only=True
+    # PyTorch 2.4+ fix: Catches numpy unpickling errors and retries with weights_only=False.
+    # RNG state files from Transformers Trainer contain numpy types that fail with
+    # weights_only=True.
     _original_torch_load = torch.load
 
     def _patched_torch_load(f, *args, **kwargs):

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -1597,6 +1597,9 @@ class cuda:
     def stream(stream_obj):
         return stream_obj
 
+def load(f, *args, **kwargs):
+    return {}
+
 Tensor = object  # Stub
 """
 
@@ -1762,6 +1765,9 @@ class cuda:
     @staticmethod
     def is_available():
         return True
+
+def load(f, *args, **kwargs):
+    return {}
 """
 
     transformers_stub = """


### PR DESCRIPTION
Fixes #
Fixes numpy unpickling errors when resuming training from checkpoints with PyTorch 2.4+.

known issue : https://docs.pytorch.org/docs/stable/notes/serialization.html#torch-load-with-weights-only-true

### Problem

Starting from PyTorch 2.4, `torch.load()` defaults to `weights_only=True` for security. HuggingFace Transformers explicitly uses `weights_only=True` when loading RNG state files:
<img width="2980" height="1586" alt="Screenshot 2025-12-10 at 10 32 07 PM" src="https://github.com/user-attachments/assets/c5da6290-042e-429c-9cfa-afd52cd857a3" />

transformers/trainer.py line 3130
checkpoint_rng_state = torch.load(rng_file, weights_only=True)
RNG state files contain numpy arrays (for CPU random state reproducibility), which triggers:
```
_pickle.UnpicklingError: Weights only load failed.
WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray._reconstpatch `torch.load` to catch numpy-related unpickling errors and automatically retry with `weights_only=False`:
```
After implementing this solution : 
<img width="2292" height="1566" alt="Screenshot 2025-12-10 at 10 51 24 PM" src="https://github.com/user-attachments/assets/73afdda9-2429-4dd5-91ad-61bb30f959da" />
<img width="3012" height="1176" alt="Screenshot 2025-12-10 at 10 51 59 PM" src="https://github.com/user-attachments/assets/e4bf699b-7a13-44c1-8713-f8f8128ed46c" />


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint loading is more resilient: the loader now recovers and retries on certain unpickling errors, reducing restore failures.

* **Tests**
  * Added tests to validate instrumentation is self-contained and to exercise checkpoint loading recovery; includes test scaffolding and load stubs to simulate failing checkpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->