### PR TITLE
fix: distributed checkpointing issues with PVC and S3

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -552,7 +552,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             except Exception as e:
                 _log(
                     f"Warning: Failed to write .incomplete marker for {checkpoint_name}: {e}. "
-                    "Check S3 write/delete permissions; resume safety may be affected."
+                    "Upload will continue, but if it fails, we won't detect it. "
+                    "Check S3 write permissions to prevent corrupted checkpoints."
                 )
 
             # Upload files in parallel
@@ -574,9 +575,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 self.remote_fs.rm_file(incomplete_marker_path)
             except Exception as e:
                 _log(
-                    f"Warning: Failed to remove remote file '{incomplete_marker_path}': {e}. "
-                    "Check S3 delete permissions; stale markers will cause resume to skip "
-                    "this checkpoint."
+                    f"Warning: Failed to remove .incomplete marker '{incomplete_marker_path}': {e}. "
+                    "This checkpoint won't be used for auto-resume. "
+                    f"To use it, manually delete: {incomplete_marker_path}"
                 )
 
             # Delete local staging checkpoint
@@ -911,8 +912,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             shutil.rmtree(checkpoint_path)
                         except Exception as e:
                             print(
-                                f"[Kubeflow] Warning: Failed to delete checkpoint: {e}. "
-                                "Check permissions and delete manually if needed."
+                                f"[Kubeflow] Warning: Failed to delete incomplete checkpoint "
+                                f"'{checkpoint_path}': {e}. Manually delete it to free disk space."
                             )
                     continue
 
