### PR TITLE
feat: async checkpoint upload to S3

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -519,12 +519,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
         def _upload_checkpoint_to_cloud(self, task: tuple) -> None:
             """Upload checkpoint."""
-            staging_path, checkpoint_name, total_size, is_global_rank_0 = task
-            incomplete_marker_path = f"{checkpoint_name}/{CHECKPOINT_INCOMPLETE_MARKER}"
+            staging_path, checkpoint_name, total_size, incomplete_marker_name = task
+            incomplete_marker_path = f"{checkpoint_name}/{incomplete_marker_name}"
 
             # Create .incomplete sentinel so resume can skip in-flight uploads.
-            if is_global_rank_0:
-                _log(f"Creating .incomplete marker in S3: {checkpoint_name}")
+            _log(f"Creating .incomplete marker in S3: {checkpoint_name}")
             try:
                 self.remote_fs.pipe(
                     incomplete_marker_path,
@@ -551,12 +550,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             _log(f"Upload complete: {checkpoint_name}")
 
-            # Delete .incomplete sentinel (global rank 0 only)
-            if is_global_rank_0:
-                try:
-                    self.remote_fs.rm_file(incomplete_marker_path)
-                except Exception as e:
-                    _log(f"Warning: Failed to remove remote file '{incomplete_marker_path}': {e}")
+            # Delete .incomplete sentinel for this uploader
+            try:
+                self.remote_fs.rm_file(incomplete_marker_path)
+            except Exception as e:
+                _log(f"Warning: Failed to remove remote file '{incomplete_marker_path}': {e}")
 
             # Delete local staging checkpoint
             try:
@@ -570,7 +568,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
         def _parallel_upload_files(
             self, staging_path: str, checkpoint_name: str, total_size: int
-        ) -> list:
+        ) -> list[tuple[str, str]]:
             """Upload files in parallel; return failed list."""
             # Collect all files to upload
             files_to_upload = []
@@ -628,7 +626,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             return failed_files
 
-        def _retry_failed_files(self, failed_files: list) -> list:
+        def _retry_failed_files(self, failed_files: list[tuple[str, str]]) -> list[tuple[str, str]]:
             """Retry failed files."""
             remaining_failures = []
 
@@ -655,10 +653,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             """Stop upload worker."""
             if self._upload_queue is not None and self._upload_thread is not None:
                 _log("Waiting for background uploads to complete...")
-                self._upload_queue.join()  # Wait for all tasks to finish
                 self._shutdown_event.set()  # Signal shutdown
-                self._upload_thread.join()  # Wait for thread to exit
-                _log("Background upload worker stopped")
+                self._upload_thread.join(timeout=3600)  # Wait up to 1 hour
+                if self._upload_thread.is_alive():
+                    _log("Warning: Upload worker thread is still running after 1 hour timeout")
+                else:
+                    _log("Background upload worker stopped")
 
         def on_init_end(self, args, state, control, **kwargs):
             """Download latest checkpoint from S3 (local rank 0)."""
@@ -686,8 +686,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
                 for step in steps:
                     name = f"checkpoint-{step}"
-                    incomplete_marker = f"{name}/{CHECKPOINT_INCOMPLETE_MARKER}"
-                    if self.remote_fs.exists(incomplete_marker):
+                    try:
+                        entries = self.remote_fs.ls(name, detail=False)
+                    except FileNotFoundError:
+                        entries = []
+                    if any(CHECKPOINT_INCOMPLETE_MARKER in entry for entry in entries):
                         continue
 
                     try:
@@ -729,15 +732,13 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 # S3 storage not configured, skip upload
                 return
 
-            # Check for background upload errors and propagate to main thread
-            self._check_upload_error()
-
             # Barrier before staging checkpoint to ensure all ranks finished saving their files
             self._wait_for_all_ranks("save")
 
-            is_local_rank_0 = args.local_process_index == 0
-            is_global_rank_0 = state.is_world_process_zero
+            # Check for background upload errors and propagate to main thread
+            self._check_upload_error()
 
+            is_local_rank_0 = args.local_process_index == 0
             # Only local rank 0 stages and queues uploads
             if is_local_rank_0:
                 current_step = state.global_step
@@ -769,11 +770,16 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     # Start upload worker if not yet running
                     self._start_upload_worker()
                     # Queue upload task (non-blocking, training continues immediately)
+                    node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
+                    marker_name = (
+                        f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-"
+                        f"rank-{args.local_process_index}"
+                    )
                     task = (
                         staging_checkpoint_path,
                         checkpoint_name,
                         total_size,
-                        is_global_rank_0,
+                        marker_name,
                     )
                     self._upload_queue.put(task)
                     _log(

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -202,10 +202,10 @@ class TransformersTrainer:
 
 
 def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
-    """
-    Checkpoint instrumentation code injected into training pods.
-    """
+    """Checkpoint instrumentation injected into training pods."""
+    from concurrent.futures import ThreadPoolExecutor, as_completed
     import os
+    from queue import Empty, LifoQueue
     import re
     import shutil
     import signal
@@ -221,7 +221,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
     from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER, CHECKPOINT_STAGING_DIR
 
     class CheckpointManager:
-        """Manages async just-in-time checkpointing on SIGTERM signal using CUDA streams."""
+        """JIT checkpoint manager."""
 
         def __init__(self, trainer):
             self.trainer = trainer
@@ -242,12 +242,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 )
 
         def setup_signal_handler(self):
-            """Register SIGTERM signal handler for JIT checkpointing."""
+            """Register SIGTERM handler."""
             self._original_sigterm_handler = signal.signal(signal.SIGTERM, self._sigterm_handler)
             print("[Kubeflow] JIT checkpoint signal handler registered for SIGTERM", flush=True)
 
         def _sigterm_handler(self, signum, frame):
-            """Handle SIGTERM by starting async checkpoint immediately."""
+            """Start async checkpoint on SIGTERM."""
             if self.checkpoint_requested:
                 return
 
@@ -261,7 +261,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             self.checkpoint_thread.start()
 
         def _async_checkpoint(self):
-            """Execute checkpoint asynchronously, waiting if in optimizer step."""
+            """Checkpoint asynchronously."""
             try:
                 # Wait if we're currently in optimizer step (unsafe to checkpoint)
                 while self._in_optimizer_step:
@@ -327,17 +327,23 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 traceback.print_exc()
 
         def checkpoint_in_progress(self):
-            """Check if a checkpoint is in progress."""
+            """Return True if checkpoint requested."""
             return self.checkpoint_requested
 
     class JITCheckpointCallback(TrainerCallback):
-        """Transformers callback that integrates JIT checkpointing with trainer lifecycle."""
+        """JIT checkpoint callback."""
 
         def __init__(self, cloud_remote_storage_uri: Optional[str] = None) -> None:
             self.jit_manager = None
             self._trainer_ref = None
             self.cloud_remote_storage_uri = cloud_remote_storage_uri
             self.remote_fs = None
+            # Async upload state
+            self._upload_queue = None  # LifoQueue for background uploads
+            self._upload_thread = None  # Background worker thread
+            self._shutdown_event = None  # Event to signal shutdown
+            self._upload_error = None  # Store background thread errors
+            self._upload_error_lock = threading.Lock()  # Lock for error propagation
 
             if cloud_remote_storage_uri and "://" in cloud_remote_storage_uri:
                 import fsspec
