### PR TITLE
fix: Remove stale metrics file on start-up

### DIFF
--- a/kubeflow/trainer/algorithms.py
+++ b/kubeflow/trainer/algorithms.py
@@ -1,0 +1,94 @@
+"""Centralized registry for training algorithms and their properties.
+
+This module defines a single authoritative place for supported training algorithms,
+their metrics file patterns, and validation logic.
+"""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AlgorithmSpec:
+    """Specification for a training algorithm.
+
+    This is a frozen (immutable) dataclass that defines the properties
+    and behavior of a supported training algorithm.
+
+    Attributes:
+        name: The algorithm identifier (e.g., "sft", "osft").
+        metrics_file_patterns: Glob patterns for metrics files written by this algorithm.
+            Used for metrics reading and cleanup operations.
+        validate: Validation function that takes a training config and raises
+            ValueError if the config is invalid for this algorithm.
+    """
+
+    name: str
+    metrics_file_patterns: Iterable[str]
+    validate: Callable[[Any], None]
+
+
+def _no_op_validate(config: Any) -> None:
+    """Default no-op validation function.
+
+    This is used for algorithms that don't require algorithm-specific validation.
+    Trainer-level validation (ports, intervals, etc.) is handled separately in
+    TrainingHubTrainer.__post_init__.
+
+    Args:
+        config: The training configuration to validate.
+
+    Raises:
+        ValueError: Never raises - this is a no-op.
+    """
+    pass
+
+
+# Registry of all supported training algorithms
+# Each entry maps algorithm name to its specification
+ALGORITHMS: dict[str, AlgorithmSpec] = {
+    "sft": AlgorithmSpec(
+        name="sft",
+        metrics_file_patterns=("training_params_and_metrics_global*.jsonl",),
+        validate=_no_op_validate,
+    ),
+    "osft": AlgorithmSpec(
+        name="osft",
+        metrics_file_patterns=("training_metrics_*.jsonl",),
+        validate=_no_op_validate,
+    ),
+}
+
+
+def get_algorithm_spec(name: str) -> AlgorithmSpec:
+    """Retrieve the specification for a training algorithm by name.
+
+    Args:
+        name: The algorithm identifier (e.g., "sft", "osft").
+
+    Returns:
+        The AlgorithmSpec for the requested algorithm.
+
+    Raises:
+        ValueError: If the algorithm name is not supported.
+
+    Examples:
+        >>> spec = get_algorithm_spec("sft")
+        >>> spec.name
+        'sft'
+        >>> spec.metrics_file_patterns
+        ('training_params_and_metrics_global*.jsonl',)
+
+        >>> get_algorithm_spec("unknown")
+        Traceback (most recent call last):
+            ...
+        ValueError: Unsupported training algorithm: 'unknown'. Supported algorithms: osft, sft
+    """
+    if name not in ALGORITHMS:
+        supported = ", ".join(sorted(ALGORITHMS.keys()))
+        raise ValueError(
+            f"Unsupported training algorithm: '{name}'. Supported algorithms: {supported}"
+        )
+
+    return ALGORITHMS[name]

--- a/kubeflow/trainer/algorithms_test.py
+++ b/kubeflow/trainer/algorithms_test.py
@@ -14,6 +14,8 @@
 
 """Tests for training algorithms registry."""
 
