### PR TITLE
fix: Raise training errors

### DIFF
--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -608,10 +608,14 @@ def _render_algorithm_wrapper(algorithm_name: str, func_args: Optional[dict]) ->
 
         except ValueError as e:
             print("Configuration error:", e, flush=True)
+            # Propagate configuration errors so the pod fails
+            raise
         except Exception as e:
             import traceback
             print("[PY] Training failed with error:", e, flush=True)
             traceback.print_exc()
+            # Propagate errors so the pod fails
+            raise
 
     """).format(algo=algorithm_name, algo_upper=algorithm_name.upper())
 


### PR DESCRIPTION
Propagate training errors so the pod fails


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Training jobs now properly fail and surface errors when exceptions occur during execution instead of continuing silently.

* **Tests**
  * Added tests that simulate failures to verify error propagation and that human-readable error messages are produced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->