### PR TITLE
chore: add kft team as owners of trainer package

### DIFF
--- a/kubeflow/trainer/OWNERS
+++ b/kubeflow/trainer/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+  - abhijeet-dhumal
+  - ChughShilpa
+  - efazel
+  - hrathina
+  - kapil27
+  - robert-bell
+  - sutaakar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ package = true
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+exclude = [
+    "**/OWNERS",
+]
+
 [tool.hatch.metadata]
 allow-direct-references = true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
As agreed with @briangallagher, we're going to trial KFT team having ownership of the trainer package in the sdk.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and formalized the repository maintainer/approver list for review and approval workflows.
  * Adjusted build configuration to exclude maintainer/ownership files from build artifacts, streamlining packaging and repository management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->