### PR TITLE
fix: Algorithm-aware entrypoint selection for TrainingHub trainer

### DIFF
--- a/kubeflow/trainer/algorithms.py
+++ b/kubeflow/trainer/algorithms.py
@@ -12,6 +12,8 @@ Adding a New Algorithm:
             name="my_algorithm",
             metrics_file_patterns=("my_metrics_*.jsonl",),
             validate=_no_op_validate,
+            # Runs inside torchrun
+            entrypoint=constants.TORCH_COMMAND,
         ),
 
     Example without metrics files (no progress tracking):
@@ -19,12 +21,16 @@ Adding a New Algorithm:
             name="my_algorithm",
             metrics_file_patterns=(),  # Empty tuple for no metrics
             validate=_no_op_validate,
+            # Internally launches torchrun as a subprocess
+            entrypoint=constants.DEFAULT_COMMAND,
         ),
 """
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
+
+from kubeflow.trainer.constants import constants
 
 
 @dataclass(frozen=True)
@@ -40,16 +46,16 @@ class AlgorithmSpec:
             Used for metrics reading and cleanup operations.
         validate: Validation function that takes a training config and raises
             ValueError if the config is invalid for this algorithm.
-        manages_own_distributed: Whether the algorithm internally launches torchrun
-            (or equivalent) as a subprocess. When True, the Training Hub entrypoint
-            uses `python` to avoid nested torchrun. When False, the entrypoint uses
-            `torchrun` so the algorithm runs inside a torchrun process.
+        entrypoint: The command tuple used to launch training. Algorithms that
+            internally launch torchrun as a subprocess (e.g. SFT, OSFT) use
+            DEFAULT_COMMAND (python). Algorithms that expect to run inside a
+            torchrun process (e.g. LoRA) use TORCH_COMMAND (torchrun).
     """
 
     name: str
     metrics_file_patterns: Iterable[str]
     validate: Callable[[Any], None]
-    manages_own_distributed: bool = False
+    entrypoint: tuple[str, ...]
 
     def __post_init__(self):
         """Validate the AlgorithmSpec at creation time.
@@ -124,19 +130,22 @@ ALGORITHMS: dict[str, AlgorithmSpec] = {
         name="sft",
         metrics_file_patterns=("training_params_and_metrics_global*.jsonl",),
         validate=_no_op_validate,
-        manages_own_distributed=True,
+        # SFT internally launches torchrun as a subprocess
+        entrypoint=constants.DEFAULT_COMMAND,
     ),
     "osft": AlgorithmSpec(
         name="osft",
         metrics_file_patterns=("training_metrics_*.jsonl",),
         validate=_no_op_validate,
-        manages_own_distributed=True,
+        # OSFT internally launches torchrun as a subprocess
+        entrypoint=constants.DEFAULT_COMMAND,
     ),
     "lora_sft": AlgorithmSpec(
         name="lora_sft",
         metrics_file_patterns=(),  # LoRA uses HF Trainer logging, not JSONL metrics files
         validate=_no_op_validate,
-        manages_own_distributed=False,
+        # LoRA expects to run inside a torchrun process
+        entrypoint=constants.TORCH_COMMAND,
     ),
 }
 
@@ -227,7 +236,6 @@ def get_algorithm_pod_metadata(name: str) -> dict:
             "name": name,
             "metrics_file_pattern": None,
             "metrics_file_rank0": None,
-            "manages_own_distributed": spec.manages_own_distributed,
         }
 
     # Use first pattern for algorithms with metrics
@@ -240,5 +248,4 @@ def get_algorithm_pod_metadata(name: str) -> dict:
         "name": name,
         "metrics_file_pattern": pattern,
         "metrics_file_rank0": rank0_file,
-        "manages_own_distributed": spec.manages_own_distributed,
     }

--- a/kubeflow/trainer/algorithms.py
+++ b/kubeflow/trainer/algorithms.py
@@ -40,11 +40,16 @@ class AlgorithmSpec:
             Used for metrics reading and cleanup operations.
         validate: Validation function that takes a training config and raises
             ValueError if the config is invalid for this algorithm.
+        manages_own_distributed: Whether the algorithm internally launches torchrun
+            (or equivalent) as a subprocess. When True, the Training Hub entrypoint
+            uses `python` to avoid nested torchrun. When False, the entrypoint uses
+            `torchrun` so the algorithm runs inside a torchrun process.
     """
 
     name: str
     metrics_file_patterns: Iterable[str]
     validate: Callable[[Any], None]