@@ -1481,6 +1482,11 @@ def get_trainer_cr_from_transformers_trainer(
     checkpoint_code = _build_checkpoint_code(trainer)
     if checkpoint_code:
         func_code = f"{checkpoint_code}\n\n{func_code}"
+        # Add cleanup call after user code to upload final model artifacts
+        if trainer.output_dir and trainer.output_dir.startswith("s3://"):
+            func_code = (
+                f"{func_code}\n# Upload final model artifacts to S3\nfinal_model_cloud_upload()\n"
+            )
 
     # Build the command directly with the wrapped function code
     func_file = os.path.basename(inspect.getfile(trainer.func))

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -281,15 +281,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 current_step = self.trainer.state.global_step
                 _log(f"Starting JIT checkpoint at step {current_step}")
 
-                # Get rank for distributed training. Fall back to True for single-process
-                # runs or if accelerate is unavailable.
+                # Get local rank 0 for distributed training.
+                # Fall back to True for single-process runs.
                 try:
-                    from accelerate import PartialState
-
-                    is_main_process = PartialState().is_main_process
+                    is_local_rank0 = self.trainer.args.local_process_index == 0
                 except Exception:
-                    # accelerate not installed or PartialState unavailable - assume single process
-                    is_main_process = True
+                    is_local_rank0 = int(os.environ.get("LOCAL_RANK", "0")) == 0
 
                 output_dir = self.trainer._get_output_dir(trial=None)
                 checkpoint_path = os.path.join(
@@ -299,7 +296,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
                 # Create sentinel file to mark incomplete checkpoint (only rank 0)
                 sentinel_file = os.path.join(checkpoint_path, CHECKPOINT_INCOMPLETE_MARKER)
-                if is_main_process:
+                if is_local_rank0:
                     try:
                         with open(sentinel_file, "w") as f:
                             f.write(f"Checkpoint started at step {current_step}")
@@ -329,7 +326,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     self.trainer._save_checkpoint(self.trainer.model, trial=None)
 
                 # Remove sentinel on success (only rank 0)
-                if is_main_process and os.path.exists(sentinel_file):
+                if is_local_rank0 and os.path.exists(sentinel_file):
                     try:
                         os.remove(sentinel_file)
                     except Exception as e:
@@ -885,15 +882,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             if not output_dir or not os.path.exists(output_dir):
                 return None
 
-            # Determine if this is rank 0 (main process). Fall back to True for single-process
-            # runs or if accelerate is unavailable.
-            try:
-                from accelerate import PartialState
-
-                is_rank_0 = PartialState().is_main_process
-            except Exception:
-                # accelerate not installed or PartialState unavailable - assume single process
-                is_rank_0 = True
+            # Only global rank-0 deletes incomplete checkpoints
+            is_global_rank_0 = True  # Default for single node process
+            if dist.is_available() and dist.is_initialized():
+                is_global_rank_0 = dist.get_rank() == 0
 
             checkpoint_pattern = re.compile(r"^checkpoint-(\d+)$")
             checkpoints = []
@@ -906,9 +898,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 checkpoint_path = os.path.join(output_dir, name)
                 incomplete_marker = os.path.join(checkpoint_path, CHECKPOINT_INCOMPLETE_MARKER)
 
-                # Delete incomplete checkpoints (rank 0 only to avoid race condition)
+                # Delete incomplete checkpoints (global rank 0 only to avoid race condition)
                 if os.path.exists(incomplete_marker):
-                    if is_rank_0:
+                    if is_global_rank_0:
                         try:
                             _log(f"Deleting incomplete checkpoint: {checkpoint_path}")
                             shutil.rmtree(checkpoint_path)

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -576,8 +576,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 _log(
                     f"Warning: Failed to remove incomplete marker '{incomplete_marker_path}': "
                     f"{remove_error}. "
-                    "This checkpoint won't be used during training resume "
-                    f"To be able to use it, manually delete: {incomplete_marker_path}"
+                    "The checkpoint is complete but cannot be loaded during training resume "
+                    f"because the marker still exists. Manually delete: {incomplete_marker_path}"
                 )
 
             # Delete local staging checkpoint
@@ -811,8 +811,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         _log(
                             f"Warning: Failed to write incomplete marker for {checkpoint_name}: "
                             f"{marker_error}. "
-                            "Upload will continue, but if it fails, we won't detect it during "
-                            "resume. Check S3 write permissions to prevent corrupted checkpoints."
+                            "Upload will continue, but if it fails, partial uploads cannot be detected during "
+                            "resume. Check S3 write permissions to prevent corrupted checkpoints. "
                             "Consider deleting the checkpoint file manually."
                         )
                     task = (
@@ -926,7 +926,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             _log(
                                 "Warning: Failed to delete incomplete checkpoint "
                                 f"'{checkpoint_path}': {e}. "
-                                "Manually delete it to free disk space."
+                                "Manually delete it to free up storage."
                             )
                     continue
 

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -281,12 +281,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 current_step = self.trainer.state.global_step
                 _log(f"Starting JIT checkpoint at step {current_step}")
 
-                # Get local rank 0 for distributed training.
+                # Get global rank 0 for distributed training.
                 # Fall back to True for single-process runs.
-                try:
-                    is_local_rank0 = self.trainer.args.local_process_index == 0
-                except Exception:
-                    is_local_rank0 = int(os.environ.get("LOCAL_RANK", "0")) == 0
+                is_global_rank0 = True
+                if dist.is_available() and dist.is_initialized():
+                    is_global_rank0 = dist.get_rank() == 0
 
                 output_dir = self.trainer._get_output_dir(trial=None)
                 checkpoint_path = os.path.join(
@@ -294,9 +293,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 )
                 os.makedirs(checkpoint_path, exist_ok=True)
 
-                # Create sentinel file to mark incomplete checkpoint (only rank 0)
+                # Create sentinel file to mark incomplete checkpoint (only global rank 0)
                 sentinel_file = os.path.join(checkpoint_path, CHECKPOINT_INCOMPLETE_MARKER)
-                if is_local_rank0:
+                if is_global_rank0:
                     try:
                         with open(sentinel_file, "w") as f:
                             f.write(f"Checkpoint started at step {current_step}")
@@ -325,8 +324,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     # Fallback if no CUDA stream
                     self.trainer._save_checkpoint(self.trainer.model, trial=None)
 
-                # Remove sentinel on success (only rank 0)
-                if is_local_rank0 and os.path.exists(sentinel_file):
+                # Remove sentinel on success (only global rank 0)
+                if is_global_rank0 and os.path.exists(sentinel_file):
                     try:
                         os.remove(sentinel_file)
                     except Exception as e:
@@ -409,6 +408,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             except Exception as e:
                                 last_error = e
                                 if attempt < 3:
+                                    _log(
+                                        f"Cloud storage access verification failed (attempt {attempt}/3), retrying..."
+                                    )
                                     time.sleep(1)
 
                         if last_error:

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -212,7 +212,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
     import signal
     import threading
     import time
-    from typing import Optional
+    from typing import Callable, Optional
 
     import torch
     import torch.distributed as dist
@@ -483,6 +483,19 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             return ProgressCallback(operation, total_size)
 
+        def _retry_marker_op(self, op: Callable[[], None]) -> Optional[Exception]:
+            """Retry marker operation with backoff."""
+            last_error = None
+            for attempt in range(1, 4):
+                try:
+                    op()
+                    return None
+                except Exception as e:
+                    last_error = e
+                    if attempt < 3:
+                        time.sleep(1)
+            return last_error
+
         def _check_upload_error(self) -> None:
             """Raise any background upload error."""
             with self._upload_error_lock:
@@ -541,20 +554,6 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             staging_path, checkpoint_name, total_size, incomplete_marker_name = task
             incomplete_marker_path = f"{checkpoint_name}/{incomplete_marker_name}"
 
-            # Create .incomplete sentinel so resume can skip in-flight uploads.
-            _log(f"Creating .incomplete marker in S3: {checkpoint_name}")
-            try:
-                self.remote_fs.pipe(
-                    incomplete_marker_path,
-                    f"Upload started for {checkpoint_name}".encode(),
-                )
-            except Exception as e:
-                _log(
-                    f"Warning: Failed to write .incomplete marker for {checkpoint_name}: {e}. "
-                    "Upload will continue, but if it fails, we won't detect it. "
-                    "Check S3 write permissions to prevent corrupted checkpoints."
-                )
-
             # Upload files in parallel
             _log(f"Starting parallel upload to S3: {checkpoint_name}")
 
@@ -569,14 +568,16 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             _log(f"Upload complete: {checkpoint_name}")
 
-            # Delete .incomplete sentinel for this uploader
-            try:
-                self.remote_fs.rm_file(incomplete_marker_path)
-            except Exception as e:
+            # Delete incomplete sentinel for this uploader
+            remove_error = self._retry_marker_op(
+                lambda: self.remote_fs.rm_file(incomplete_marker_path)
+            )
+            if remove_error:
                 _log(
-                    f"Warning: Failed to remove .incomplete marker '{incomplete_marker_path}': {e}. "
-                    "This checkpoint won't be used for auto-resume. "
-                    f"To use it, manually delete: {incomplete_marker_path}"
+                    f"Warning: Failed to remove incomplete marker '{incomplete_marker_path}': "
+                    f"{remove_error}. "
+                    "This checkpoint won't be used during training resume "
+                    f"To be able to use it, manually delete: {incomplete_marker_path}"
                 )
 
             # Delete local staging checkpoint
@@ -797,6 +798,23 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-"
                         f"rank-{args.local_process_index}"
                     )
+                    # Create marker at enqueue time so resume won't treat queued uploads
+                    # as complete if the node specific upload worker hasn't started yet.
+                    marker_path = f"{checkpoint_name}/{marker_name}"
+                    marker_error = self._retry_marker_op(
+                        lambda: self.remote_fs.pipe(
+                            marker_path,
+                            f"Upload queued for {checkpoint_name}".encode(),
+                        )
+                    )
+                    if marker_error:
+                        _log(
+                            f"Warning: Failed to write incomplete marker for {checkpoint_name}: "
+                            f"{marker_error}. "
+                            "Upload will continue, but if it fails, we won't detect it during "
+                            "resume. Check S3 write permissions to prevent corrupted checkpoints."
+                            "Consider deleting the checkpoint file manually."
+                        )
                     task = (
                         staging_checkpoint_path,
                         checkpoint_name,
@@ -1475,11 +1493,6 @@ def get_trainer_cr_from_transformers_trainer(
     checkpoint_code = _build_checkpoint_code(trainer)
     if checkpoint_code:
         func_code = f"{checkpoint_code}\n\n{func_code}"
-        # Add cleanup call after user code to upload final model artifacts
-        if trainer.output_dir and trainer.output_dir.startswith("s3://"):
-            func_code = (
-                f"{func_code}\n# Upload final model artifacts to S3\nfinal_model_cloud_upload()\n"
-            )
 
     # Build the command directly with the wrapped function code
     func_file = os.path.basename(inspect.getfile(trainer.func))

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -307,7 +307,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         _log(
                             f"Warning: Failed to write sentinel file: {e}. "
                             "Check local disk space and write permissions in output_dir; "
-                            "this checkpoint may be treated as complete during resume."
+                            "this checkpoint will be treated as complete during resume."
+                            "Please manually verify if the checkpoint is indeed complete"
+                            f"{checkpoint_path}"
                         )
 
                 # Checkpoint using dedicated CUDA stream
@@ -908,12 +910,13 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 if os.path.exists(incomplete_marker):
                     if is_rank_0:
                         try:
-                            print(f"[Kubeflow] Deleting incomplete checkpoint: {checkpoint_path}")
+                            _log(f"Deleting incomplete checkpoint: {checkpoint_path}")
                             shutil.rmtree(checkpoint_path)
                         except Exception as e:
-                            print(
-                                f"[Kubeflow] Warning: Failed to delete incomplete checkpoint "
-                                f"'{checkpoint_path}': {e}. Manually delete it to free disk space."
+                            _log(
+                                "Warning: Failed to delete incomplete checkpoint "
+                                f"'{checkpoint_path}': {e}. "
+                                "Manually delete it to free disk space."
                             )
                     continue
 
@@ -922,7 +925,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             if checkpoints:
                 checkpoints.sort(reverse=True)
                 latest = checkpoints[0][1]
-                print(f"[Kubeflow] Found latest checkpoint: {latest}")
+                _log(f"Found latest checkpoint: {latest}")
                 return latest
 
             return None
@@ -954,16 +957,16 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 # Apply output_dir if provided by user
                 if "output_dir" in checkpoint_config:
                     training_args.output_dir = checkpoint_config["output_dir"]
-                    print(
-                        f"[Kubeflow] Applied output_dir: {checkpoint_config['output_dir']}",
-                        flush=True,
+                    _log(
+                        f"Applied output_dir: {checkpoint_config['output_dir']}",
+                        args=training_args,
                     )
 
                 if "save_strategy" in checkpoint_config:
                     training_args.save_strategy = checkpoint_config["save_strategy"]
-                    print(
-                        f"[Kubeflow] Applied save_strategy: {checkpoint_config['save_strategy']}",
-                        flush=True,
+                    _log(
+                        f"Applied save_strategy: {checkpoint_config['save_strategy']}",
+                        args=training_args,
                     )
 
                 if (
@@ -971,17 +974,16 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     and checkpoint_config["save_steps"] is not None
                 ):
                     training_args.save_steps = checkpoint_config["save_steps"]
-                    print(
-                        f"[Kubeflow] Applied save_steps: {checkpoint_config['save_steps']}",
-                        flush=True,
+                    _log(
+                        f"Applied save_steps: {checkpoint_config['save_steps']}",
+                        args=training_args,
                     )
 
                 if "save_total_limit" in checkpoint_config:
                     training_args.save_total_limit = checkpoint_config["save_total_limit"]
-                    print(
-                        f"[Kubeflow] Applied save_total_limit: "
-                        f"{checkpoint_config['save_total_limit']}",
-                        flush=True,
+                    _log(
+                        f"Applied save_total_limit: {checkpoint_config['save_total_limit']}",
+                        args=training_args,
                     )
 
                 if checkpoint_config.get("cloud_remote_storage_uri") and getattr(
@@ -1000,7 +1002,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     callbacks = list(callbacks)
                 if not any(isinstance(cb, JITCheckpointCallback) for cb in callbacks):
                     callbacks.append(_jit_checkpoint_callback)
-                    print("[Kubeflow] Auto-injected JIT checkpoint callback", flush=True)
+                    _log("Auto-injected JIT checkpoint callback", args=training_args)
                 kwargs["callbacks"] = callbacks
 
             # Call original __init__
@@ -1017,10 +1019,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 if dist.is_available() and dist.is_initialized():
                     rank = dist.get_rank()
                     world_size = dist.get_world_size()
-                    print(
-                        f"[Kubeflow] Rank {rank}/{world_size} - "
+                    _log(
+                        f"Rank {rank}/{world_size} - "
                         "Waiting for all ranks before training starts...",
-                        flush=True,
+                        args=training_args,
                     )
                     try:
                         dist.barrier()
@@ -1033,10 +1035,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             "distributed training is properly configured. Retrying the "
                             "training job often resolves transient issues."
                         ) from e
-                    print(
-                        f"[Kubeflow] Rank {rank}/{world_size} - "
-                        "All ranks synchronized, proceeding...",
-                        flush=True,
+                    _log(
+                        f"Rank {rank}/{world_size} - All ranks synchronized, proceeding...",
+                        args=training_args,
                     )
 
                 # Only auto-resume if user didn't explicitly set it
@@ -1044,7 +1045,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     latest_checkpoint = _find_latest_checkpoint(training_args.output_dir)
                     if latest_checkpoint:
                         resume_from_checkpoint = latest_checkpoint
-                        print(f"[Kubeflow] Auto-resuming from: {latest_checkpoint}")
+                        _log(f"Auto-resuming from: {latest_checkpoint}", args=training_args)
                 return _original_train(
                     resume_from_checkpoint=resume_from_checkpoint, **train_kwargs
                 )
@@ -1053,7 +1054,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
         # Apply monkey-patch
         _TransformersTrainer.__init__ = _patched_trainer_init
-        print("[Kubeflow] Trainer auto-instrumentation enabled", flush=True)
+        _log("Trainer auto-instrumentation enabled")
 
     enable_jit = checkpoint_config.get("enable_jit", False)
     return (

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -398,9 +398,21 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     # Verify storage access by writing/reading test file (if enabled)
                     if checkpoint_config.get("verify_cloud_storage_access", True):
                         test_file = ".kubeflow-access-test"
-                        self.remote_fs.pipe(test_file, b"test")
-                        self.remote_fs.cat(test_file)
-                        self.remote_fs.rm_file(test_file)
+                        last_error = None
+                        for attempt in range(1, 4):  # 3 attempts with backoff
+                            try:
+                                self.remote_fs.pipe(test_file, b"test")
+                                self.remote_fs.cat(test_file)
+                                self.remote_fs.rm_file(test_file)
+                                last_error = None
+                                break  # Success
+                            except Exception as e:
+                                last_error = e
+                                if attempt < 3:
+                                    time.sleep(1)
+
+                        if last_error:
+                            raise last_error  # Re-raise to outer except
 
                     _log(f"Cloud storage configured: {cloud_remote_storage_uri} ({protocol})")
                 except Exception as e:

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -2987,5 +2987,35 @@ def test_output_dir_normalization(test_case):
     print("test execution complete")
 
 
+def test_s3_access_retry_code_generation():
+    """Test that S3 access verification includes 3-retry logic in generated code."""
+    print("Executing test: S3 retry logic in generated code")
+
+    # Generate checkpoint injection code with S3 config
+    code = get_jit_checkpoint_injection_code(
+        output_dir="/mnt/checkpoints",
+        cloud_remote_storage_uri="s3://test-bucket/path",
+        enable_jit_checkpoint=True,
+        verify_cloud_storage_access=True,
+    )
+
+    # Verify retry logic is present in generated code
+    assert "for attempt in range(1, 4):" in code, "3-attempt retry loop not found"
+    assert "last_error = None" in code, "Error tracking not found"
+    assert "last_error = e" in code, "Error capture not found"
+    assert "if attempt < 3:" in code, "Retry condition not found"
+    assert "time.sleep(1)" in code, "Backoff sleep not found"
+    assert "if last_error:" in code, "Error re-raise check not found"
+    assert "raise last_error" in code, "Error propagation not found"
+
+    # Verify code structure contains the access verification section
+    assert "verify_cloud_storage_access" in code
+    assert 'self.remote_fs.pipe(test_file, b"test")' in code
+    assert "self.remote_fs.cat(test_file)" in code
+    assert "self.remote_fs.rm_file(test_file)" in code
+
+    print("test execution complete")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -2584,9 +2584,10 @@ print("TEST_COMPLETE=True")
 
     assert result.returncode == 0, f"Execution failed with return code {result.returncode}"
     assert "TEST_COMPLETE=True" in output
-    assert f"PIPE=checkpoint-3/{CHECKPOINT_INCOMPLETE_MARKER}" in output
+    expected_marker = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-0-rank-0"
+    assert f"PIPE=checkpoint-3/{expected_marker}" in output
     assert "PUT_FILE=checkpoint-3/model.bin" in output
-    assert f"RM_FILE=checkpoint-3/{CHECKPOINT_INCOMPLETE_MARKER}" in output
+    assert f"RM_FILE=checkpoint-3/{expected_marker}" in output
     assert "STAGING_CHECKPOINT_EXISTS=False" in output
     assert "CHECKPOINT_EXISTS=False" in output
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the robustness of async checkpointing to S3 and resume safety in distributed runs. It adds retries for incomplete‑marker operations, writes markers at enqueue time to avoid “false complete” checkpoints, and standardizes Kubeflow logging in checkpoint instrumentation. Detail breakdown:

 - Write .incomplete markers at enqueue time (on_save) to prevent checkpoints being treated as complete when uploads are queued but not started.
  - Retry marker create/delete with small backoff to reduce transient S3 failures.
  - Per‑node/per‑rank markers to prevent race conditions across nodes.
  - Standardize checkpointing logs via _log() for consistent logging to identify rank specific logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry/backoff (3 attempts with backoff) for checkpoint marker and cloud storage access; marker creation/removal now gated to local-rank0.

* **Bug Fixes**
  * Improved checkpoint discovery, cleanup and marker ownership for distributed/multi‑rank training.
  * Replaced ad‑hoc prints with centralized logging including rank/step context and clearer failure guidance.

* **Tests**
  * Updated tests to expect rank‑suffixed checkpoint markers and added tests validating S3 access retry/backoff logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->