@@ -386,16 +392,16 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"'{cloud_remote_storage_uri}'. Error: {e}. "
                         f"If using self-signed certificates, "
                         f"set verify_cloud_storage_ssl=False. "
-                        f"If experiencing permission issues, check you have read and "
-                        f"write permissions to '{cloud_remote_storage_uri}'. "
+                        f"If experiencing permission issues, check you have read, "
+                        f"write and delete permissions to '{cloud_remote_storage_uri}'. "
                         f"This check can be disabled by setting verify_cloud_storage_access=False."
                     ) from e
 
         def _wait_for_all_ranks(self, operation: str) -> None:
-            """Wait for all distributed ranks to reach this point.
-            Args:
-                operation: Description of the operation (e.g., "download", "upload")
-            """
+            """Barrier across ranks."""
+            # Avoid barrier in single-process or when torch.distributed is not initialized.
+            if not dist.is_available() or not dist.is_initialized():
+                return
             try:
                 dist.barrier()
             except Exception as e:
@@ -411,7 +417,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 ) from e
 
         def _calculate_local_dir_size(self, path: str) -> int:
-            """Calculate total size of local directory."""
+            """Total size of local directory."""
             import contextlib
 
             total = 0
@@ -422,7 +428,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             return total
 
         def _cloud_storage_progress_callback(self, operation: str, total_size: int):
-            """Create progress callback with byte-level tracking via branched()."""
+            """Progress callback."""
             from fsspec.callbacks import Callback
 
             class ProgressCallback(Callback):
@@ -463,8 +469,233 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             return ProgressCallback(operation, total_size)
 
+        def _check_upload_error(self) -> None:
+            """Raise any background upload error."""
+            with self._upload_error_lock:
+                if self._upload_error is not None:
+                    error = self._upload_error
+                    self._upload_error = None  # Clear after reading
+                    raise error
+
+        def _start_upload_worker(self) -> None:
+            """Start background upload worker."""
+            if self._upload_queue is None:
+                self._upload_queue = LifoQueue()
+                self._shutdown_event = threading.Event()
+                self._upload_thread = threading.Thread(
+                    target=self._upload_worker_loop,
+                    daemon=True,
+                    name="KubeflowCheckpointUploader",
+                )
+                self._upload_thread.start()
+                print("[Kubeflow] Background upload worker started", flush=True)
+
+        def _upload_worker_loop(self) -> None:
+            """Upload worker loop."""
+            while not self._shutdown_event.is_set():
+                try:
+                    # Use timeout to periodically check shutdown event
+                    task = self._upload_queue.get(timeout=1.0)
+                except Empty:
+                    continue
+
+                try:
+                    self._upload_checkpoint_to_cloud(task)
+                except Exception as e:
+                    # Store error for main thread propagation
+                    checkpoint_name = task[1]
+                    with self._upload_error_lock:
+                        self._upload_error = RuntimeError(
+                            f"[Kubeflow] Background upload failed for {checkpoint_name}: {e}. "
+                            "This may be caused by network issues, S3 outage, or "
+                            "permission changes. Verify S3 connectivity and retry the training job."
+                        )
+                        self._upload_error.__cause__ = e
+                    print(
+                        f"[Kubeflow] ERROR: Background upload failed for {checkpoint_name}: {e}",
+                        flush=True,
+                    )
+                finally:
+                    self._upload_queue.task_done()
+
+        def _upload_checkpoint_to_cloud(self, task: tuple) -> None:
+            """Upload checkpoint."""
+            staging_path, checkpoint_name, total_size, is_global_rank_0 = task
+            incomplete_marker_path = f"{checkpoint_name}/{CHECKPOINT_INCOMPLETE_MARKER}"
+
+            # Create .incomplete sentinel so resume can skip in-flight uploads.
+            if is_global_rank_0:
+                print(
+                    f"[Kubeflow] Creating .incomplete marker in S3: {checkpoint_name}",
+                    flush=True,
+                )
+            try:
+                self.remote_fs.pipe(
+                    incomplete_marker_path,
+                    f"Upload started for {checkpoint_name}".encode(),
+                )
+            except Exception as e:
+                print(
+                    f"[Kubeflow] Warning: Failed to write .incomplete marker for "
+                    f"{checkpoint_name}: {e}",
+                    flush=True,
+                )
+
+            # Upload files in parallel
+            print(
+                f"[Kubeflow] Starting parallel upload to S3: {checkpoint_name}",
+                flush=True,
+            )
+
+            failed_files = self._parallel_upload_files(staging_path, checkpoint_name, total_size)
+
+            # Retry failed files if any
+            if failed_files:
+                print(
+                    f"[Kubeflow] Retrying {len(failed_files)} failed files for {checkpoint_name}",
+                    flush=True,
+                )
+                remaining_failures = self._retry_failed_files(failed_files)
+
+                if remaining_failures:
+                    raise RuntimeError(
+                        f"Upload failed for {len(remaining_failures)} files after retry: "
+                        f"{[f[1] for f in remaining_failures[:5]]}"  # Show first 5
+                    )
+
+            print(f"[Kubeflow] Upload complete: {checkpoint_name}", flush=True)
+
+            # Delete .incomplete sentinel (global rank 0 only)
+            if is_global_rank_0:
+                try:
+                    self.remote_fs.rm_file(incomplete_marker_path)
+                except Exception as e:
+                    print(
+                        f"[Kubeflow] Warning: Failed to remove remote file "
+                        f"'{incomplete_marker_path}': {e}",
+                        flush=True,
+                    )
+
+            # Delete local staging checkpoint
+            try:
+                shutil.rmtree(staging_path)
+                print(
+                    f"[Kubeflow] Deleted local staging checkpoint: {checkpoint_name}",
+                    flush=True,
+                )
+            except Exception as cleanup_error:
+                print(
+                    f"[Kubeflow] Warning: Failed to delete local staging checkpoint "
+                    f"{checkpoint_name}: {cleanup_error}. "
+                    "Upload succeeded, but local cleanup failed.",
+                    flush=True,
+                )
+
+        def _parallel_upload_files(
+            self, staging_path: str, checkpoint_name: str, total_size: int
+        ) -> list:
+            """Upload files in parallel; return failed list."""
+            # Collect all files to upload
+            files_to_upload = []
+            for root, _, files in os.walk(staging_path):
+                for f in files:
+                    local_file = os.path.join(root, f)
+                    # Compute relative path from staging_path
+                    rel_path = os.path.relpath(local_file, staging_path)
+                    remote_file = f"{checkpoint_name}/{rel_path}"
+                    files_to_upload.append((local_file, remote_file))
+
+            if not files_to_upload:
+                return []
+
+            # Cap workers at min(4, file_count)
+            num_workers = min(4, len(files_to_upload))
+            failed_files = []
+
+            # Progress tracking
+            uploaded_bytes = 0
+            last_update = time.time()
+            lock = threading.Lock()
+
+            def upload_file(local_file: str, remote_file: str) -> bool:
+                """Upload single file, return True on success."""
+                nonlocal uploaded_bytes, last_update
+                try:
+                    self.remote_fs.put_file(local_file, remote_file)
+
+                    # Update progress
+                    file_size = os.path.getsize(local_file)
+                    with lock:
+                        uploaded_bytes += file_size
+                        if time.time() - last_update >= 1:
+                            mb = uploaded_bytes / (1024 * 1024)
+                            pct = int((uploaded_bytes / total_size) * 100) if total_size else 0
+                            print(
+                                f"[Kubeflow] Progress: {mb:.1f}"
+                                f"/{total_size / (1024 * 1024):.1f} MB ({pct}%)",
+                                flush=True,
+                            )
+                            last_update = time.time()
+
+                    return True
+                except Exception:
+                    return False
+
+            # Upload files in parallel
+            with ThreadPoolExecutor(max_workers=num_workers) as executor:
+                futures = {
+                    executor.submit(upload_file, local, remote): (local, remote)
+                    for local, remote in files_to_upload
+                }
+
+                for future in as_completed(futures):
+                    local, remote = futures[future]
+                    if not future.result():
+                        failed_files.append((local, remote))
+
+            return failed_files
+
+        def _retry_failed_files(self, failed_files: list) -> list:
+            """Retry failed files."""
+            remaining_failures = []
+
+            for local_file, remote_file in failed_files:
+                success = False
+                for attempt in range(1, 4):  # 3 attempts total
+                    try:
+                        self.remote_fs.put_file(local_file, remote_file)
+                        success = True
+                        break
+                    except Exception as e:
+                        if attempt == 3:
+                            print(
+                                f"[Kubeflow] File upload failed after 3 attempts: "
+                                f"{remote_file}: {e}",
+                                flush=True,
+                            )
+                        else:
+                            print(
+                                f"[Kubeflow] Retry {attempt}/3 for {remote_file}",
+                                flush=True,
+                            )
+                            time.sleep(1)  # Brief delay before retry
+
+                if not success:
+                    remaining_failures.append((local_file, remote_file))
+
+            return remaining_failures
+
+        def _shutdown_upload_worker(self) -> None:
+            """Stop upload worker."""
+            if self._upload_queue is not None and self._upload_thread is not None:
+                print("[Kubeflow] Waiting for background uploads to complete...", flush=True)
+                self._upload_queue.join()  # Wait for all tasks to finish
+                self._shutdown_event.set()  # Signal shutdown
+                self._upload_thread.join(timeout=10)  # Wait for thread to exit
+                print("[Kubeflow] Background upload worker stopped", flush=True)
+
         def on_init_end(self, args, state, control, **kwargs):
