### PR TITLE
chore: update kubeflow hub owners

### DIFF
--- a/kubeflow/hub/OWNERS
+++ b/kubeflow/hub/OWNERS
@@ -1,14 +1,24 @@
 approvers:
-  - Al-Pragliola
-  - ederign
-  - jonburdo
-  - pboyd
-  - rareddy
-  - tarilabs
-emeritus_approvers:
-  - andreyvelich
-  - ckadner
-  - Tomcli
-  - zijianjoy
+- Al-Pragliola
+- adysenrothman
+- fege
+- jonburdo
+- pboyd
+- rareddy
+- tarilabs
 reviewers:
-  - fege
+- Al-Pragliola
+- adysenrothman
+- fege
+- jonburdo
+- pboyd
+- rareddy
+- tarilabs
+emeritus_approvers:
+- dhirajsb
+- isinyaaa
+- lampajr
+- nehachopra27
+- rkubis
+- tonyxrmdavidson
+- Crazyglue


### PR DESCRIPTION
This updates kubeflow/hub/OWNERS to match the root [OWNERS](https://github.com/opendatahub-io/model-registry/blob/main/OWNERS) file in opendatahub-io/model-registry.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project governance and team assignments for the hub component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->