### PR TITLE
feat: add common snyk workflow

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -7,13 +7,33 @@ on:
         description: 'Release version (e.g., v0.2.0+rhai0)'
         required: true
         type: string
+      acknowledge_cve_risk:
+        description: >-
+          Set to true to proceed with the release even if Snyk detects
+          High or Critical CVEs (e.g., after human review determines
+          they do not affect the SDK).
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
+  security-events: write
 
 jobs:
+  snyk-scan:
+    name: Security gate
+    if: ${{ github.repository == 'opendatahub-io/kubeflow-sdk' }}
+    uses: ./.github/workflows/snyk-security-scan.yaml
+    with:
+      fail_on_cves: ${{ !inputs.acknowledge_cve_risk }}
+      sarif_category: odh-release-snyk-audit
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
   prepare:
     name: Prepare release branch
+    needs: [snyk-scan]
     if: ${{ github.repository == 'opendatahub-io/kubeflow-sdk' }}
     runs-on: ubuntu-latest
     outputs:
@@ -56,6 +76,11 @@ jobs:
           echo "Upstream version: $UPSTREAM_VERSION"
           echo "Release branch: $BRANCH"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
       - name: Create or update release branch
         run: |
           set -euo pipefail
@@ -78,7 +103,10 @@ jobs:
           echo "Updated kubeflow/__init__.py:"
           cat kubeflow/__init__.py
 
-          git add kubeflow/__init__.py
+          # Regenerate requirements.txt from current lock file
+          uv export --format requirements-txt > requirements.txt
+
+          git add kubeflow/__init__.py requirements.txt
           git commit -m "chore: Set version to $VERSION for release" || echo "No changes to commit"
           git push origin "$BRANCH"
 

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -21,6 +21,9 @@ permissions:
   security-events: write
 
 jobs:
+  # Security gate: must pass before any release work begins.
+  # Blocks on High/Critical CVEs unless the operator explicitly sets
+  # acknowledge_cve_risk=true after reviewing the findings.
   snyk-scan:
     name: Security gate
     if: ${{ github.repository == 'opendatahub-io/kubeflow-sdk' }}
@@ -33,7 +36,7 @@ jobs:
 
   prepare:
     name: Prepare release branch
-    needs: [snyk-scan]
+    needs: [snyk-scan]  # Gated behind the security scan
     if: ${{ github.repository == 'opendatahub-io/kubeflow-sdk' }}
     runs-on: ubuntu-latest
     outputs:
@@ -103,8 +106,10 @@ jobs:
           echo "Updated kubeflow/__init__.py:"
           cat kubeflow/__init__.py
 
-          # Regenerate requirements.txt from current lock file
-          uv export --format requirements-txt > requirements.txt
+          # Regenerate requirements.txt from current lock file.
+          # --locked fails if uv.lock is stale vs pyproject.toml, preventing
+          # silent re-resolution during a release.
+          uv export --locked --format requirements-txt > requirements.txt
 
           git add kubeflow/__init__.py requirements.txt
           git commit -m "chore: Set version to $VERSION for release" || echo "No changes to commit"

--- a/.github/workflows/rebase-upstream.yaml
+++ b/.github/workflows/rebase-upstream.yaml
@@ -23,6 +23,9 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.diffcheck.outputs.has_changes }}
+      head_branch: ${{ env.HEAD_BRANCH }}
     env:
       DOWNSTREAM_BRANCH: ${{ inputs.downstream_branch || 'main' }}
       UPSTREAM_BRANCH: ${{ inputs.upstream_branch || 'main' }}
@@ -160,6 +163,19 @@ jobs:
             fi
           fi
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Update requirements.txt
+        run: |
+          uv export --format requirements-txt > requirements.txt
+          if ! git diff --quiet requirements.txt; then
+            git add requirements.txt
+            git commit -m "chore(deps): Update requirements.txt from uv.lock"
+          fi
+
       - name: Check for real changes (excluding owned paths)
         id: diffcheck
         run: |
@@ -230,28 +246,13 @@ jobs:
               --body "$BODY"
           fi
 