+    manages_own_distributed: bool = False
 
     def __post_init__(self):
         """Validate the AlgorithmSpec at creation time.
@@ -119,16 +124,19 @@ ALGORITHMS: dict[str, AlgorithmSpec] = {
         name="sft",
         metrics_file_patterns=("training_params_and_metrics_global*.jsonl",),
         validate=_no_op_validate,
+        manages_own_distributed=True,
     ),
     "osft": AlgorithmSpec(
         name="osft",
         metrics_file_patterns=("training_metrics_*.jsonl",),
         validate=_no_op_validate,
+        manages_own_distributed=True,
     ),
     "lora_sft": AlgorithmSpec(
         name="lora_sft",
         metrics_file_patterns=(),  # LoRA uses HF Trainer logging, not JSONL metrics files
         validate=_no_op_validate,
+        manages_own_distributed=False,
     ),
 }
 
@@ -219,6 +227,7 @@ def get_algorithm_pod_metadata(name: str) -> dict:
             "name": name,
             "metrics_file_pattern": None,
             "metrics_file_rank0": None,
+            "manages_own_distributed": spec.manages_own_distributed,
         }
 
     # Use first pattern for algorithms with metrics
@@ -231,4 +240,5 @@ def get_algorithm_pod_metadata(name: str) -> dict:
         "name": name,
         "metrics_file_pattern": pattern,
         "metrics_file_rank0": rank0_file,
+        "manages_own_distributed": spec.manages_own_distributed,
     }

--- a/kubeflow/trainer/algorithms_test.py
+++ b/kubeflow/trainer/algorithms_test.py
@@ -406,7 +406,12 @@ def test_pod_metadata_has_all_required_keys():
     """Test that pod metadata contains all required keys for all algorithms."""
     print("Executing test: pod_metadata_has_all_required_keys")
 
-    required_keys = {"name", "metrics_file_pattern", "metrics_file_rank0"}
+    required_keys = {
+        "name",
+        "metrics_file_pattern",
+        "metrics_file_rank0",
+        "manages_own_distributed",
+    }
 
     for algorithm_name in ALGORITHMS:
         print("  Checking algorithm:", algorithm_name)

--- a/kubeflow/trainer/algorithms_test.py
+++ b/kubeflow/trainer/algorithms_test.py
@@ -24,6 +24,7 @@ from kubeflow.trainer.algorithms import (
     get_algorithm_pod_metadata,
     get_algorithm_spec,
 )
+from kubeflow.trainer.constants import constants
 from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
 
 
@@ -35,6 +36,7 @@ def test_algorithm_spec_is_frozen():
         name="test",
         metrics_file_patterns=("pattern_*.jsonl",),
         validate=lambda x: None,
+        entrypoint=("python",),
     )
 
     # Attempt to modify frozen dataclass should raise FrozenInstanceError or AttributeError
@@ -53,6 +55,7 @@ def test_algorithm_spec_validation_empty_name():
             name="",
             metrics_file_patterns=("pattern_*.jsonl",),
             validate=lambda x: None,
+            entrypoint=("python",),
         )
 
     print("test execution complete")
@@ -67,6 +70,7 @@ def test_algorithm_spec_validation_uppercase_name():
             name="SFT",
             metrics_file_patterns=("pattern_*.jsonl",),
             validate=lambda x: None,
+            entrypoint=("python",),
         )
 
     print("test execution complete")
@@ -81,6 +85,7 @@ def test_algorithm_spec_allows_empty_patterns():
         name="test",
         metrics_file_patterns=(),
         validate=lambda x: None,
+        entrypoint=("python",),
     )
 
     assert spec.name == "test"
@@ -98,6 +103,7 @@ def test_algorithm_spec_validation_non_callable_validate():
             name="test",
             metrics_file_patterns=("pattern_*.jsonl",),
             validate="not a function",  # type: ignore[arg-type]
+            entrypoint=("python",),
         )
 
     print("test execution complete")
@@ -386,6 +392,7 @@ def test_get_algorithm_pod_metadata_no_metrics():
             name="test_no_metrics",
             metrics_file_patterns=(),
             validate=_no_op_validate,
+            entrypoint=constants.TORCH_COMMAND,
         )
 
         metadata = get_algorithm_pod_metadata("test_no_metrics")
@@ -410,7 +417,6 @@ def test_pod_metadata_has_all_required_keys():
         "name",
         "metrics_file_pattern",
         "metrics_file_rank0",
-        "manages_own_distributed",
     }
 
     for algorithm_name in ALGORITHMS:
@@ -474,12 +480,12 @@ def test_pod_metadata_self_contained():
         # Verify metadata is a plain dict (serializable to pod code)
         assert isinstance(metadata, dict)
 
-        # Verify all values are basic Python types (str, int, bool, None, etc.)
+        # Verify all values are basic Python types (str, int, bool, tuple, None, etc.)
         # Pod code should not need to import anything to use this metadata
         for key, value in metadata.items():
             assert isinstance(key, str), f"Metadata key should be string, got {type(key)}"
             # None is allowed for algorithms without metrics
-            assert isinstance(value, (str, int, bool, type(None))), (
+            assert isinstance(value, (str, int, bool, tuple, type(None))), (
                 f"Metadata value for key '{key}' should be basic type, got {type(value).__name__}"
             )
 
@@ -720,6 +726,7 @@ def test_algorithm_without_metrics_integration():
             name="test_no_metrics",
             metrics_file_patterns=(),
             validate=_no_op_validate,
+            entrypoint=constants.TORCH_COMMAND,
         )
 
         # Test get_algorithm_spec

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -248,7 +248,7 @@ def get_custom_trainer(
             "\n\nread -r -d '' SCRIPT << EOM\n\nfunc=lambda: "
             'print("Hello World"),\n\n<lambda>(**'
             "{'learning_rate': 0.001, 'batch_size': 32})\n\nEOM\nprintf \"%s\" "
-            '"$SCRIPT" > "backend_test.py"\ntorchrun "backend_test.py"',
+            '"$SCRIPT" > "backend_test.py"\ntorchrun --nnodes=${PET_NNODES:-1} --nproc-per-node=${PET_NPROC_PER_NODE:-1} --node-rank=${PET_NODE_RANK:-0} --rdzv-backend=c10d --rdzv-endpoint=${PET_MASTER_ADDR:-localhost}:${PET_MASTER_PORT:-29500} --rdzv-id=1 "backend_test.py"',
         ],
         numNodes=2,
         env=env,

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -248,7 +248,7 @@ def get_custom_trainer(
             "\n\nread -r -d '' SCRIPT << EOM\n\nfunc=lambda: "
             'print("Hello World"),\n\n<lambda>(**'
             "{'learning_rate': 0.001, 'batch_size': 32})\n\nEOM\nprintf \"%s\" "
-            '"$SCRIPT" > "backend_test.py"\ntorchrun --nnodes=${PET_NNODES:-1} --nproc-per-node=${PET_NPROC_PER_NODE:-1} --node-rank=${PET_NODE_RANK:-0} "backend_test.py"',
+            '"$SCRIPT" > "backend_test.py"\ntorchrun "backend_test.py"',
         ],
         numNodes=2,
         env=env,

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -248,7 +248,7 @@ def get_custom_trainer(
             "\n\nread -r -d '' SCRIPT << EOM\n\nfunc=lambda: "
             'print("Hello World"),\n\n<lambda>(**'
             "{'learning_rate': 0.001, 'batch_size': 32})\n\nEOM\nprintf \"%s\" "
-            '"$SCRIPT" > "backend_test.py"\ntorchrun --nnodes=${PET_NNODES:-1} --nproc-per-node=${PET_NPROC_PER_NODE:-1} --node-rank=${PET_NODE_RANK:-0} --rdzv-backend=c10d --rdzv-endpoint=${PET_MASTER_ADDR:-localhost}:${PET_MASTER_PORT:-29500} --rdzv-id=1 "backend_test.py"',
+            '"$SCRIPT" > "backend_test.py"\ntorchrun --nnodes=${PET_NNODES:-1} --nproc-per-node=${PET_NPROC_PER_NODE:-1} --node-rank=${PET_NODE_RANK:-0} "backend_test.py"',
         ],
         numNodes=2,
         env=env,

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -155,9 +155,8 @@ MPI_COMMAND = (
 DEFAULT_TRAINING_RUNTIME = os.getenv("DEFAULT_TRAINING_RUNTIME", "torch-distributed")
 
 # The default container command for the Torch CustomTrainer.
-# Rendezvous args are required for multi-node distributed training.
-# TODO: Remove explicit rendezvous args once upstream Kubeflow Trainer torch plugin
-# sets PET_RDZV_* env vars (currently only sets PET_NNODES, PET_MASTER_ADDR, etc.).
+# torchrun automatically uses c10d rendezvous with PET_MASTER_ADDR/PET_MASTER_PORT
+# when nnodes > 1. Explicit --rdzv-* flags are not needed.
 TORCH_COMMAND = (
     "bash",
     "-c",
@@ -166,10 +165,7 @@ TORCH_COMMAND = (
         "torchrun"
         " --nnodes=${{PET_NNODES:-1}}"
         " --nproc-per-node=${{PET_NPROC_PER_NODE:-1}}"
-        " --node-rank=${{PET_NODE_RANK:-0}}"
-        " --rdzv-backend=c10d"
-        " --rdzv-endpoint=${{PET_MASTER_ADDR:-localhost}}:${{PET_MASTER_PORT:-29500}}"
-        " --rdzv-id=1",
+        " --node-rank=${{PET_NODE_RANK:-0}}",
     ),
 )
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -154,11 +154,23 @@ MPI_COMMAND = (
 # The default name for the ClusterTrainingRuntime.
 DEFAULT_TRAINING_RUNTIME = os.getenv("DEFAULT_TRAINING_RUNTIME", "torch-distributed")
 
-# The default container command for the Torch CustomTrainer
+# The default container command for the Torch CustomTrainer.
+# Rendezvous args are required for multi-node distributed training.
+# TODO: Remove explicit rendezvous args once upstream Kubeflow Trainer torch plugin
+# sets PET_RDZV_* env vars (currently only sets PET_NNODES, PET_MASTER_ADDR, etc.).
 TORCH_COMMAND = (
     "bash",
     "-c",
-    EXEC_FUNC_SCRIPT.replace("__ENTRYPOINT__", "torchrun"),
+    EXEC_FUNC_SCRIPT.replace(
+        "__ENTRYPOINT__",
+        "torchrun"
+        " --nnodes=${{PET_NNODES:-1}}"
+        " --nproc-per-node=${{PET_NPROC_PER_NODE:-1}}"
+        " --node-rank=${{PET_NODE_RANK:-0}}"
+        " --rdzv-backend=c10d"
+        " --rdzv-endpoint=${{PET_MASTER_ADDR:-localhost}}:${{PET_MASTER_PORT:-29500}}"
+        " --rdzv-id=1",
+    ),
 )
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).
 TORCH_ENV_NUM_PROC_PER_NODE = "PET_NPROC_PER_NODE"

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -155,18 +155,10 @@ MPI_COMMAND = (
 DEFAULT_TRAINING_RUNTIME = os.getenv("DEFAULT_TRAINING_RUNTIME", "torch-distributed")
 
 # The default container command for the Torch CustomTrainer.
-# torchrun automatically uses c10d rendezvous with PET_MASTER_ADDR/PET_MASTER_PORT
-# when nnodes > 1. Explicit --rdzv-* flags are not needed.
 TORCH_COMMAND = (
     "bash",
     "-c",
-    EXEC_FUNC_SCRIPT.replace(
-        "__ENTRYPOINT__",
-        "torchrun"
-        " --nnodes=${{PET_NNODES:-1}}"
-        " --nproc-per-node=${{PET_NPROC_PER_NODE:-1}}"
-        " --node-rank=${{PET_NODE_RANK:-0}}",
-    ),
+    EXEC_FUNC_SCRIPT.replace("__ENTRYPOINT__", "torchrun"),
 )
 # The Torch env name for the number of procs per node (e.g. number of GPUs per Pod).
 TORCH_ENV_NUM_PROC_PER_NODE = "PET_NPROC_PER_NODE"

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -526,7 +526,8 @@ def _create_training_hub_progression_instrumentation(
                                 files_removed += 1
                                 filename = os.path.basename(file_path)
                                 print(
-                                    f"[Kubeflow] Removed stale metrics file: {filename}", flush=True
+                                    f"[Kubeflow] Removed stale metrics file: {filename}",
+                                    flush=True,
                                 )
                             except OSError as e:
                                 filename = os.path.basename(file_path)
@@ -764,12 +765,38 @@ def _render_user_func_code(func: Callable, func_args: Optional[dict]) -> tuple[s
     return func_code, func_file
 
 
-def _compose_exec_script(func_code: str, func_file: str) -> str:
-    """Compose the final exec script body using the common template."""
-    return constants.EXEC_FUNC_SCRIPT.replace("__ENTRYPOINT__", "python").format(
-        func_code=func_code,
-        func_file=func_file,
-    )
+def _get_command_from_runtime(
+    runtime: types.Runtime,
+    func_code: str,
+    func_file: str,
+    install_snippet: str,
+) -> list[str]:
+    """Build command using runtime's command template (matches CustomTrainer pattern).
+
+    Args:
+        runtime: Runtime configuration with command template
+        func_code: The training function code to execute
+        func_file: The filename to write the code to
+        install_snippet: Package installation script to prepend
+
+    Returns:
+        Command list ready for trainer_crd.command/args
+
+    Note:
+        This matches CustomTrainer's approach of using runtime.trainer.command directly,
+        ensuring consistent behavior across all trainer types.
+    """
+    command = []
+    for c in runtime.trainer.command:
+        if "{func_file}" in c:
+            # Format the runtime's command template with our code
+            exec_script = c.format(func_code=func_code, func_file=func_file)
+            if install_snippet:
+                exec_script = install_snippet + exec_script
+            command.append(exec_script)
+        else:
+            command.append(c)
+    return command
 
 
 def get_training_hub_instrumentation_wrapper(
@@ -857,6 +884,24 @@ def get_trainer_cr_from_training_hub_trainer(
         Distributed training settings (num_nodes, resources) should be configured
         via TrainJob spec.mlPolicy, not in the trainer configuration.
     """
