### PR TITLE
feat: Update odh release process to use branching

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -1,44 +1,88 @@
 name: ODH Release
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v0.2.0+rhai0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
   prepare:
-    name: Prepare release
+    name: Prepare release branch
     if: ${{ github.repository == 'opendatahub-io/kubeflow-sdk' }}
     runs-on: ubuntu-latest
     outputs:
-      base-version: ${{ steps.vars.outputs.base-version }}
-      release-version: ${{ steps.vars.outputs.release-version }}
-      is-prerelease: ${{ steps.vars.outputs.is-prerelease }}
+      version: ${{ steps.vars.outputs.version }}
+      branch: ${{ steps.vars.outputs.branch }}
+      upstream-version: ${{ steps.vars.outputs.upstream-version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Determine release version
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate and parse version
         id: vars
         run: |
-          BASE_VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' kubeflow/__init__.py)
+          VERSION="${{ github.event.inputs.version }}"
 
-          # Use the version from kubeflow/__init__.py directly as the release tag.
-          FINAL_VERSION="${BASE_VERSION}"
-
-          echo "base-version=$BASE_VERSION" >> $GITHUB_OUTPUT
-          echo "release-version=$FINAL_VERSION" >> $GITHUB_OUTPUT
-
-          if [[ "$BASE_VERSION" =~ rc[0-9]+$ ]]; then
-            echo "is-prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "is-prerelease=false" >> $GITHUB_OUTPUT
+          # Validate version format: vX.Y.Z+rhaiN
+          if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+rhai[0-9]+$ ]]; then
+            echo "ERROR: Invalid version format. Expected: vX.Y.Z+rhaiN (e.g., v0.2.0+rhai0)"
+            exit 1
           fi
 
-          echo "Base version: $BASE_VERSION"
-          echo "Release version: $FINAL_VERSION"
+          # Extract upstream version (e.g., v0.2.0+rhai0 -> 0.2.0)
+          UPSTREAM_VERSION=$(echo "$VERSION" | sed 's/^v//' | cut -d'+' -f1)
+
+          # Extract major.minor for branch name (e.g., 0.2.0 -> 0.2)
+          MAJOR_MINOR=$(echo "$UPSTREAM_VERSION" | cut -d. -f1,2)
+          BRANCH="release-$MAJOR_MINOR"
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "upstream-version=$UPSTREAM_VERSION" >> $GITHUB_OUTPUT
+
+          echo "Release version: $VERSION"
+          echo "Upstream version: $UPSTREAM_VERSION"
+          echo "Release branch: $BRANCH"
+
+      - name: Create or update release branch
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.vars.outputs.version }}"
+          BRANCH="${{ steps.vars.outputs.branch }}"
+          CURRENT_SHA="${{ github.sha }}"
+
+          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+            echo "Using existing branch: $BRANCH"
+            git fetch origin "$BRANCH":"$BRANCH"
+            git checkout "$BRANCH"
+            # Merge latest from main
+            git merge --no-edit origin/main || true
+          else
+            echo "Creating new branch: $BRANCH from main"
+            git checkout -B "$BRANCH" "$CURRENT_SHA"
+          fi
+
+          # Update version in __init__.py to rhai version
+          sed -i "s/^__version__ = \".*\"/__version__ = \"$VERSION\"/" kubeflow/__init__.py
+
+          echo "Updated kubeflow/__init__.py:"
+          cat kubeflow/__init__.py
+
+          git add kubeflow/__init__.py
+          git commit -m "chore: Set version to $VERSION for release" || echo "No changes to commit"
+          git push origin "$BRANCH"
 
   build:
     name: Build package
@@ -48,6 +92,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,6 +107,18 @@ jobs:
         run: |
           make test-python
 
+      - name: Verify version
+        run: |
+          EXPECTED_VERSION="${{ needs.prepare.outputs.version }}"
+          CODE_VERSION="$(python -c "import kubeflow; print(kubeflow.__version__)")"
+          echo "Expected version: $EXPECTED_VERSION"
+          echo "Code version: $CODE_VERSION"
+          if [[ "$EXPECTED_VERSION" != "$CODE_VERSION" ]]; then
+            echo "ERROR: Version mismatch!"
+            exit 1
+          fi
+          echo "Version verified: $EXPECTED_VERSION"
+
       - name: Build package
         run: |
           uv build