-            """Download latest checkpoint from S3 (local rank 0)."""
+            """Download latest checkpoint from S3."""
             if not self.remote_fs:
                 # Return since cloud storage not configured by user
                 return
@@ -489,8 +720,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
                 for step in steps:
                     name = f"checkpoint-{step}"
-                    marker = f"{name}/{CHECKPOINT_INCOMPLETE_MARKER}"
-                    if self.remote_fs.exists(marker):
+                    incomplete_marker = f"{name}/{CHECKPOINT_INCOMPLETE_MARKER}"
+                    if self.remote_fs.exists(incomplete_marker):
                         continue
 
                     try:
@@ -527,10 +758,13 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             self._wait_for_all_ranks("download")
 
         def on_save(self, args, state, control, **kwargs):
-            """Upload checkpoint to S3 (local rank 0)."""
+            """Stage checkpoint and queue async upload."""
             if not self.remote_fs:
                 # S3 storage not configured, skip upload
                 return
+
+            # Check for background upload errors and propagate to main thread
+            self._check_upload_error()
 
             # Barrier before staging checkpoint to ensure all ranks finished saving their files
             self._wait_for_all_ranks("save")
@@ -538,15 +772,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             is_local_rank_0 = args.local_process_index == 0
             is_global_rank_0 = state.is_world_process_zero
 
-            # Define checkpoint paths (needed by both local_rank_0 and global_rank_0)
-            current_step = state.global_step
-            checkpoint_name = f"{PREFIX_CHECKPOINT_DIR}-{current_step}"
-            incomplete_marker_path = f"{checkpoint_name}/{CHECKPOINT_INCOMPLETE_MARKER}"
-            staging_checkpoint_path = None  # Initialize for cleanup later
-
-            # Only local rank 0 uploads to S3, but all ranks must wait at barrier
-            upload_exception = None
+            # Only local rank 0 stages and queues uploads
             if is_local_rank_0:
+                current_step = state.global_step
+                checkpoint_name = f"{PREFIX_CHECKPOINT_DIR}-{current_step}"
                 checkpoint_path = os.path.join(args.output_dir, checkpoint_name)
 
                 # Verify checkpoint exists
@@ -562,88 +791,28 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     os.makedirs(staging_dir, exist_ok=True)
                     staging_checkpoint_path = os.path.join(staging_dir, checkpoint_name)
 
-                    try:
-                        # Move checkpoint to staging (instant metadata operation, not a copy)
-                        print(
-                            f"[Kubeflow] Moving checkpoint to staging: {checkpoint_name}",
-                            flush=True,
-                        )
-                        shutil.move(checkpoint_path, staging_checkpoint_path)
-
-                        # S3 operations: create sentinel, upload, delete sentinel
-                        if is_global_rank_0:
-                            print(
-                                f"[Kubeflow] Creating .incomplete marker in S3: {checkpoint_name}",
-                                flush=True,
-                            )
-                            self.remote_fs.pipe(
-                                incomplete_marker_path,
-                                f"Upload started at step {current_step}".encode(),
-                            )
-
-                        print(
-                            f"[Kubeflow] Starting synchronous upload to S3: {checkpoint_name}",
-                            flush=True,
-                        )
-                        # Calculate local directory size
-                        local_size = self._calculate_local_dir_size(staging_checkpoint_path)
-
-                        # fsspec.put() with recursive=True uploads entire directory
-                        # s3fs retries operations 5 times automatically on failure
-                        # gcsfs retries 6 times, adlfs retries 3 times
-                        self.remote_fs.put(
-                            staging_checkpoint_path,
-                            "",  # Maintain same local checkpoint structure in remote
-                            recursive=True,
-                            callback=self._cloud_storage_progress_callback("Upload", local_size),
-                        )
-
-                        print(f"[Kubeflow] Upload complete: {checkpoint_name}", flush=True)
-
-                    except Exception as e:
-                        upload_exception = RuntimeError(
-                            f"[Kubeflow] Checkpoint upload failed for {checkpoint_name}: {e}. "
-                            "This may be caused by network issues, S3 outage, or "
-                            "permission changes. Verify S3 connectivity and retry the training job."
-                        )
-                        upload_exception.__cause__ = e
-
-            # Barrier to wait for all local rank 0 upload to complete
-            self._wait_for_all_ranks("upload")
-
-            # Raise upload exception after barrier to ensure all ranks see the failure
-            if upload_exception is not None:
-                raise upload_exception
-
-            if is_global_rank_0:
-                # Delete .incomplete sentinel (marks upload complete)
-                try:
-                    self.remote_fs.rm_file(incomplete_marker_path)
-                    print(f"[Kubeflow] Removed .incomplete marker: {checkpoint_name}", flush=True)
-                except Exception as e:
-                    # Log warning but don't fail - checkpoint upload succeeded
-                    # Stale marker will cause this checkpoint to be skipped on resume
+                    # Move checkpoint to staging (instant metadata operation, not a copy)
                     print(
-                        f"[Kubeflow] Warning: Failed to remove .incomplete marker for "
-                        f"{checkpoint_name}: {e}. Checkpoint uploaded successfully but may be "
-                        f"skipped during resume. Consider manually removing: "
-                        f"{incomplete_marker_path}",
+                        f"[Kubeflow] Moving checkpoint to staging: {checkpoint_name}",
                         flush=True,
                     )