-      - name: Run Snyk to check for vulnerabilities
-        if: steps.diffcheck.outputs.has_changes == 'true'
-        uses: snyk/actions/python@master
-        continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --sarif-file-output=snyk-sync-results.sarif --severity-threshold=high
-
-      - name: Check Snyk SARIF
-        id: check-sarif
-        if: always() && steps.diffcheck.outputs.has_changes == 'true'
-        run: |
-          if [ -f "snyk-sync-results.sarif" ]; then
-            echo "sarif_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload Snyk Audit to Security Tab
-        if: always() && steps.check-sarif.outputs.sarif_exists == 'true'
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: 'snyk-sync-results.sarif'
-          category: midstream-snyk-audit
+  snyk-scan:
+    needs: sync
+    if: needs.sync.outputs.has_changes == 'true'
+    uses: ./.github/workflows/snyk-security-scan.yaml
+    with:
+      ref: ${{ needs.sync.outputs.head_branch }}
+      fail_on_cves: false
+      sarif_category: midstream-snyk-audit
+    secrets:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/rebase-upstream.yaml
+++ b/.github/workflows/rebase-upstream.yaml
@@ -23,6 +23,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Outputs are consumed by the snyk-scan job (separate runner)
     outputs:
       has_changes: ${{ steps.diffcheck.outputs.has_changes }}
       head_branch: ${{ env.HEAD_BRANCH }}
@@ -168,6 +169,8 @@ jobs:
         with:
           enable-cache: true
 
+      # Keep requirements.txt in sync after the upstream merge.
+      # Committed here so the change is included in the sync PR.
       - name: Update requirements.txt
         run: |
           uv export --format requirements-txt > requirements.txt
@@ -246,6 +249,8 @@ jobs:
               --body "$BODY"
           fi
 
+  # Informational Snyk scan on the sync branch -- results appear in the
+  # Security tab but do not block the PR (fail_on_cves: false).
   snyk-scan:
     needs: sync
     if: needs.sync.outputs.has_changes == 'true'

--- a/.github/workflows/snyk-security-scan.yaml
+++ b/.github/workflows/snyk-security-scan.yaml
@@ -1,3 +1,7 @@
+# Reusable Snyk vulnerability scan.
+# Called from rebase-upstream.yaml (informational) and odh-release.yaml (release gate).
+# Generates requirements.txt from uv.lock so Snyk scans the actual locked dependencies,
+# then uploads SARIF results to the GitHub Security tab.
 name: Snyk Security Scan
 
 on:
@@ -47,9 +51,15 @@ jobs:
         with:
           enable-cache: true
 
+      # Snyk needs requirements.txt to resolve the dependency tree.
+      # This is the same command used by update-requirements.yaml but ephemeral
+      # here -- callers are responsible for committing the file if needed.
       - name: Generate requirements.txt
         run: uv export --format requirements-txt > requirements.txt
 
+      # continue-on-error: true lets subsequent steps run regardless of whether
+      # Snyk finds vulnerabilities (exit 1) or encounters a scan error (exit 2-3).
+      # The actual pass/fail decision is deferred to the "Evaluate CVE gate" step.
       - name: Run Snyk to check for vulnerabilities
         id: snyk
         uses: snyk/actions/python@master
@@ -76,18 +86,27 @@ jobs:
           sarif_file: snyk-results.sarif
           category: ${{ inputs.sarif_category }}
 
+      # Distinguish "CVEs found" (failure + SARIF exists) from "scan broke"
+      # (failure + no SARIF). Only the former should set cves_found=true.
       - name: Set CVE result output
         id: result
         if: always()
         run: |
-          if [ "${{ steps.snyk.outcome }}" = "failure" ]; then
+          if [ "${{ steps.snyk.outcome }}" = "failure" ] && [ "${{ steps.check-sarif.outputs.sarif_exists }}" = "true" ]; then
             echo "cves_found=true" >> "$GITHUB_OUTPUT"
           else
             echo "cves_found=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # When fail_on_cves is true, block on ANY Snyk failure -- both real CVEs