@@ -69,7 +126,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ needs.prepare.outputs.release-version }}
+          name: dist-${{ needs.prepare.outputs.version }}
           path: dist/
 
   create-tag:
@@ -80,15 +137,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.branch }}
       - name: Create tag
         run: |
-          RELEASE_VERSION="${{ needs.prepare.outputs.release-version }}"
-          echo "Creating tag: $RELEASE_VERSION"
+          VERSION="${{ needs.prepare.outputs.version }}"
+          echo "Creating tag: $VERSION"
 
-          if git ls-remote --tags origin | grep -q "refs/tags/${RELEASE_VERSION}$"; then
-            echo "Tag $RELEASE_VERSION already exists. Skipping"; exit 0; fi
-          git tag "$RELEASE_VERSION"
-          git push origin "$RELEASE_VERSION"
+          if git ls-remote --tags origin | grep -q "refs/tags/${VERSION}$"; then
+            echo "Tag $VERSION already exists. Skipping"
+            exit 0
+          fi
+          git tag "$VERSION"
+          git push origin "$VERSION"
 
   github-release:
     name: Create GitHub Release
@@ -98,43 +158,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.branch }}
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist-${{ needs.prepare.outputs.release-version }}
+          name: dist-${{ needs.prepare.outputs.version }}
           path: dist/
-      - name: Extract changelog
-        if: needs.prepare.outputs.is-prerelease != 'true'
-        id: changelog
-        run: |
-          BASE_VERSION="${{ needs.prepare.outputs.base-version }}"
-          MAJOR_MINOR=$(echo "$BASE_VERSION" | cut -d. -f1,2)
-          CHANGELOG_FILE="CHANGELOG/CHANGELOG-${MAJOR_MINOR}.md"
-          set -euo pipefail
-          [[ -f "$CHANGELOG_FILE" ]] || { echo "ERROR: $CHANGELOG_FILE not found" >&2; exit 1; }
-          HEADER_REGEX="^# \\[${BASE_VERSION//./\\.}\\]"
-          SECTION=$(sed -n "/$HEADER_REGEX/,\$p" "$CHANGELOG_FILE" | tail -n +2)
-          [[ -n "$SECTION" ]] || { echo "ERROR: No changelog section for $BASE_VERSION in $CHANGELOG_FILE" >&2; exit 1; }
-          NEXT_VERSION=$(echo "$SECTION" | grep -m1 "^# \\[[0-9]" || true)
-          if [[ -n "$NEXT_VERSION" ]]; then
-            CHANGELOG=$(echo "$SECTION" | sed -n "1,/^# \\[[0-9]/p" | sed '1d;$d')
-          else
-            CHANGELOG=$(echo "$SECTION" | sed '1d')
-          fi
-          [[ -n "$CHANGELOG" ]] || { echo "ERROR: Empty changelog body for $BASE_VERSION in $CHANGELOG_FILE" >&2; exit 1; }
-          {
-            echo "changelog<<EOF"
-            echo "$CHANGELOG"
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.prepare.outputs.release-version }}
-          name: ${{ needs.prepare.outputs.release-version }}
-          body: ${{ steps.changelog.outputs.changelog }}
+          tag_name: ${{ needs.prepare.outputs.version }}
+          name: ${{ needs.prepare.outputs.version }}
           draft: false