+                    shutil.move(checkpoint_path, staging_checkpoint_path)
 
-            if is_local_rank_0 and staging_checkpoint_path is not None:
-                # Delete local staging checkpoint to free disk space
-                try:
-                    shutil.rmtree(staging_checkpoint_path)
-                    print(
-                        f"[Kubeflow] Deleted local staging checkpoint: {checkpoint_name}",
-                        flush=True,
+                    # Calculate directory size for progress tracking
+                    total_size = self._calculate_local_dir_size(staging_checkpoint_path)
+
+                    # Start upload worker if not yet running
+                    self._start_upload_worker()
+                    # Queue upload task (non-blocking, training continues immediately)
+                    task = (
+                        staging_checkpoint_path,
+                        checkpoint_name,
+                        total_size,
+                        is_global_rank_0,
                     )
-                except Exception as cleanup_error:
+                    self._upload_queue.put(task)
                     print(
-                        f"[Kubeflow] Warning: Failed to delete local staging checkpoint "
-                        f"{checkpoint_name}: {cleanup_error}. "
-                        "Upload succeeded, but local cleanup failed.",
+                        f"[Kubeflow] Queued checkpoint for async upload: {checkpoint_name}",
                         flush=True,
                     )
 
@@ -688,6 +857,13 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             is_local_rank_0 = args.local_process_index == 0
             if is_local_rank_0:
+                # Shutdown background upload worker and wait for all uploads to complete
+                self._shutdown_upload_worker()
+
+                # Check for any errors that occurred during final uploads
+                self._check_upload_error()
+
+                # Clean up staging directory
                 staging_dir = os.path.join(args.output_dir, CHECKPOINT_STAGING_DIR)
                 if os.path.exists(staging_dir):
                     try:
@@ -764,6 +940,13 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             # Apply Kubeflow checkpoint config to training_args
             if training_args and checkpoint_config:
+                if getattr(training_args, "save_only_model", False):
+                    raise ValueError(
+                        "save_only_model=True is not supported for checkpointing because it "
+                        "prevents a full resume (optimizer/scheduler/RNG state are missing). "
+                        "Set save_only_model=False to enable fault-tolerant training."
+                    )
+
                 # Apply output_dir if provided by user
                 if "output_dir" in checkpoint_config:
                     training_args.output_dir = checkpoint_config["output_dir"]
@@ -795,6 +978,17 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"[Kubeflow] Applied save_total_limit: "
                         f"{checkpoint_config['save_total_limit']}",
                         flush=True,
+                    )
+
+                if (
+                    isinstance(training_args.output_dir, str)
+                    and training_args.output_dir.startswith("s3://")
+                    and getattr(training_args, "save_on_each_node", False)
+                ):
+                    raise ValueError(
+                        "save_on_each_node=True is not supported when output_dir is an S3 URI. "
+                        "This would duplicate full checkpoints on every node and waste bandwidth. "
+                        "Set save_on_each_node=False or use a PVC-backed output_dir instead."
                     )
 
             # Inject JIT callback if enabled
@@ -1340,10 +1534,7 @@ def get_jit_checkpoint_injection_code(
     verify_cloud_storage_ssl: bool = True,
 ) -> str:
     """Generate the complete JIT checkpoint code to inject into training scripts."""
-    from kubeflow.trainer.rhai.constants import (
-        CHECKPOINT_INCOMPLETE_MARKER,
-        CHECKPOINT_STAGING_DIR,
-    )
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER, CHECKPOINT_STAGING_DIR
 
     # Build checkpoint config dict
     config_dict = {

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -233,7 +233,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
         print(f"{_log_prefix} {message}", flush=True)
 
     class CheckpointManager:
-        """JIT checkpoint manager."""
+        """Manages async just-in-time checkpointing on SIGTERM signal using CUDA streams."""
 
         def __init__(self, trainer):
             self.trainer = trainer
@@ -252,7 +252,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 _log("CUDA not available, checkpointing will be synchronous")
 
         def setup_signal_handler(self):
-            """Register SIGTERM handler."""
+            """Register SIGTERM signal handler for JIT checkpointing."""
             self._original_sigterm_handler = signal.signal(signal.SIGTERM, self._sigterm_handler)
             _log("JIT checkpoint signal handler registered for SIGTERM")
 
@@ -271,7 +271,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             self.checkpoint_thread.start()
 
         def _async_checkpoint(self):
-            """Checkpoint asynchronously."""
+            """Execute checkpoint asynchronously, waiting if in optimizer step."""
             try:
                 # Wait if we're currently in optimizer step (unsafe to checkpoint)
                 while self._in_optimizer_step:
@@ -341,7 +341,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             return self.checkpoint_requested
 
     class JITCheckpointCallback(TrainerCallback):
-        """JIT checkpoint callback."""
+        """Transformers callback that integrates JIT checkpointing with trainer lifecycle."""
 
         def __init__(self, cloud_remote_storage_uri: Optional[str] = None) -> None:
             self.jit_manager = None
@@ -422,7 +422,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 ) from e
 
         def _calculate_local_dir_size(self, path: str) -> int:
-            """Total size of local directory."""
+            """Calculate total size of local directory."""
             import contextlib
 
             total = 0
@@ -433,7 +433,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             return total
 
         def _cloud_storage_progress_callback(self, operation: str, total_size: int):
-            """Progress callback."""
+            """Create progress callback with byte-level tracking via branched()."""
             from fsspec.callbacks import Callback
 
             class ProgressCallback(Callback):
@@ -661,7 +661,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 _log("Background upload worker stopped")
 
         def on_init_end(self, args, state, control, **kwargs):
-            """Download latest checkpoint from S3."""
+            """Download latest checkpoint from S3 (local rank 0)."""
             if not self.remote_fs:
                 # Return since cloud storage not configured by user
                 return

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -220,6 +220,18 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
     from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER, CHECKPOINT_STAGING_DIR
 
+    _log_prefix = None
+
+    def _log(message: str, args: Optional[object] = None) -> None:
+        nonlocal _log_prefix
+        if _log_prefix is None:
+            node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
+            rank = getattr(args, "local_process_index", None)
+            if rank is None:
+                rank = os.environ.get("LOCAL_RANK") or "0"
+            _log_prefix = f"[Kubeflow-node{node}-rank{rank}]"
+        print(f"{_log_prefix} {message}", flush=True)
+
     class CheckpointManager:
         """JIT checkpoint manager."""
 
@@ -235,23 +247,21 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             try:
                 if torch.cuda.is_available():
                     self.checkpoint_stream = torch.cuda.Stream()
-                    print("[Kubeflow] CUDA stream initialized for async checkpointing", flush=True)
+                    _log("CUDA stream initialized for async checkpointing")
             except (ImportError, AttributeError):
-                print(
-                    "[Kubeflow] CUDA not available, checkpointing will be synchronous", flush=True
-                )
+                _log("CUDA not available, checkpointing will be synchronous")
 
         def setup_signal_handler(self):
             """Register SIGTERM handler."""
             self._original_sigterm_handler = signal.signal(signal.SIGTERM, self._sigterm_handler)