+      # and scan errors. A release should not proceed if we cannot verify safety.
+      # The error message differentiates the two scenarios for the operator.
       - name: Evaluate CVE gate
         if: inputs.fail_on_cves && steps.snyk.outcome == 'failure'
         run: |
-          echo "::error::Snyk detected High or Critical CVEs. Review findings in the Security tab or re-run with the CVE bypass option."
+          if [ "${{ steps.check-sarif.outputs.sarif_exists }}" = "true" ]; then
+            echo "::error::Snyk detected High or Critical CVEs. Review findings in the Security tab or re-run with the CVE bypass option."
+          else
+            echo "::error::Snyk scan failed (possible authentication, network, or runtime error). No SARIF report was generated. Check the 'Run Snyk' step logs."
+          fi
           exit 1

--- a/.github/workflows/snyk-security-scan.yaml
+++ b/.github/workflows/snyk-security-scan.yaml
@@ -1,0 +1,93 @@
+name: Snyk Security Scan
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to checkout (empty uses caller default)
+        required: false
+        type: string
+        default: ''
+      fail_on_cves:
+        description: Fail the job when High or Critical CVEs are found
+        required: false
+        type: boolean
+        default: true
+      sarif_category:
+        description: Category label for the SARIF upload to the Security tab
+        required: false
+        type: string
+        default: snyk-security-scan
+    secrets:
+      SNYK_TOKEN:
+        required: true
+    outputs:
+      cves_found:
+        description: Whether Snyk detected High or Critical CVEs
+        value: ${{ jobs.snyk-scan.outputs.cves_found }}
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  snyk-scan:
+    name: Snyk vulnerability scan
+    runs-on: ubuntu-latest
+    outputs:
+      cves_found: ${{ steps.result.outputs.cves_found }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Generate requirements.txt
+        run: uv export --format requirements-txt > requirements.txt
+
+      - name: Run Snyk to check for vulnerabilities
+        id: snyk
+        uses: snyk/actions/python@master
+        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --sarif-file-output=snyk-results.sarif --severity-threshold=high
+
+      - name: Check Snyk SARIF
+        id: check-sarif
+        if: always()
+        run: |
+          if [ -f "snyk-results.sarif" ]; then
+            echo "sarif_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "sarif_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Snyk results to Security tab
+        if: always() && steps.check-sarif.outputs.sarif_exists == 'true'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: snyk-results.sarif
+          category: ${{ inputs.sarif_category }}
+
+      - name: Set CVE result output
+        id: result
+        if: always()
+        run: |
+          if [ "${{ steps.snyk.outcome }}" = "failure" ]; then
+            echo "cves_found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cves_found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Evaluate CVE gate
+        if: inputs.fail_on_cves && steps.snyk.outcome == 'failure'
+        run: |
+          echo "::error::Snyk detected High or Critical CVEs. Review findings in the Security tab or re-run with the CVE bypass option."
+          exit 1


### PR DESCRIPTION
**Summary**
Extract the inline Snyk vulnerability scan from rebase-upstream.yaml into a reusable workflow (snyk-security-scan.yaml) and call it from both the upstream sync and the ODH release pipelines. The reusable workflow regenerates requirements.txt before scanning to ensure Snyk always evaluates the current lock state, and both caller workflows now also commit that regenerated file so changes are never lost.

**Motivation**

- DRY: Snyk scan logic was hardcoded in rebase-upstream.yaml. Extracting it avoids duplication as we add it to additional workflows.
- Release gating: Every ODH release is now pre-screened for High/Critical CVEs before any branch, tag, or artifact is created.
- Escape hatch: A human can set acknowledge_cve_risk: true when the CVE is reviewed and determined not to affect the SDK, allowing the release to proceed.
- requirements.txt freshness: Both caller workflows now regenerate and commit requirements.txt from uv.lock, ensuring the checked-in file stays in sync with the lock file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in CVE risk acknowledgment for release workflows
  * Integrated a reusable automated security scan with configurable CVE gating

* **Infrastructure**
  * CI/CD workflow now gates releases on security scan results and coordinates scan runs
  * Automated regeneration and committed updates of dependency requirements during sync/release
  * Improved job outputs and orchestration to share scan status across workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->