+    # Determine the correct entrypoint command based on algorithm behavior.
+    # Algorithms that manage their own distributed training (SFT, OSFT) internally
+    # launch torchrun as a subprocess, so we use `python` to avoid nested torchrun.
+    # Algorithms that don't (LoRA) expect to run inside a torchrun process.
+    algorithm_manages_distributed = False
+    if trainer.algorithm:
+        from kubeflow.trainer.algorithms import get_algorithm_pod_metadata as _get_meta
+
+        _meta = _get_meta(trainer.algorithm.value)
+        algorithm_manages_distributed = _meta.get("manages_own_distributed", False)
+
+    if algorithm_manages_distributed:
+        # SFT/OSFT: use plain python to avoid nested torchrun
+        runtime.trainer.set_command(constants.DEFAULT_COMMAND)
+    else:
+        # LoRA or no algorithm: use torchrun
+        runtime.trainer.set_command(constants.TORCH_COMMAND)
+
     trainer_crd = models.TrainerV1alpha1Trainer()
 
     # Derive topology (nnodes, nproc_per_node) from func_args, if provided.
@@ -884,8 +929,9 @@ def get_trainer_cr_from_training_hub_trainer(
 
     install_snippet = _build_install_snippet(trainer.packages_to_install, trainer.pip_index_urls)
 
-    # Primary case: no user function; generate wrapper that imports and calls algorithm(**func_args)
+    # Generate the training function code based on mode
     if trainer.func is None:
+        # Primary case: no user function; generate wrapper that calls algorithm(**func_args)
         if not trainer.algorithm:
             raise ValueError("TrainingHubTrainer requires 'algorithm' when 'func' is not provided")
 
@@ -894,55 +940,40 @@ def get_trainer_cr_from_training_hub_trainer(
         algorithm_name = trainer.algorithm.value
 
         # Resolve algorithm metadata from centralized registry
-        # This validates the algorithm is supported and retrieves its metadata
         algorithm_metadata = get_algorithm_pod_metadata(algorithm_name)
 
-        raw_code = _render_algorithm_wrapper(algorithm_metadata, trainer.func_args)
+        func_code = _render_algorithm_wrapper(algorithm_metadata, trainer.func_args)
+        func_file = "training_script.py"
+    else:
+        # Secondary case: user provided function; embed their function and call with kwargs
+        func_code, func_file = _render_user_func_code(trainer.func, trainer.func_args)
+        algorithm_name = trainer.algorithm.value if trainer.algorithm else None
 
-        # Inject progress tracking code if enabled
-        if trainer.enable_progression_tracking:
-            # Use the same default as the wrapper if ckpt_output_dir is not provided.
-            ckpt_dir = "/tmp/checkpoints"
-            if trainer.func_args and "ckpt_output_dir" in trainer.func_args:
-                ckpt_dir = trainer.func_args["ckpt_output_dir"]
+    # Add progress tracking instrumentation if enabled (common for both modes)
+    if trainer.enable_progression_tracking:
+        # Determine checkpoint directory (algorithm mode vs user function mode)
+        ckpt_dir = "/tmp/checkpoints" if trainer.func is None else "/tmp/training_metrics"
 
+        # Override with user-provided value if available
+        if trainer.func_args and "ckpt_output_dir" in trainer.func_args:
+            ckpt_dir = trainer.func_args["ckpt_output_dir"]
+
+        # Only add instrumentation if algorithm is specified
+        if algorithm_name:
             progress_code = get_training_hub_instrumentation_wrapper(
                 algorithm=algorithm_name,
                 ckpt_output_dir=ckpt_dir,
                 metrics_port=trainer.metrics_port,
             )
-            raw_code = progress_code + "\n" + raw_code
-
-        exec_script = _compose_exec_script(raw_code, "training_script.py")
-        full_script = install_snippet + exec_script
-
-        trainer_crd.command = ["bash", "-c"]
-        trainer_crd.args = [full_script]
-    else:
-        # Secondary case: user provided function; embed their function and call with kwargs
-        func_code, func_file = _render_user_func_code(trainer.func, trainer.func_args)
-
-        # Inject progress tracking code if enabled (for custom functions)
-        # Try to extract ckpt_output_dir from the function code or use default
-        if trainer.enable_progression_tracking and trainer.algorithm:
-            # For custom functions, use a default metrics directory
-            # User should ensure their function writes to this directory
-            ckpt_dir = "/tmp/training_metrics"
-            if trainer.func_args and "ckpt_output_dir" in trainer.func_args:
-                ckpt_dir = trainer.func_args["ckpt_output_dir"]
-
-            progress_code = get_training_hub_instrumentation_wrapper(
-                algorithm=trainer.algorithm.value,
-                ckpt_output_dir=ckpt_dir,
-                metrics_port=trainer.metrics_port,
-            )
             func_code = progress_code + "\n" + func_code
 
-        exec_script = _compose_exec_script(func_code, func_file)
-        full_script = install_snippet + exec_script
-
-        trainer_crd.command = ["bash", "-c"]
-        trainer_crd.args = [full_script]
+    # Build command using runtime's template (common for both modes)
+    trainer_crd.command = _get_command_from_runtime(
+        runtime=runtime,
+        func_code=func_code,
+        func_file=func_file,
+        install_snippet=install_snippet,
+    )
 
     # Add environment variables to the Trainer if provided by user
     trainer_crd.env = (

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -884,23 +884,15 @@ def get_trainer_cr_from_training_hub_trainer(
         Distributed training settings (num_nodes, resources) should be configured
         via TrainJob spec.mlPolicy, not in the trainer configuration.
     """
-    # Determine the correct entrypoint command based on algorithm behavior.
-    # Algorithms that manage their own distributed training (SFT, OSFT) internally
-    # launch torchrun as a subprocess, so we use `python` to avoid nested torchrun.
-    # Algorithms that don't (LoRA) expect to run inside a torchrun process.
-    algorithm_manages_distributed = False
+    # Determine the correct entrypoint command based on algorithm.
+    # Each algorithm specifies its own entrypoint in the registry.
+    entrypoint = constants.TORCH_COMMAND
     if trainer.algorithm:
-        from kubeflow.trainer.algorithms import get_algorithm_pod_metadata as _get_meta
+        from kubeflow.trainer.algorithms import get_algorithm_spec
 
-        _meta = _get_meta(trainer.algorithm.value)
-        algorithm_manages_distributed = _meta.get("manages_own_distributed", False)
+        entrypoint = get_algorithm_spec(trainer.algorithm.value).entrypoint
 
-    if algorithm_manages_distributed:
-        # SFT/OSFT: use plain python to avoid nested torchrun
-        runtime.trainer.set_command(constants.DEFAULT_COMMAND)
-    else:
-        # LoRA or no algorithm: use torchrun
-        runtime.trainer.set_command(constants.TORCH_COMMAND)
+    runtime.trainer.set_command(entrypoint)
 
     trainer_crd = models.TrainerV1alpha1Trainer()
 

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -425,8 +425,8 @@ def test_progression_tracking_disabled_no_server():
 
     trainer_crd = get_trainer_cr_from_training_hub_trainer(runtime, trainer)
 
-    # Command is split into command and args, script is in args[0]
-    script = trainer_crd.args[0] if trainer_crd.args else ""
+    # Script is in command (matches CustomTrainer pattern after refactor)
+    script = " ".join(trainer_crd.command) if trainer_crd.command else ""
     # Should NOT contain progression tracking code
     assert "[Kubeflow] Initializing Training Hub progression tracking" not in script
     assert "TrainingHubMetricsHandler" not in script
@@ -457,8 +457,8 @@ def test_progression_tracking_enabled_has_server():
 
     trainer_crd = get_trainer_cr_from_training_hub_trainer(runtime, trainer)
 
-    # Command is split into command and args, script is in args[0]
-    script = trainer_crd.args[0] if trainer_crd.args else ""
+    # Script is in command (matches CustomTrainer pattern after refactor)
+    script = " ".join(trainer_crd.command) if trainer_crd.command else ""
     # Should contain progression tracking code
     assert "[Kubeflow]" in script  # Message is in the script
     assert "TrainingHubMetricsHandler" in script
@@ -856,6 +856,85 @@ def test_instrumentation_cleanup_continues_on_error():
 
     # Verify error handling is present
     assert "Warning: Metrics cleanup failed" in wrapper, "Should log cleanup failures"
+
+    print("test execution complete")
+
+
+def test_traininghub_runtime_without_command_uses_algorithm_default():
+    """Test that TrainingHub sets correct command based on algorithm when no command set."""
+    print("Executing test: Runtime without command uses algorithm-based default")
+
+    from kubeflow.trainer.rhai.traininghub import get_trainer_cr_from_training_hub_trainer
+    from kubeflow.trainer.types import types
+
+    # SFT (manages own distributed) should get python
+    runtime_sft = types.Runtime(
+        name="torch-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="pytorch/pytorch:latest",
+        ),
+    )
+
+    trainer_sft = TrainingHubTrainer(
+        algorithm=TrainingHubAlgorithms.SFT,
+        func_args={"data_path": "/data/train.jsonl", "ckpt_output_dir": "/tmp/checkpoints"},
+    )
+
+    trainer_crd_sft = get_trainer_cr_from_training_hub_trainer(runtime_sft, trainer_sft)
+    command_str_sft = " ".join(trainer_crd_sft.command)
+    assert "python" in command_str_sft, f"SFT should default to python: {command_str_sft}"
+
+    # LoRA (does NOT manage own distributed) should get torchrun
+    runtime_lora = types.Runtime(
+        name="torch-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="pytorch/pytorch:latest",
+        ),
+    )
+
+    trainer_lora = TrainingHubTrainer(
+        algorithm=TrainingHubAlgorithms.LORA_SFT,
+        func_args={"data_path": "/data/train.jsonl", "ckpt_output_dir": "/tmp/checkpoints"},
+    )
+
+    trainer_crd_lora = get_trainer_cr_from_training_hub_trainer(runtime_lora, trainer_lora)
+    command_str_lora = " ".join(trainer_crd_lora.command)
+    assert "torchrun" in command_str_lora, f"LoRA should default to torchrun: {command_str_lora}"
+
+    print("test execution complete")
+
+
+def test_osft_algorithm_uses_python_entrypoint():
+    """Test that OSFT algorithm uses python entrypoint (manages own distributed training)."""
+    print("Executing test: OSFT algorithm uses python entrypoint")
+
+    from kubeflow.trainer.rhai.traininghub import get_trainer_cr_from_training_hub_trainer
+    from kubeflow.trainer.types import types
+
+    runtime = types.Runtime(
+        name="torch-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="pytorch/pytorch:latest",
+        ),
+    )
+    runtime.trainer.set_command(constants.TORCH_COMMAND)
+
+    trainer = TrainingHubTrainer(
+        algorithm=TrainingHubAlgorithms.OSFT,
+        func_args={"data_path": "/data/train.jsonl", "ckpt_output_dir": "/tmp/checkpoints"},
+    )
+
+    trainer_crd = get_trainer_cr_from_training_hub_trainer(runtime, trainer)
+    command_str = " ".join(trainer_crd.command)
+
+    assert "python" in command_str, f"OSFT should use python: {command_str}"
+    assert "torchrun" not in command_str, f"OSFT should NOT use torchrun: {command_str}"
 
     print("test execution complete")
 


### PR DESCRIPTION
When testing LoRA with the Kubeflow SDK I noticed it was not running correctly as the entrypoint had been set to python. Existing TrainingHubTrainer algorithms (SFT and OSFT) use mini-trainer as a backend which internally launches torchrun, so python was the correct entrypoint for them. LoRA uses Unsloth as a backend and requires a torchrun entrypoint. Simply switching to torchrun for all algorithms would cause nested torchrun for SFT/OSFT, so the entrypoint is now selected based on the algorithm.

## Summary
This PR includes the following:

- **Algorithm-aware entrypoint selection**: Added `manages_own_distributed` field to `AlgorithmSpec` to control whether the training script is launched with `python` or `torchrun`. SFT and OSFT algorithms internally spawn their own `torchrun` subprocess, so they use `python` to avoid nested torchrun. LoRA (unsloth) expects to already be running inside a `torchrun` process, so it uses `torchrun`.
- **Adds torchrun rendezvous args to `TORCH_COMMAND`**: The upstream Kubeflow Trainer v2 torch plugin sets `PET_NNODES`, `PET_MASTER_ADDR`, etc., but does **not** set `PET_RDZV_*` env vars. Without explicit `--rdzv-backend=c10d` and `--rdzv-endpoint` args, torchrun defaults to standalone mode and multi-node training silently fails. Added these args as a workaround.
- **Exposed `manages_own_distributed` via `get_algorithm_pod_metadata()`** so the trainer builder can select the correct entrypoint based on the algorithm.
- **Updated and streamlined tests** for the new entrypoint logic.

## Testing
This has been tested manually on the team IBM cluster using the SDK from this branch.
The following tests can be run manyally:
- [ ] `pytest kubeflow/trainer/rhai/traininghub_test.py -v` — verifies SFT/OSFT use `python` and LoRA uses `torchrun`
- [ ] `pytest kubeflow/trainer/algorithms_test.py -v` — verifies `manages_own_distributed` is included in algorithm metadata
- [ ] `pytest kubeflow/trainer/backends/kubernetes/backend_test.py -v` — verifies updated `TORCH_COMMAND` with rendezvous args

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Algorithm specifications now include explicit entrypoint configuration, allowing algorithms to specify their default execution command.

* **Tests**
  * Added test coverage validating entrypoint behavior across different training algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->