-            print("[Kubeflow] JIT checkpoint signal handler registered for SIGTERM", flush=True)
+            _log("JIT checkpoint signal handler registered for SIGTERM")
 
         def _sigterm_handler(self, signum, frame):
             """Start async checkpoint on SIGTERM."""
             if self.checkpoint_requested:
                 return
 
-            print("[Kubeflow] SIGTERM received, starting async checkpoint", flush=True)
+            _log("SIGTERM received, starting async checkpoint")
             self.checkpoint_requested = True
 
             # Start checkpoint thread immediately
@@ -268,7 +278,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     time.sleep(0.5)
 
                 current_step = self.trainer.state.global_step
-                print(f"[Kubeflow] Starting JIT checkpoint at step {current_step}", flush=True)
+                _log(f"Starting JIT checkpoint at step {current_step}")
 
                 # Get rank for distributed training. Fall back to True for single-process
                 # runs or if accelerate is unavailable.
@@ -293,7 +303,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         with open(sentinel_file, "w") as f:
                             f.write(f"Checkpoint started at step {current_step}")
                     except Exception as e:
-                        print(f"[Kubeflow] Warning: Failed to write sentinel file: {e}")
+                        _log(f"Warning: Failed to write sentinel file: {e}")
 
                 # Checkpoint using dedicated CUDA stream
                 if self.checkpoint_stream is not None:
@@ -316,12 +326,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     try:
                         os.remove(sentinel_file)
                     except Exception as e:
-                        print(f"[Kubeflow] Warning: Failed to remove sentinel file: {e}")
+                        _log(f"Warning: Failed to remove sentinel file: {e}")
 
-                print(f"[Kubeflow] JIT checkpoint completed at step {current_step}", flush=True)
+                _log(f"JIT checkpoint completed at step {current_step}")
 
             except Exception as e:
-                print(f"[Kubeflow] Failed to save JIT checkpoint: {e}", flush=True)
+                _log(f"Failed to save JIT checkpoint: {e}")
                 import traceback
 
                 traceback.print_exc()
@@ -363,10 +373,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
                         # Warn when SSL verification is disabled
                         if not verify_ssl:
-                            print(
-                                "[Kubeflow] WARNING: SSL certificate verification disabled. "
-                                "This should only be used with trusted S3-compatible storage.",
-                                flush=True,
+                            _log(
+                                "WARNING: SSL certificate verification disabled. "
+                                "This should only be used with trusted S3-compatible storage."
                             )
 
                 try:
@@ -381,11 +390,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         self.remote_fs.cat(test_file)
                         self.remote_fs.rm_file(test_file)
 
-                    print(
-                        f"[Kubeflow] Cloud storage configured: {cloud_remote_storage_uri} "
-                        f"({protocol})",
-                        flush=True,
-                    )
+                    _log(f"Cloud storage configured: {cloud_remote_storage_uri} ({protocol})")
                 except Exception as e:
                     raise RuntimeError(
                         f"Failed to check this node has access to the storage path: "
@@ -438,9 +443,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     self.total_size = total_size
                     self.last = time.time()
                     self.value = 0
-                    print(
-                        f"[Kubeflow] {name} size: {total_size / (1024 * 1024):.1f} MB", flush=True
-                    )
+                    _log(f"{name} size: {total_size / (1024 * 1024):.1f} MB")
 
                 def branched(self, path_1, path_2, **kwargs):
                     """Return child callback that accumulates bytes to parent."""
@@ -457,10 +460,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                                     if parent.total_size
                                     else 0
                                 )
-                                print(
-                                    f"[Kubeflow] Progress: {mb:.1f}"
-                                    f"/{parent.total_size / (1024 * 1024):.1f} MB ({pct}%)",
-                                    flush=True,
+                                _log(
+                                    f"Progress: {mb:.1f}"
+                                    f"/{parent.total_size / (1024 * 1024):.1f} MB ({pct}%)"
                                 )
                                 parent.last = time.time()
 
@@ -484,11 +486,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 self._shutdown_event = threading.Event()
                 self._upload_thread = threading.Thread(
                     target=self._upload_worker_loop,
-                    daemon=True,
+                    daemon=False,
                     name="KubeflowCheckpointUploader",
                 )
                 self._upload_thread.start()
-                print("[Kubeflow] Background upload worker started", flush=True)
+                _log("Background upload worker started")
 
         def _upload_worker_loop(self) -> None:
             """Upload worker loop."""
@@ -511,10 +513,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             "permission changes. Verify S3 connectivity and retry the training job."
                         )
                         self._upload_error.__cause__ = e
-                    print(
-                        f"[Kubeflow] ERROR: Background upload failed for {checkpoint_name}: {e}",
-                        flush=True,
-                    )
+                    _log(f"ERROR: Background upload failed for {checkpoint_name}: {e}")
                 finally:
                     self._upload_queue.task_done()
 
@@ -525,36 +524,23 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             # Create .incomplete sentinel so resume can skip in-flight uploads.
             if is_global_rank_0:
-                print(
-                    f"[Kubeflow] Creating .incomplete marker in S3: {checkpoint_name}",
-                    flush=True,
-                )
+                _log(f"Creating .incomplete marker in S3: {checkpoint_name}")
             try:
                 self.remote_fs.pipe(
                     incomplete_marker_path,
                     f"Upload started for {checkpoint_name}".encode(),
                 )
             except Exception as e:
-                print(
-                    f"[Kubeflow] Warning: Failed to write .incomplete marker for "
-                    f"{checkpoint_name}: {e}",
-                    flush=True,
-                )
+                _log(f"Warning: Failed to write .incomplete marker for {checkpoint_name}: {e}")
 
             # Upload files in parallel
-            print(
-                f"[Kubeflow] Starting parallel upload to S3: {checkpoint_name}",
-                flush=True,
-            )
+            _log(f"Starting parallel upload to S3: {checkpoint_name}")
 
             failed_files = self._parallel_upload_files(staging_path, checkpoint_name, total_size)
 
             # Retry failed files if any
             if failed_files:
-                print(
-                    f"[Kubeflow] Retrying {len(failed_files)} failed files for {checkpoint_name}",
-                    flush=True,
-                )
+                _log(f"Retrying {len(failed_files)} failed files for {checkpoint_name}")
                 remaining_failures = self._retry_failed_files(failed_files)
 
                 if remaining_failures:
@@ -563,32 +549,23 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"{[f[1] for f in remaining_failures[:5]]}"  # Show first 5
                     )
 
-            print(f"[Kubeflow] Upload complete: {checkpoint_name}", flush=True)
+            _log(f"Upload complete: {checkpoint_name}")
 
             # Delete .incomplete sentinel (global rank 0 only)
             if is_global_rank_0:
                 try:
                     self.remote_fs.rm_file(incomplete_marker_path)
                 except Exception as e:
-                    print(
-                        f"[Kubeflow] Warning: Failed to remove remote file "
-                        f"'{incomplete_marker_path}': {e}",
-                        flush=True,
-                    )
+                    _log(f"Warning: Failed to remove remote file '{incomplete_marker_path}': {e}")
 
             # Delete local staging checkpoint
             try:
                 shutil.rmtree(staging_path)