-          prerelease: ${{ needs.prepare.outputs.is-prerelease == 'true' }}
-          generate_release_notes: false
+          prerelease: false
+          generate_release_notes: true
           files: |
             dist/*

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -65,10 +65,8 @@ jobs:
 
           if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
             echo "Using existing branch: $BRANCH"
-            git fetch origin "$BRANCH":"$BRANCH"
+            git fetch origin "$BRANCH"
             git checkout "$BRANCH"
-            # Merge latest from main
-            git merge --no-edit origin/main || true
           else
             echo "Creating new branch: $BRANCH from main"
             git checkout -B "$BRANCH" "$CURRENT_SHA"

--- a/odh-release.md
+++ b/odh-release.md
@@ -9,125 +9,81 @@ This document describes the release process for the OpenDataHub (ODH) midstream 
 
 ## Versioning Policy
 
-### Base Version
-The base version in `kubeflow/__init__.py` follows upstream Kubeflow SDK versioning (format: `X.Y.Z`).
+### Main Branch (Synced with Upstream)
+The `main` branch version in `kubeflow/__init__.py` stays in sync with upstream Kubeflow SDK:
+```python
+__version__ = "0.2.0"  # Matches upstream
+```
 
-### ODH Release Version
-ODH releases use the format: `vX.Y.Z-odh-N` where:
+### Release Branches (RHAI Versioning)
+Release branches use the RHAI version format: `vX.Y.Z+rhaiN` where:
 - `X.Y.Z` is the upstream base version
-- `-odh` suffix indicates an ODH midstream release
-- `-N` is an auto-incrementing number starting at 1
+- `+rhai` suffix indicates an RHAI midstream release
+- `N` is an incrementing number starting at 0 for each upstream version
 
 **Examples:**
-- First ODH release based on upstream 0.2.0: `v0.2.0-odh-1`
-- Second ODH release (with patches) on same base: `v0.2.0-odh-2`
-- First ODH release based on upstream 0.3.0: `v0.3.0-odh-1`
+- First release based on upstream 0.2.0: `v0.2.0+rhai0`
+- Second release (with patches) on same base: `v0.2.0+rhai1`
+- First release based on upstream 0.3.0: `v0.3.0+rhai0`
 
-The release workflow automatically determines the next available `-N` increment.
+## Release Branches
 
-## Changelog Management
+Releases are cut from minor version branches:
+- `release-0.2` for all `v0.2.x+rhaiN` releases
+- `release-0.3` for all `v0.3.x+rhaiN` releases
 
-### Changelog Structure
-
-ODH maintains the same changelog structure as upstream:
-
-```markdown
-CHANGELOG/
-├── CHANGELOG-0.1.md    # All 0.1.x releases
-├── CHANGELOG-0.2.md    # All 0.2.x releases
-└── CHANGELOG-0.3.md    # All 0.3.x releases
-```
-
-### Adding ODH-Specific Changes
-
-When making ODH-specific changes, manually add them to the appropriate changelog file and prefix them with `[ODH]` to distinguish from upstream changes.
-
-**Example:**
-
-```markdown
-# [0.2.0](https://github.com/kubeflow/sdk/releases/tag/0.2.0) (2025-11-06)
-
-## New Features
-
-- feat(optimizer): Add get_best_results API to OptimizerClient ([#152](https://github.com/kubeflow/sdk/pull/152)) by @kramaranya
-- **[ODH] feat: Add support for ODH authentication** by @yourname
-
-## Bug Fixes
-
-- fix(ci): Update url for installing docker ([#151](https://github.com/kubeflow/sdk/pull/151)) by @Fiona-Waters
-- **[ODH] fix: Container backend compatibility with ODH clusters** by @yourname
-
-## Maintenance
-
-- chore: Add HPO support to readme ([#141](https://github.com/kubeflow/sdk/pull/141)) by @kramaranya
-- **[ODH] chore: Update documentation for ODH deployment** by @yourname
-```
-
-### Guidelines for ODH Changelog Entries
-
-1. **Prefix with `[ODH]`**: All ODH-specific changes should be clearly marked
-2. **Follow upstream conventions**: Use the same format as upstream (feat/fix/chore prefix)
-3. **Add to appropriate section**: New Features, Bug Fixes, or Maintenance
-4. **Keep it concise**: One line per change, focus on what and why
+The workflow automatically:
+1. Creates these branches if they don't exist
+2. Updates `__init__.py` on the release branch with the rhai version
 
 ## Release Process
 
-### 1. Update Changelog (if needed)
-
-If you're releasing ODH-specific changes:
-
-1. Edit the appropriate `CHANGELOG/CHANGELOG-X.Y.md` file
-2. Add your ODH-specific changes with `[ODH]` prefix
-3. Commit and push to `main`:
-   ```bash
-   git add CHANGELOG/CHANGELOG-X.Y.md
-   git commit -m "chore: Update changelog for ODH release"
-   git push origin main
-   ```
-
-### 2. Trigger Release Workflow
-
-The release workflow is **manual-only** to give you full control:
+### 1. Trigger Release Workflow
 
 1. Go to [GitHub Actions](https://github.com/opendatahub-io/kubeflow-sdk/actions)
 2. Select the **ODH Release** workflow
 3. Click **Run workflow**
-4. Select the branch to release from (usually `main`)
+4. Enter the release version (e.g., `v0.2.0+rhai0`)
 5. Click **Run workflow**
 
-### 3. Workflow Steps
+### 2. Workflow Steps
 
 The automated workflow will:
 
-1. **Prepare**:
-   - Extract base version from `kubeflow/__init__.py` (e.g., `0.2.0`)
-   - Determine next ODH release version (e.g., `v0.2.0-odh-1`)
+1. **Validate & Prepare**:
+   - Validate version format matches `vX.Y.Z+rhaiN`
+   - Create release branch if it doesn't exist (e.g., `release-0.2`)
+   - Or update existing release branch with latest from main
+   - Update `__init__.py` on release branch with rhai version
 
 2. **Build**:
    - Set up Python environment
    - Run tests (`make test-python`)
+   - Verify version in code matches expected
    - Build package with `uv build`
-   - Upload build artifacts
 
 3. **Create Tag**:
-   - Create git tag with release version
+   - Create git tag with the version (e.g., `v0.2.0+rhai0`)
    - Push tag to repository
 
 4. **GitHub Release**:
-   - Extract changelog from `CHANGELOG/CHANGELOG-X.Y.md`
-   - Create GitHub release with changelog as release notes
+   - Create GitHub release with auto-generated release notes
    - Attach build artifacts to release
 
-### 4. Verification
+### 3. Verification
 
 After the workflow completes:
 
 1. Verify the tag was created:
    ```bash
    git fetch --tags
-   git tag -l "v*-odh-*"
+   git tag -l "v*+rhai*"
    ```
 
 2. Check the [GitHub Releases page](https://github.com/opendatahub-io/kubeflow-sdk/releases)
 
-3. Verify release notes include both upstream and ODH changes
+3. Verify the release branch has the rhai version:
+   ```bash
+   git fetch origin
+   git show origin/release-0.2:kubeflow/__init__.py
+   ```

--- a/odh-release.md
+++ b/odh-release.md
@@ -52,8 +52,8 @@ The automated workflow will:
 
 1. **Validate & Prepare**:
    - Validate version format matches `vX.Y.Z+rhaiN`
-   - Create release branch if it doesn't exist (e.g., `release-0.2`)
-   - Or update existing release branch with latest from main
+   - Create release branch from main if it doesn't exist (e.g., `release-0.2`)
+   - Or use existing release branch as-is
    - Update `__init__.py` on release branch with rhai version
 
 2. **Build**:


### PR DESCRIPTION
I updated odh release process to include version param as an input and create release branch 

I've tested it on my fork:
https://github.com/odh-testing/kubeflow-sdk/releases/tag/v0.2.0%2Brhai1 - release
https://github.com/odh-testing/kubeflow-sdk/tree/release-0.2 - new branch
https://github.com/odh-testing/kubeflow-sdk/actions/runs/20320742869 - workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release flow now uses a version-driven UI input (vX.Y.Z+rhaiN), with automated release-branch creation, validation, tagging and artifact naming tied to that version.
  * Build verifies release branch version and uploads artifacts under the versioned name.
  * Automated GitHub Release creation with generated release notes; manual changelog extraction removed.

* **Documentation**
  * Release docs updated to reflect the new versioning scheme and streamlined, workflow-driven release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->