### PR TITLE
chore: add snyk scan to upstream sync workflow

### DIFF
--- a/.github/workflows/rebase-upstream.yaml
+++ b/.github/workflows/rebase-upstream.yaml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  security-events: write
 
 jobs:
   sync:
@@ -228,3 +229,29 @@ jobs:
               --title "$TITLE" \
               --body "$BODY"
           fi
+
+      - name: Run Snyk to check for vulnerabilities
+        if: steps.diffcheck.outputs.has_changes == 'true'
+        uses: snyk/actions/python@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk-sync-results.sarif --severity-threshold=high
+
+      - name: Check Snyk SARIF
+        id: check-sarif
+        if: always() && steps.diffcheck.outputs.has_changes == 'true'
+        run: |
+          if [ -f "snyk-sync-results.sarif" ]; then
+            echo "sarif_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Snyk Audit to Security Tab
+        if: always() && steps.check-sarif.outputs.sarif_exists == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: 'snyk-sync-results.sarif'
+          category: midstream-snyk-audit


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following on from the addition of a cve scan in the upstream sdk (https://github.com/kubeflow/sdk/pull/266 and https://github.com/kubeflow/sdk/pull/267) this PR adds a Snyk scan to our upstream sync workflow. This adds an extra layer of security using Snyk to re-scan once the upstream sync happens and before merging. This catches vulnerabilities that might not have been present in the Upstream when they last scanned, but are present now.

It will also report any CVEs that are found in the Github Security Tab.

This relies on a SNYK_TOKEN which has been added to the repo secrets.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #
https://issues.redhat.com/browse/RHOAIENG-48765


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated automated vulnerability scanning into the CI workflow: scans run when changes are present, results are checked for presence, and available findings are automatically uploaded to the Security tab to improve visibility and monitoring of potential issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->