-                print(
-                    f"[Kubeflow] Deleted local staging checkpoint: {checkpoint_name}",
-                    flush=True,
-                )
+                _log(f"Deleted local staging checkpoint: {checkpoint_name}")
             except Exception as cleanup_error:
-                print(
-                    f"[Kubeflow] Warning: Failed to delete local staging checkpoint "
-                    f"{checkpoint_name}: {cleanup_error}. "
-                    "Upload succeeded, but local cleanup failed.",
-                    flush=True,
+                _log(
+                    f"Warning: Failed to delete local staging checkpoint {checkpoint_name}: "
+                    f"{cleanup_error}. Upload succeeded, but local cleanup failed."
                 )
 
         def _parallel_upload_files(
@@ -630,11 +607,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         if time.time() - last_update >= 1:
                             mb = uploaded_bytes / (1024 * 1024)
                             pct = int((uploaded_bytes / total_size) * 100) if total_size else 0
-                            print(
-                                f"[Kubeflow] Progress: {mb:.1f}"
-                                f"/{total_size / (1024 * 1024):.1f} MB ({pct}%)",
-                                flush=True,
-                            )
+                            _log(f"Progress: {mb:.1f}/{total_size / (1024 * 1024):.1f} MB ({pct}%)")
                             last_update = time.time()
 
                     return True
@@ -668,16 +641,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         break
                     except Exception as e:
                         if attempt == 3:
-                            print(
-                                f"[Kubeflow] File upload failed after 3 attempts: "
-                                f"{remote_file}: {e}",
-                                flush=True,
-                            )
+                            _log(f"File upload failed after 3 attempts: {remote_file}: {e}")
                         else:
-                            print(
-                                f"[Kubeflow] Retry {attempt}/3 for {remote_file}",
-                                flush=True,
-                            )
+                            _log(f"Retry {attempt}/3 for {remote_file}")
                             time.sleep(1)  # Brief delay before retry
 
                 if not success:
@@ -688,11 +654,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
         def _shutdown_upload_worker(self) -> None:
             """Stop upload worker."""
             if self._upload_queue is not None and self._upload_thread is not None:
-                print("[Kubeflow] Waiting for background uploads to complete...", flush=True)
+                _log("Waiting for background uploads to complete...")
                 self._upload_queue.join()  # Wait for all tasks to finish
                 self._shutdown_event.set()  # Signal shutdown
-                self._upload_thread.join(timeout=10)  # Wait for thread to exit
-                print("[Kubeflow] Background upload worker stopped", flush=True)
+                self._upload_thread.join()  # Wait for thread to exit
+                _log("Background upload worker stopped")
 
         def on_init_end(self, args, state, control, **kwargs):
             """Download latest checkpoint from S3."""
@@ -725,7 +691,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         continue
 
                     try:
-                        print(f"[Kubeflow] Downloading checkpoint: {name}", flush=True)
+                        _log(f"Downloading checkpoint: {name}", args=args)
                         # Calculate remote directory size
                         remote_size = self.remote_fs.du(name, total=True, maxdepth=None)
                         self.remote_fs.get(
@@ -734,7 +700,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             recursive=True,
                             callback=self._cloud_storage_progress_callback("Download", remote_size),
                         )
-                        print("[Kubeflow] Download complete", flush=True)
+                        _log("Download complete", args=args)
 
                     except Exception as e:
                         raise RuntimeError(
@@ -748,10 +714,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     break
                 else:
                     # Loop completed without break - either no checkpoints or all incomplete
-                    print(
-                        "[Kubeflow] No existing or valid checkpoints found in cloud storage. "
+                    _log(
+                        "No existing or valid checkpoints found in cloud storage. "
                         "Training will start from scratch.",
-                        flush=True,
+                        args=args,
                     )
 
             # Barrier to wait for local rank 0 checkpoint download to complete
@@ -780,10 +746,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
                 # Verify checkpoint exists
                 if not os.path.exists(checkpoint_path):
-                    print(
-                        f"[Kubeflow] Warning: Checkpoint {checkpoint_path} not found, "
-                        "skipping upload",
-                        flush=True,
+                    _log(
+                        f"Warning: Checkpoint {checkpoint_path} not found, skipping upload",
+                        args=args,
                     )
                 else:
                     # Create staging directory (prevents save_total_limit race condition)
@@ -792,9 +757,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     staging_checkpoint_path = os.path.join(staging_dir, checkpoint_name)
 
                     # Move checkpoint to staging (instant metadata operation, not a copy)
-                    print(
-                        f"[Kubeflow] Moving checkpoint to staging: {checkpoint_name}",
-                        flush=True,
+                    _log(
+                        f"Moving checkpoint to staging: {checkpoint_name}",
+                        args=args,
                     )
                     shutil.move(checkpoint_path, staging_checkpoint_path)
 
@@ -811,20 +776,20 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         is_global_rank_0,
                     )
                     self._upload_queue.put(task)
-                    print(
-                        f"[Kubeflow] Queued checkpoint for async upload: {checkpoint_name}",
-                        flush=True,
+                    _log(
+                        f"Queued checkpoint for async upload: {checkpoint_name}",
+                        args=args,
                     )
 
         def on_train_begin(self, args, state, control, **kwargs):
             if self._trainer_ref is not None and self.jit_manager is None:
                 self.jit_manager = CheckpointManager(trainer=self._trainer_ref)
                 self.jit_manager.setup_signal_handler()
-                print("[Kubeflow] JIT checkpointing enabled", flush=True)
+                _log("JIT checkpointing enabled", args=args)
             elif self._trainer_ref is None:
-                print(
-                    "[Kubeflow] Warning: Trainer reference not set for JIT checkpoint callback",
-                    flush=True,
+                _log(
+                    "Warning: Trainer reference not set for JIT checkpoint callback",
+                    args=args,
                 )
 
         def on_pre_optimizer_step(self, args, state, control, **kwargs):
@@ -868,9 +833,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 if os.path.exists(staging_dir):
                     try:
                         shutil.rmtree(staging_dir)
-                        print("[Kubeflow] Deleted staging directory", flush=True)
+                        _log("Deleted staging directory", args=args)
                     except Exception as e:
-                        print(f"[Kubeflow] Warning: Staging cleanup failed: {e}", flush=True)
+                        _log(f"Warning: Staging cleanup failed: {e}", args=args)
 
     def apply_checkpointing():
         """Setup monkey patch for Trainer to auto inject JIT checkpoint callback."""
@@ -942,9 +907,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             if training_args and checkpoint_config:
                 if getattr(training_args, "save_only_model", False):
                     raise ValueError(
-                        "save_only_model=True is not supported for checkpointing because it "
-                        "prevents a full resume (optimizer/scheduler/RNG state are missing). "
-                        "Set save_only_model=False to enable fault-tolerant training."
+                        "save_only_model=True is incompatible with Kubeflow checkpointing. "
+                        "When enabled, only model weights are saved, but optimizer state, "
+                        "scheduler state, and RNG state are excluded. This prevents resuming "
+                        "training from the exact point of interruption, breaking fault tolerance. "
+                        "\nTo fix: Set save_only_model=False in your TrainingArguments, or "
+                        "remove it entirely (defaults to False)."
                     )
 
                 # Apply output_dir if provided by user
@@ -980,10 +948,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         flush=True,
                     )
 
-                if (
-                    isinstance(training_args.output_dir, str)
-                    and training_args.output_dir.startswith("s3://")
-                    and getattr(training_args, "save_on_each_node", False)
+                if checkpoint_config.get("cloud_remote_storage_uri") and getattr(
+                    training_args, "save_on_each_node", False
                 ):
                     raise ValueError(
                         "save_on_each_node=True is not supported when output_dir is an S3 URI. "

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -1609,6 +1609,10 @@ class cuda:
 
 class distributed:
     @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
     def is_initialized():
         return False
 
@@ -1784,6 +1788,10 @@ class cuda:
         return True
 
 class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
     @staticmethod
     def is_initialized():
         return False
@@ -2196,6 +2204,226 @@ def test_get_jit_checkpoint_injection_code_with_storage_uri():
     print("test execution complete")
 
 
+def test_async_upload_worker_scaffolding():
+    """Test async upload worker scaffolding is present in generated code."""
+    print("Executing test: async upload worker scaffolding")
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir="/mnt/kubeflow-checkpoints",
+        cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
+        enable_jit_checkpoint=True,
+    )
+
+    assert "LifoQueue" in checkpoint_code
+    assert "daemon=False" in checkpoint_code
+    assert "KubeflowCheckpointUploader" in checkpoint_code
+    assert "self._upload_queue.join()" in checkpoint_code
+    assert "self._upload_thread.join()" in checkpoint_code
+
+    print("test execution complete")
+
+
+def test_async_parallel_upload_scaffolding():
+    """Test parallel upload scaffolding is present in generated code."""
+    print("Executing test: async parallel upload scaffolding")
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir="/mnt/kubeflow-checkpoints",
+        cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
+        enable_jit_checkpoint=True,
+    )
+
+    assert "ThreadPoolExecutor" in checkpoint_code
+    assert "as_completed" in checkpoint_code
+    assert "_parallel_upload_files" in checkpoint_code
+
+    print("test execution complete")
+
+
+def test_async_upload_execution(tmp_path):
+    """Integration test: async upload runs and cleans staging."""
+    print("Executing test: async upload execution")
+
+    import subprocess
+    import sys
+
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER
+
+    output_dir = tmp_path / "checkpoints"
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir=str(output_dir),
+        cloud_remote_storage_uri="s3://test-bucket/model-checkpoints",
+        enable_jit_checkpoint=True,
+    )
+
+    fsspec_stub = """
+class MockS3FileSystem:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def ls(self, path, detail=False):
+        return []
+
+    def exists(self, path):
+        return False
+
+    def pipe(self, path, data):
+        print(f"PIPE={path}")
+
+    def cat(self, path):
+        return b"test"
+
+    def put_file(self, local, remote):
+        print(f"PUT_FILE={remote}")
+
+    def rm_file(self, path):
+        print(f"RM_FILE={path}")
+
+    def get(self, src, dst, recursive=False, callback=None):
+        pass
+
+    def du(self, path, total=True, maxdepth=None):
+        return 0
+
+def filesystem(protocol, **kwargs):
+    return MockS3FileSystem()
+"""
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
+        pass
+
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+"""
+
+    transformers_stub = """
+class TrainerCallback:
+    pass
+
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class TrainerState:
+    def __init__(self):
+        self.global_step = 0
+        self.is_world_process_zero = True
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        self.state = TrainerState()
+        self.model = None
+        self._init_args = args
+        self._init_kwargs = kwargs
+
+    def train(self, resume_from_checkpoint=None):
+        return {"train_called": True, "resume_from": resume_from_checkpoint}
+"""
+
+    test_file = tmp_path / "test_async_upload_execution.py"
+
+    test_code = f"""
+import os
+import sys
+import types
+
+fsspec_module = types.ModuleType('fsspec')
+exec('''{fsspec_stub}''', fsspec_module.__dict__)
+sys.modules['fsspec'] = fsspec_module
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+{checkpoint_code}
+
+from transformers import TrainerCallback
+
+callback_class = None
+for name, obj in list(globals().items()):
+    if isinstance(obj, type) and issubclass(obj, TrainerCallback) and name != 'TrainerCallback':
+        callback_class = obj
+        break
+
+if not callback_class:
+    print("ERROR: JITCheckpointCallback not found")
+    sys.exit(1)
+
+callback = callback_class(cloud_remote_storage_uri="s3://test-bucket/model-checkpoints")
+
+class MockArgs:
+    output_dir = r"{output_dir}"
+    local_process_index = 0
+
+class MockState:
+    global_step = 3
+    is_world_process_zero = True
+
+checkpoint_path = os.path.join(MockArgs.output_dir, "checkpoint-3")
+os.makedirs(checkpoint_path, exist_ok=True)
+with open(os.path.join(checkpoint_path, "model.bin"), "w", encoding="utf-8") as f:
+    f.write("data")
+
+callback.on_save(MockArgs(), MockState(), None)
+callback._shutdown_upload_worker()
+
+if True:
+    staging_checkpoint = os.path.join(
+        MockArgs.output_dir, CHECKPOINT_STAGING_DIR, "checkpoint-3"
+    )
+    print(f"STAGING_CHECKPOINT_EXISTS={{os.path.exists(staging_checkpoint)}}")
+    print(f"CHECKPOINT_EXISTS={{os.path.exists(checkpoint_path)}}")
+
+print("TEST_COMPLETE=True")
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=10
+    )
+
+    output = result.stdout
+    print(f"Test output:\\n{output}")
+
+    if result.returncode != 0:
+        print(f"Test stderr:\\n{result.stderr}")
+
+    assert result.returncode == 0, f"Execution failed with return code {result.returncode}"
+    assert "TEST_COMPLETE=True" in output
+    assert f"PIPE=checkpoint-3/{CHECKPOINT_INCOMPLETE_MARKER}" in output
+    assert "PUT_FILE=checkpoint-3/model.bin" in output
+    assert f"RM_FILE=checkpoint-3/{CHECKPOINT_INCOMPLETE_MARKER}" in output
+    assert "STAGING_CHECKPOINT_EXISTS=False" in output
+    assert "CHECKPOINT_EXISTS=False" in output
+
+    print("test execution complete")
+
+
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -2354,6 +2582,10 @@ def filesystem(protocol, **kwargs):
 
     torch_stub = """
 class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
     @staticmethod
     def is_initialized():
         return False

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -14,6 +14,7 @@
 
 """Tests for TransformersTrainer and instrumentation wrapper generation."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -2200,6 +2201,174 @@ def test_get_jit_checkpoint_injection_code_with_storage_uri():
     # Verify cloud_remote_storage_uri is in the generated config
     assert "cloud_remote_storage_uri" in checkpoint_code
     assert "s3://my-bucket/model-checkpoints" in checkpoint_code
+
+    print("test execution complete")
+
+
+def _run_checkpoint_validation_subprocess(
+    tmp_path: Path, test_name: str, checkpoint_code: str, training_args_body: str
+) -> tuple[int, str, str]:
+    """Run injected checkpoint code in a subprocess and return exit code and output."""
+    import subprocess
+    import sys
+
+    fsspec_stub = """
+class MockS3FileSystem:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def pipe(self, path, data):
+        pass
+
+    def cat(self, path):
+        return b"test"
+
+    def rm_file(self, path):
+        pass
+
+def filesystem(protocol, **kwargs):
+    return MockS3FileSystem()
+"""
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
+        pass
+
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+
+class Tensor:
+    pass
+"""
+
+    transformers_stub = """
+class TrainerCallback:
+    pass
+
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        self._init_args = args
+        self._init_kwargs = kwargs
+
+    def train(self, resume_from_checkpoint=None, **train_kwargs):
+        return {"train_called": True, "resume_from": resume_from_checkpoint}
+"""
+
+    test_file = tmp_path / f"{test_name}.py"
+    test_code = f"""
+import sys
+import types
+
+fsspec_module = types.ModuleType('fsspec')
+exec('''{fsspec_stub}''', fsspec_module.__dict__)
+sys.modules['fsspec'] = fsspec_module
+
+callbacks_module = types.ModuleType('fsspec.callbacks')
+callbacks_module.Callback = type('Callback', (), {{}})
+sys.modules['fsspec.callbacks'] = callbacks_module
+fsspec_module.callbacks = callbacks_module
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+{checkpoint_code}
+
+from transformers import Trainer
+
+class TrainingArgs:
+{training_args_body}
+
+try:
+    Trainer(args=TrainingArgs())
+    print("NO_ERROR")
+    sys.exit(1)
+except ValueError as e:
+    print(str(e))
+    sys.exit(0)
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=10
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_save_only_model_validation_error(tmp_path):
+    """Test save_only_model=True raises a validation error."""
+    print("Executing test: save_only_model validation error")
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir="/mnt/kubeflow-checkpoints",
+        enable_jit_checkpoint=True,
+    )
+
+    returncode, stdout, stderr = _run_checkpoint_validation_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_save_only_model_validation_error",
+        checkpoint_code=checkpoint_code,
+        training_args_body="    save_only_model = True\n",
+    )
+
+    if returncode != 0:
+        print(f"Test stderr:\n{stderr}")
+
+    assert returncode == 0
+    assert "save_only_model=True is incompatible with Kubeflow checkpointing" in stdout
+
+    print("test execution complete")
+
+
+def test_save_on_each_node_validation_error(tmp_path):
+    """Test save_on_each_node=True raises a validation error with S3."""
+    print("Executing test: save_on_each_node validation error")
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir="/mnt/kubeflow-checkpoints",
+        cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
+        enable_jit_checkpoint=True,
+    )
+
+    returncode, stdout, stderr = _run_checkpoint_validation_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_save_on_each_node_validation_error",
+        checkpoint_code=checkpoint_code,
+        training_args_body="    save_on_each_node = True\n",
+    )
+
+    if returncode != 0:
+        print(f"Test stderr:\n{stderr}")
+
+    assert returncode == 0
+    assert "save_on_each_node=True is not supported when output_dir is an S3 URI" in stdout
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -2386,8 +2386,8 @@ def test_async_upload_worker_scaffolding():
     assert "LifoQueue" in checkpoint_code
     assert "daemon=False" in checkpoint_code
     assert "KubeflowCheckpointUploader" in checkpoint_code