+import ast
+
 import pytest
 
 from kubeflow.trainer.algorithms import (
@@ -224,10 +226,13 @@ def test_get_algorithm_spec(test_case):
 
         # For error cases, verify error message contains expected information
         error_message = str(e)
-        assert "Unsupported training algorithm" in error_message
 
-        # For non-empty algorithm names, verify the name is in the error
-        if test_case.config["algorithm"]:
+        # Empty string gets caught by input validation, not unsupported algorithm check
+        if test_case.config["algorithm"] == "":
+            assert "must be a non-empty string" in error_message
+        else:
+            # Non-empty invalid algorithm names
+            assert "Unsupported training algorithm" in error_message
             assert test_case.config["algorithm"] in error_message
 
     print("test execution complete")
@@ -459,7 +464,7 @@ def test_pod_metadata_serializable():
         assert len(metadata_repr) > 0
 
         # Verify metadata can be eval'd back (sanity check)
-        metadata_evaled = eval(metadata_repr)
+        metadata_evaled = ast.literal_eval(metadata_repr)
         assert metadata_evaled == metadata
 
     print("test execution complete")

--- a/kubeflow/trainer/algorithms_test.py
+++ b/kubeflow/trainer/algorithms_test.py
@@ -1,0 +1,231 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for training algorithms registry."""
+
+import pytest
+
+from kubeflow.trainer.algorithms import (
+    ALGORITHMS,
+    AlgorithmSpec,
+    get_algorithm_spec,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+
+
+def test_algorithm_spec_is_frozen():
+    """Test that AlgorithmSpec is frozen and cannot be modified after creation."""
+    print("Executing test: algorithm_spec_is_frozen")
+
+    spec = AlgorithmSpec(
+        name="test",
+        metrics_file_patterns=("pattern.jsonl",),
+        validate=lambda x: None,
+    )
+
+    # Attempt to modify frozen dataclass should raise FrozenInstanceError or AttributeError
+    with pytest.raises((AttributeError, Exception)):
+        spec.name = "modified"
+
+    print("test execution complete")
+
+
+def test_all_algorithms_have_non_empty_metrics_patterns():
+    """Test that all registered algorithms define non-empty metrics_file_patterns."""
+    print("Executing test: all_algorithms_have_non_empty_metrics_patterns")
+
+    for algorithm_name, spec in ALGORITHMS.items():
+        print("  Checking algorithm:", algorithm_name)
+
+        # Verify metrics_file_patterns is not None
+        assert spec.metrics_file_patterns is not None, (
+            f"Algorithm '{algorithm_name}' has None metrics_file_patterns"
+        )
+
+        # Verify metrics_file_patterns is iterable
+        assert hasattr(spec.metrics_file_patterns, "__iter__"), (
+            f"Algorithm '{algorithm_name}' metrics_file_patterns is not iterable"
+        )
+
+        # Convert to list to check length
+        patterns_list = list(spec.metrics_file_patterns)
+
+        # Verify metrics_file_patterns is not empty
+        assert len(patterns_list) > 0, (
+            f"Algorithm '{algorithm_name}' has empty metrics_file_patterns"
+        )
+
+        # Verify all patterns are non-empty strings
+        for pattern in patterns_list:
+            assert isinstance(pattern, str), (
+                f"Algorithm '{algorithm_name}' has non-string pattern: {pattern}"
+            )
+            assert len(pattern) > 0, f"Algorithm '{algorithm_name}' has empty string pattern"
+
+    print("test execution complete")
+
+
+def test_all_algorithms_have_callable_validate():
+    """Test that all registered algorithms define a callable validate function."""
+    print("Executing test: all_algorithms_have_callable_validate")
+
+    for algorithm_name, spec in ALGORITHMS.items():
+        print("  Checking algorithm:", algorithm_name)
+
+        # Verify validate is not None
+        assert spec.validate is not None, f"Algorithm '{algorithm_name}' has None validate function"
+
+        # Verify validate is callable
+        assert callable(spec.validate), f"Algorithm '{algorithm_name}' validate is not callable"
+
+        # Verify validate can be called without raising (with any argument)
+        try:
+            spec.validate(None)
+        except Exception as e:
+            # If it raises, it should be ValueError (validation failed)
+            # Any other exception is a bug in the validate function
+            if not isinstance(e, ValueError):
+                pytest.fail(
+                    f"Algorithm '{algorithm_name}' validate raised unexpected "
+                    f"exception: {type(e).__name__}: {e}"
+                )
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="unknown algorithm raises ValueError",
+            expected_status=FAILED,
+            config={"algorithm": "unknown_algorithm"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="empty string algorithm raises ValueError",
+            expected_status=FAILED,
+            config={"algorithm": ""},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="valid sft algorithm returns spec",
+            expected_status=SUCCESS,
+            config={"algorithm": "sft"},
+            expected_output="sft",
+        ),
+        TestCase(
+            name="valid osft algorithm returns spec",
+            expected_status=SUCCESS,
+            config={"algorithm": "osft"},
+            expected_output="osft",
+        ),
+    ],
+)
+def test_get_algorithm_spec(test_case):
+    """Test get_algorithm_spec for various inputs."""
+    print("Executing test:", test_case.name)
+
+    try:
+        spec = get_algorithm_spec(test_case.config["algorithm"])
+
+        assert test_case.expected_status == SUCCESS
+        assert spec.name == test_case.expected_output
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+
+        # For error cases, verify error message contains expected information
+        error_message = str(e)
+        assert "Unsupported training algorithm" in error_message
+
+        # For non-empty algorithm names, verify the name is in the error
+        if test_case.config["algorithm"]:
+            assert test_case.config["algorithm"] in error_message
+
+    print("test execution complete")
+
+
+def test_algorithms_registry_has_expected_algorithms():
+    """Test that ALGORITHMS registry contains exactly the expected algorithms."""
+    print("Executing test: algorithms_registry_has_expected_algorithms")
+
+    # As of now, only sft and osft are supported (lora_sft is TODO)
+    expected_algorithms = {"sft", "osft"}
+    actual_algorithms = set(ALGORITHMS.keys())
+
+    assert actual_algorithms == expected_algorithms, (
+        f"Expected algorithms {expected_algorithms}, but found {actual_algorithms}"
+    )
+
+    print("test execution complete")
+
+
+def test_algorithm_spec_name_matches_registry_key():
+    """Test that each AlgorithmSpec.name matches its registry key."""
+    print("Executing test: algorithm_spec_name_matches_registry_key")
+
+    for registry_key, spec in ALGORITHMS.items():
+        assert spec.name == registry_key, (
+            f"Registry key '{registry_key}' does not match spec.name '{spec.name}'"
+        )
+
+    print("test execution complete")
+
+
+def test_sft_metrics_patterns_match_constants():
+    """Test that SFT metrics patterns match the patterns used in traininghub.py."""
+    print("Executing test: sft_metrics_patterns_match_constants")
+
+    spec = get_algorithm_spec("sft")
+    patterns = list(spec.metrics_file_patterns)
+
+    # Should match TRAININGHUB_SFT_METRICS_FILE_PATTERN from traininghub.py
+    assert "training_params_and_metrics_global*.jsonl" in patterns
+
+    print("test execution complete")
+
+
+def test_osft_metrics_patterns_match_constants():
+    """Test that OSFT metrics patterns match the patterns used in traininghub.py."""
+    print("Executing test: osft_metrics_patterns_match_constants")
+
+    spec = get_algorithm_spec("osft")
+    patterns = list(spec.metrics_file_patterns)
+
+    # Should match TRAININGHUB_OSFT_METRICS_FILE_PATTERN from traininghub.py
+    assert "training_metrics_*.jsonl" in patterns
+
+    print("test execution complete")
+
+
+def test_algorithm_spec_metrics_patterns_are_tuples():
+    """Test that metrics_file_patterns are stored as tuples (immutable)."""
+    print("Executing test: algorithm_spec_metrics_patterns_are_tuples")
+
+    for algorithm_name, spec in ALGORITHMS.items():
+        print("  Checking algorithm:", algorithm_name)
+
+        # Verify patterns are tuples (immutable)
+        assert isinstance(spec.metrics_file_patterns, tuple), (
+            f"Algorithm '{algorithm_name}' metrics_file_patterns should be tuple, "
+            f"got {type(spec.metrics_file_patterns).__name__}"
+        )
+
+    print("test execution complete")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -516,27 +516,20 @@ def _create_training_hub_progression_instrumentation(
                     try:
                         os.remove(file_path)
                         files_removed += 1
-                        print(
-                            f"[Kubeflow] Removed stale metrics file: {os.path.basename(file_path)}",
-                            flush=True,
-                        )
-                    except Exception as e:
                         filename = os.path.basename(file_path)
-                        print(
-                            f"[Kubeflow] Warning: Could not remove {filename}: {e}",
-                            flush=True,
-                        )
+                        print(f"[Kubeflow] Removed stale metrics file: {filename}", flush=True)
+                    except OSError as e:
+                        filename = os.path.basename(file_path)
+                        print(f"[Kubeflow] Warning: Could not remove {filename}: {e}", flush=True)
 
             if files_removed > 0:
-                print(f"[Kubeflow] Cleaned {files_removed} stale metrics file(s)", flush=True)
+                file_word = "files" if files_removed != 1 else "file"
+                print(f"[Kubeflow] Cleaned {files_removed} stale metrics {file_word}", flush=True)
             else:
                 print("[Kubeflow] No stale metrics files found", flush=True)
 
-        except Exception as e:
-            print(
-                f"[Kubeflow] Warning: Metrics cleanup failed: {e}. Proceeding with training.",
-                flush=True,
-            )
+        except OSError as e:
+            print(f"[Kubeflow] Warning: Metrics cleanup failed: {e}", flush=True)
 
         # Start HTTP server for metrics
         try:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds logic to cleanup stale metrics files on job startup. This is for training hub trainer only. Training hub trainer does not support pause/resume functionailty yet and if the job restarts the metrics file will be appended but will repeat step 0 etc. Therefore removing any existing metrics files at the beginning makes most sense in order to ensure correct progression tracking in the UI.

If/When pause/resume functionality is added later this will need to be updated.

I've tested this manually on my teams OpenShift cluster.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes # https://issues.redhat.com/browse/RHOAIENG-41647

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata-driven algorithm support enabling dynamic metric detection and more robust termination/reporting across training variants.

* **Bug Fixes**
  * Startup now removes stale training metrics from previous runs (performed only by the primary pod), logs cleanup activity, and still starts the metrics server even if cleanup fails.
  * Termination metric extraction is more resilient to differing metric key names.

* **Tests**
  * Added tests for metrics cleanup, metadata handling, primary-pod detection, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->