-    assert "self._upload_queue.join()" in checkpoint_code
-    assert "self._upload_thread.join()" in checkpoint_code
+    assert "1 hour" in checkpoint_code
+    assert "self._upload_thread.join(timeout=" in checkpoint_code
 
     print("test execution complete")
 
@@ -2675,6 +2675,7 @@ def test_s3_download_execution(test_case, tmp_path):
     import subprocess
     import sys
 
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER
     from kubeflow.trainer.rhai.transformers import get_jit_checkpoint_injection_code
 
     checkpoint_code = get_jit_checkpoint_injection_code(
@@ -2687,18 +2688,16 @@ def test_s3_download_execution(test_case, tmp_path):
     checkpoints = test_case.config["checkpoints"]
     if checkpoints is None:
         # Simulate remote storage path not existing yet
-        ls_implementation = '        raise FileNotFoundError("Remote storage path does not exist")'
+        ls_implementation = (
+            '            raise FileNotFoundError("Remote storage path does not exist")'
+        )
     else:
         checkpoints_list = ", ".join([f'"{cp}"' for cp in checkpoints])
-        ls_implementation = f"        return [{checkpoints_list}]"
+        ls_implementation = f"            return [{checkpoints_list}]"
 
-    incomplete_checks = []
-    for marker in test_case.config["incomplete_markers"]:
-        incomplete_checks.append(
-            f'        if "{marker}" in path and "checkpoint-is-incomplete.txt" in path:\n'
-            f"            return True"
-        )
-    incomplete_logic = "\n".join(incomplete_checks) if incomplete_checks else "        pass"
+    incomplete_markers = ", ".join(
+        [f'"{marker}"' for marker in test_case.config["incomplete_markers"]]
+    )
 
     fsspec_stub = f"""
 class MockS3FileSystem:
@@ -2706,10 +2705,13 @@ class MockS3FileSystem:
         pass
 
     def ls(self, path, detail=False):
+        if path == "":
 {ls_implementation}
+        if path in [{incomplete_markers}]:
+            return [f"{{path}}/{CHECKPOINT_INCOMPLETE_MARKER}.node-0-rank-0"]
+        return []
 
     def exists(self, path):
-{incomplete_logic}
         return False
 
     def pipe(self, path, data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ podman = [
   "podman>=5.6.0"
 ]
 rhai = [
-  "fsspec>=2025.9.0",
-  "s3fs>=2024.12.0",
+  "fsspec>=2025.3.0",
+  "s3fs>=2025.3.0",
 ]
 hub = [
   "model-registry>=0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ podman = [
   "podman>=5.6.0"
 ]
 rhai = [
-  "fsspec>=2025.3.0",
-  "s3fs>=2025.3.0",
+  "fsspec>=2025.9.0",
+  "s3fs>=2024.12.0",
 ]
 hub = [
   "model-registry>=0.3.0",


### PR DESCRIPTION

**What this PR does / why we need it**:
Implemented feature outlined in ticket [RHOAIENG-45707](https://issues.redhat.com/browse/RHOAIENG-45707). This updates the exisiting synchronous  checkpoint upload to asynchronous. The PR does the following things:

 - Add async, parallel checkpoint uploads to S3 using a background worker with a LIFO queue and bounded thread pool.
 - Add structured print statements with node/rank prefix.
 - Enforce `save_only_model=True` as an error for resumable training.
 - Enforce `save_on_each_node=False` when using S3 output_dir.
 - Update unit tests and add test covering async upload behavior.

Test logs of resuming a training with Llama-3.3-70B-instruct model (FSDP sharded training) PEFT/LoRA enabled:
[fsdp-sharded-Llama-70B-resume.txt](https://github.com/user-attachments/files/25472840/fsdp-sharded-Llama-70B-resume.txt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background asynchronous checkpoint uploads with progress tracking, retries, and staged cleanup.
  * Standardized, context-rich logging for checkpoint operations and transfer phases.
  * Validation preventing incompatible checkpoint configurations (e.g., certain save modes with cloud outputs).

* **Bug Fixes**
  * Improved error detection and propagation for background upload and checkpoint lifecycles.
  * More robust handling of cloud storage access, SSL warnings, and cleanup.

* **Tests**
  * Expanded end-to-end and subprocess tests covering checkpoint injection, upload/download scenarios, and validation of storage URI handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->