### PR TITLE
feat: Automatic final model upload to S3 after training

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -360,7 +360,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             self.cloud_remote_storage_uri = cloud_remote_storage_uri
             self.remote_fs = None
             # Async upload state
-            self._upload_queue = None  # LifoQueue for background uploads
+            self.upload_queue = None  # LifoQueue for background uploads
             self._upload_thread = None  # Background worker thread
             self._shutdown_event = None  # Event to signal shutdown
             self._upload_error = None  # Store background thread errors
@@ -428,7 +428,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"This check can be disabled by setting verify_cloud_storage_access=False."
                     ) from e
 
-        def _wait_for_all_ranks(self, operation: str) -> None:
+        def wait_for_all_ranks(self, operation: str) -> None:
             """Barrier across ranks."""
             # Avoid barrier in single-process or when torch.distributed is not initialized.
             if not dist.is_available() or not dist.is_initialized():
@@ -447,7 +447,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     "Retrying the training job often resolves transient issues."
                 ) from e
 
-        def _calculate_local_dir_size(self, path: str) -> int:
+        def calculate_local_dir_size(self, path: str) -> int:
             """Calculate total size of local directory."""
             import contextlib
 
@@ -518,15 +518,15 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     self._upload_error = None  # Clear after reading
                     raise error
 
-        def _start_upload_worker(self) -> None:
+        def start_upload_worker(self) -> None:
             """Start background upload worker."""
             # Start worker if queue doesn't exist OR if the worker thread is not alive
             upload_thread = getattr(self, "_upload_thread", None)
             worker_alive = upload_thread is not None and upload_thread.is_alive()
-            if self._upload_queue is None or not worker_alive:
+            if self.upload_queue is None or not worker_alive:
                 # Use LIFO to prioritize the latest checkpoint
                 # when resuming after interruptions the latest state is picked.
-                self._upload_queue = LifoQueue()
+                self.upload_queue = LifoQueue()
                 self._shutdown_event = threading.Event()
                 self._upload_thread = threading.Thread(
                     target=self._upload_worker_loop,
@@ -541,7 +541,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             while True:
                 try:
                     # Use timeout to periodically check shutdown event
-                    task = self._upload_queue.get(timeout=1.0)
+                    task = self.upload_queue.get(timeout=1.0)
                 except Empty:
                     if self._shutdown_event.is_set():
                         break
@@ -564,7 +564,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         "Check S3 connectivity/permissions and retry."
                     )
                 finally:
-                    self._upload_queue.task_done()
+                    self.upload_queue.task_done()
 
         def _upload_checkpoint_to_cloud(self, task: tuple) -> None:
             """Upload checkpoint."""
@@ -683,9 +683,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             return failed_files
 
-        def _shutdown_upload_worker(self) -> None:
+        def shutdown_upload_worker(self) -> None:
             """Stop upload worker."""
-            if self._upload_queue is not None and self._upload_thread is not None:
+            if self.upload_queue is not None and self._upload_thread is not None:
                 _log("Waiting for background uploads to complete...")
                 self._shutdown_event.set()  # Signal shutdown
                 self._upload_thread.join(timeout=3600)  # Wait up to 1 hour
@@ -764,7 +764,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     )
 
             # Barrier to wait for local rank 0 checkpoint download to complete
-            self._wait_for_all_ranks("download")
+            self.wait_for_all_ranks("download")
 
         def on_save(self, args, state, control, **kwargs):
             """Stage checkpoint and queue async upload."""
@@ -773,7 +773,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 return
 
             # Barrier before staging checkpoint to ensure all ranks finished saving their files
-            self._wait_for_all_ranks("save")
+            self.wait_for_all_ranks("save")
 
             # Check for background upload errors and propagate to main thread
             self._check_upload_error()
@@ -805,10 +805,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     shutil.move(checkpoint_path, staging_checkpoint_path)
 
                     # Calculate directory size for progress tracking
-                    total_size = self._calculate_local_dir_size(staging_checkpoint_path)
+                    total_size = self.calculate_local_dir_size(staging_checkpoint_path)
 
                     # Start upload worker if not yet running
-                    self._start_upload_worker()
+                    self.start_upload_worker()
                     # Queue upload task (non-blocking, training continues immediately)
                     node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
                     marker_name = (
@@ -838,7 +838,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         total_size,
                         marker_name,
                     )
-                    self._upload_queue.put(task)
+                    self.upload_queue.put(task)
                     _log(
                         f"Queued checkpoint for async upload: {checkpoint_name}",
                         args=args,
@@ -886,7 +886,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             is_local_rank_0 = args.local_process_index == 0
             if is_local_rank_0:
                 # Shutdown background upload worker and wait for all uploads to complete
-                self._shutdown_upload_worker()
+                self.shutdown_upload_worker()
 
                 # Check for any errors that occurred during final uploads
                 self._check_upload_error()
@@ -913,60 +913,61 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
         )
 
         # Monkey-patch save_model() to upload final model to S3 immediately after save
-        _original_save_model = _TransformersTrainer.save_model
+        if hasattr(_TransformersTrainer, "save_model"):
+            _original_save_model = _TransformersTrainer.save_model
 
-        def _patched_save_model(
-            self,
-            output_dir: str | None = None,
-            _internal_call: bool = False,
-        ):
-            """Save model and upload to S3 if remote storage configured.
-
-            Only uploads when _internal_call=False (user-initiated saves like final model).
-            Periodic checkpoints (_internal_call=True) are already handled by JIT checkpoint infrastructure.
-            """
-            # Call original save_model (handles all distributed training logic)
-            result = _original_save_model(
+            def _patched_save_model(
                 self,
-                output_dir=output_dir,
-                _internal_call=_internal_call,
-            )
-
-            # Upload after save ONLY for user-initiated saves (final model, not periodic checkpoints)
-            if (
-                not _internal_call
-                and _jit_checkpoint_callback.remote_fs
-                and output_dir
-                and os.path.exists(output_dir)
+                output_dir: str | None = None,
+                _internal_call: bool = False,
             ):
-                # Barrier to ensure all ranks finished saving
-                _jit_checkpoint_callback._wait_for_all_ranks("final_save")
+                """Save model and upload to S3 if remote storage configured.
 
-                # Upload from local rank 0 only (works for all strategies - DDP/FSDP/DeepSpeed)
-                if self.args.local_process_index == 0:
-                    # Determine checkpoint name from output_dir
-                    checkpoint_name = os.path.basename(output_dir)
+                Only uploads when _internal_call=False (user-initiated saves like final model).
+                Periodic checkpoints (_internal_call=True) are already handled by JIT checkpoint infrastructure.
+                """
+                # Call original save_model (handles all distributed training logic)
+                result = _original_save_model(
+                    self,
+                    output_dir=output_dir,
+                    _internal_call=_internal_call,
+                )
 
-                    # Queue upload using existing infrastructure
-                    total_size = _jit_checkpoint_callback._calculate_local_dir_size(output_dir)
-                    _jit_checkpoint_callback._start_upload_worker()
+                # Upload after save ONLY for user-initiated saves (final model, not periodic checkpoints)
+                if (
+                    not _internal_call
+                    and _jit_checkpoint_callback.remote_fs
+                    and output_dir
+                    and os.path.exists(output_dir)
+                ):
+                    # Barrier to ensure all ranks finished saving
+                    _jit_checkpoint_callback.wait_for_all_ranks("final_save")
 
-                    node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
-                    marker_name = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-rank-{self.args.local_process_index}"
+                    # Upload from local rank 0 only (works for all strategies - DDP/FSDP/DeepSpeed)
+                    if self.args.local_process_index == 0:
+                        # Determine checkpoint name from output_dir
+                        checkpoint_name = os.path.basename(output_dir)
 
-                    task = (output_dir, checkpoint_name, total_size, marker_name)
-                    _jit_checkpoint_callback._upload_queue.put(task)
-                    _log(
-                        f"[Kubeflow] Queued final model for upload: {checkpoint_name}",
-                        args=self.args,
-                    )
+                        # Queue upload using existing infrastructure
+                        total_size = _jit_checkpoint_callback.calculate_local_dir_size(output_dir)
+                        _jit_checkpoint_callback.start_upload_worker()
 
-                    # Wait for final model upload to complete
-                    _jit_checkpoint_callback._shutdown_upload_worker()
+                        node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
+                        marker_name = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-rank-{self.args.local_process_index}"
 
-            return result
+                        task = (output_dir, checkpoint_name, total_size, marker_name)
+                        _jit_checkpoint_callback.upload_queue.put(task)
+                        _log(
+                            f"[Kubeflow] Queued final model for upload: {checkpoint_name}",
+                            args=self.args,
+                        )
 
-        _TransformersTrainer.save_model = _patched_save_model
+                        # Wait for final model upload to complete
+                        _jit_checkpoint_callback.shutdown_upload_worker()
+
+                return result
+
+            _TransformersTrainer.save_model = _patched_save_model
 
         def _find_latest_checkpoint(output_dir):
             """Find the latest checkpoint and deleting incomplete ones."""

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -520,7 +520,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
         def _start_upload_worker(self) -> None:
             """Start background upload worker."""
-            if self._upload_queue is None:
+            # Start worker if queue doesn't exist OR if the worker thread is not alive
+            upload_thread = getattr(self, "_upload_thread", None)
+            worker_alive = upload_thread is not None and upload_thread.is_alive()
+            if self._upload_queue is None or not worker_alive:
                 # Use LIFO to prioritize the latest checkpoint
                 # when resuming after interruptions the latest state is picked.
                 self._upload_queue = LifoQueue()
@@ -957,6 +960,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"[Kubeflow] Queued final model for upload: {checkpoint_name}",
                         args=self.args,
                     )
+
+                    # Wait for final model upload to complete
+                    _jit_checkpoint_callback._shutdown_upload_worker()
 
             return result
 

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -909,6 +909,59 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             checkpoint_config.get("cloud_remote_storage_uri")
         )
 
+        # Monkey-patch save_model() to upload final model to S3 immediately after save
+        _original_save_model = _TransformersTrainer.save_model
+
+        def _patched_save_model(
+            self,
+            output_dir: str | None = None,
+            _internal_call: bool = False,
+        ):
+            """Save model and upload to S3 if remote storage configured.
+
+            Only uploads when _internal_call=False (user-initiated saves like final model).
+            Periodic checkpoints (_internal_call=True) are already handled by JIT checkpoint infrastructure.
+            """
+            # Call original save_model (handles all distributed training logic)
+            result = _original_save_model(
+                self,
+                output_dir=output_dir,
+                _internal_call=_internal_call,
+            )
+
+            # Upload after save ONLY for user-initiated saves (final model, not periodic checkpoints)
+            if (
+                not _internal_call
+                and _jit_checkpoint_callback.remote_fs
+                and output_dir
+                and os.path.exists(output_dir)
+            ):
+                # Barrier to ensure all ranks finished saving
+                _jit_checkpoint_callback._wait_for_all_ranks("final_save")
+
+                # Upload from local rank 0 only (works for all strategies - DDP/FSDP/DeepSpeed)
+                if self.args.local_process_index == 0:
+                    # Determine checkpoint name from output_dir
+                    checkpoint_name = os.path.basename(output_dir)
+
+                    # Queue upload using existing infrastructure
+                    total_size = _jit_checkpoint_callback._calculate_local_dir_size(output_dir)
+                    _jit_checkpoint_callback._start_upload_worker()
+
+                    node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
+                    marker_name = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-rank-{self.args.local_process_index}"
+
+                    task = (output_dir, checkpoint_name, total_size, marker_name)
+                    _jit_checkpoint_callback._upload_queue.put(task)
+                    _log(
+                        f"[Kubeflow] Queued final model for upload: {checkpoint_name}",
+                        args=self.args,
+                    )
+
+            return result
+
+        _TransformersTrainer.save_model = _patched_save_model
+
         def _find_latest_checkpoint(output_dir):
             """Find the latest checkpoint and deleting incomplete ones."""
             if not output_dir or not os.path.exists(output_dir):

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -520,21 +520,21 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
         def start_upload_worker(self) -> None:
             """Start background upload worker."""
-            # Start worker if queue doesn't exist OR if the worker thread is not alive
-            upload_thread = getattr(self, "_upload_thread", None)
-            worker_alive = upload_thread is not None and upload_thread.is_alive()
-            if self.upload_queue is None or not worker_alive:
+            worker_alive = self._upload_thread is not None and self._upload_thread.is_alive()
+            if worker_alive:
+                return
+            if self.upload_queue is None:
                 # Use LIFO to prioritize the latest checkpoint
                 # when resuming after interruptions the latest state is picked.
                 self.upload_queue = LifoQueue()
-                self._shutdown_event = threading.Event()
-                self._upload_thread = threading.Thread(
-                    target=self._upload_worker_loop,
-                    daemon=False,
-                    name="KubeflowCheckpointUploader",
-                )
-                self._upload_thread.start()
-                _log("Background upload worker started")
+            self._shutdown_event = threading.Event()
+            self._upload_thread = threading.Thread(
+                target=self._upload_worker_loop,
+                daemon=False,
+                name="KubeflowCheckpointUploader",
+            )
+            self._upload_thread.start()
+            _log("Background upload worker started")
 
         def _upload_worker_loop(self) -> None:
             """Upload worker loop."""
@@ -904,70 +904,15 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             args=args,
                         )
 
+    # Create callback instance at outer scope so both apply_checkpointing()
+    # and upload_final_model_to_cloud() can reference it via closure.
+    _jit_checkpoint_callback = JITCheckpointCallback(
+        checkpoint_config.get("cloud_remote_storage_uri")
+    )
+
     def apply_checkpointing():
         """Setup monkey patch for Trainer to auto inject JIT checkpoint callback."""
         from transformers import Trainer as _TransformersTrainer
-
-        _jit_checkpoint_callback = JITCheckpointCallback(
-            checkpoint_config.get("cloud_remote_storage_uri")
-        )
-
-        # Monkey-patch save_model() to upload final model to S3 immediately after save
-        if hasattr(_TransformersTrainer, "save_model"):
-            _original_save_model = _TransformersTrainer.save_model
-
-            def _patched_save_model(
-                self,
-                output_dir: str | None = None,
-                _internal_call: bool = False,
-            ):
-                """Save model and upload to S3 if remote storage configured.
-
-                Only uploads when _internal_call=False (user-initiated saves like final model).
-                Periodic checkpoints (_internal_call=True) are already handled by JIT checkpoint infrastructure.
-                """
-                # Call original save_model (handles all distributed training logic)
-                result = _original_save_model(
-                    self,
-                    output_dir=output_dir,
-                    _internal_call=_internal_call,
-                )
-
-                # Upload after save ONLY for user-initiated saves (final model, not periodic checkpoints)
-                if (
-                    not _internal_call
-                    and _jit_checkpoint_callback.remote_fs
-                    and output_dir
-                    and os.path.exists(output_dir)
-                ):
-                    # Barrier to ensure all ranks finished saving
-                    _jit_checkpoint_callback.wait_for_all_ranks("final_save")
-
-                    # Upload from local rank 0 only (works for all strategies - DDP/FSDP/DeepSpeed)
-                    if self.args.local_process_index == 0:
-                        # Determine checkpoint name from output_dir
-                        checkpoint_name = os.path.basename(output_dir)
-
-                        # Queue upload using existing infrastructure
-                        total_size = _jit_checkpoint_callback.calculate_local_dir_size(output_dir)
-                        _jit_checkpoint_callback.start_upload_worker()
-
-                        node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
-                        marker_name = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-rank-{self.args.local_process_index}"
-
-                        task = (output_dir, checkpoint_name, total_size, marker_name)
-                        _jit_checkpoint_callback.upload_queue.put(task)
-                        _log(
-                            f"[Kubeflow] Queued final model for upload: {checkpoint_name}",
-                            args=self.args,
-                        )
-
-                        # Wait for final model upload to complete
-                        _jit_checkpoint_callback.shutdown_upload_worker()
-
-                return result
-
-            _TransformersTrainer.save_model = _patched_save_model
 
         def _find_latest_checkpoint(output_dir):
             """Find the latest checkpoint and deleting incomplete ones."""
@@ -1140,11 +1085,76 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
         _TransformersTrainer.__init__ = _patched_trainer_init
         _log("Trainer auto-instrumentation enabled")
 
+    def upload_final_model_to_cloud():
+        """Upload final model artifacts from output_dir to cloud storage."""
+
+        if not checkpoint_config.get("cloud_remote_storage_uri"):
+            return
+
+        # Ensure all ranks finish writing final artifacts before upload starts.
+        _jit_checkpoint_callback.wait_for_all_ranks("final_model_upload")
+
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        if local_rank != 0:
+            return
+
+        output_dir = checkpoint_config.get("output_dir")
+        if not output_dir or not os.path.exists(output_dir):
+            return
+
+        _log("Uploading final model artifacts to S3")
+
+        try:
+            uploaded_count = 0
+            for item in os.listdir(output_dir):
+                if item.startswith("checkpoint-") or item in (
+                    CHECKPOINT_STAGING_DIR,
+                    ".cache",
+                ):
+                    continue
+
+                local_path = os.path.join(output_dir, item)
+                if os.path.isfile(local_path):
+                    size = os.path.getsize(local_path)
+                    _jit_checkpoint_callback.remote_fs.put_file(
+                        local_path,
+                        item,
+                        callback=_jit_checkpoint_callback._cloud_storage_progress_callback(
+                            "Upload", size
+                        ),
+                    )
+                    uploaded_count += 1
+                elif os.path.isdir(local_path):
+                    size = _jit_checkpoint_callback.calculate_local_dir_size(local_path)
+                    _jit_checkpoint_callback.remote_fs.put(
+                        local_path,
+                        item,
+                        recursive=True,
+                        callback=_jit_checkpoint_callback._cloud_storage_progress_callback(
+                            "Upload", size
+                        ),
+                    )
+                    uploaded_count += 1
+
+            if uploaded_count == 0:
+                _log("No final model artifacts to upload")
+                return
+
+            _log("Final model upload complete")
+
+        except Exception as e:
+            _log(
+                f"Warning: Final model upload failed: {e}. "
+                "Training completed successfully but final model artifacts "
+                "may not be fully available in cloud storage."
+            )
+
     enable_jit = checkpoint_config.get("enable_jit", False)
     return (
         CheckpointManager if enable_jit else None,
         JITCheckpointCallback if enable_jit else None,
         apply_checkpointing,
+        upload_final_model_to_cloud,
     )
 
 
@@ -1563,10 +1573,12 @@ def get_trainer_cr_from_transformers_trainer(
         )
         func_code = wrapper_code.replace("{{user_func_import_and_call}}", func_code)
 
-    # Inject checkpoint code if enabled
-    checkpoint_code = _build_checkpoint_code(trainer)
-    if checkpoint_code:
-        func_code = f"{checkpoint_code}\n\n{func_code}"
+    # Inject checkpoint code if enabled (header before user code, footer after)
+    checkpoint_header, checkpoint_footer = _build_checkpoint_code(trainer)
+    if checkpoint_header:
+        func_code = f"{checkpoint_header}\n\n{func_code}"
+    if checkpoint_footer:
+        func_code = f"{func_code}\n\n{checkpoint_footer}"
 
     # Build the command directly with the wrapped function code
     func_file = os.path.basename(inspect.getfile(trainer.func))
@@ -1595,11 +1607,16 @@ def get_trainer_cr_from_transformers_trainer(
     return trainer_crd
 
 
-def _build_checkpoint_code(trainer: TransformersTrainer) -> str:
-    """Generate checkpoint injection code for the trainer."""
+def _build_checkpoint_code(trainer: TransformersTrainer) -> tuple[str, str]:
+    """Generate checkpoint injection code for the trainer.
+
+    Returns:
+        Tuple of (header_code, footer_code). Header runs before user code,
+        footer runs after. Both are empty strings when checkpointing is disabled.
+    """
     # Only inject if JIT or periodic checkpoint is enabled
     if not trainer.enable_jit_checkpoint and not trainer.periodic_checkpoint_config:
-        return ""
+        return "", ""
 
     # Create default periodic config if JIT is enabled but no config provided
     periodic_config = trainer.periodic_checkpoint_config
@@ -1643,8 +1660,13 @@ def get_jit_checkpoint_injection_code(
     enable_jit_checkpoint: bool = False,
     verify_cloud_storage_access: bool = True,
     verify_cloud_storage_ssl: bool = True,
-) -> str:
-    """Generate the complete JIT checkpoint code to inject into training scripts."""
+) -> tuple[str, str]:
+    """Generate the complete JIT checkpoint code to inject into training scripts.
+
+    Returns:
+        Tuple of (header_code, footer_code). Header initializes checkpoint instrumentation
+        and runs before user code. Footer uploads final model artifacts and runs after.
+    """
     from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER, CHECKPOINT_STAGING_DIR
 
     # Build checkpoint config dict
@@ -1684,8 +1706,8 @@ def get_jit_checkpoint_injection_code(
 
     config_dict_str = pprint.pformat(config_dict, indent=4, width=100, sort_dicts=False)
 
-    # Build the wrapper with function call
-    wrapper = f"""# =============================================================================
+    # Build the header (runs before user code)
+    header = f"""# =============================================================================
 # Kubeflow SDK - Checkpoint Instrumentation
 # Generated by kubeflow.trainer.rhai.transformers
 # =============================================================================
@@ -1701,9 +1723,17 @@ CHECKPOINT_STAGING_DIR = {repr(CHECKPOINT_STAGING_DIR)}
 
 # Initialize and apply instrumentation
 checkpoint_config = {config_dict_str}
-_, _, apply_checkpointing = _create_checkpoint_instrumentation(checkpoint_config)
+_, _, apply_checkpointing, upload_final_model_to_cloud = _create_checkpoint_instrumentation(checkpoint_config)
 apply_checkpointing()
 print("[Kubeflow] Checkpoint instrumentation enabled", flush=True)
 """
 
-    return wrapper
+    # Build the footer (runs after user code)
+    footer = """
+# =============================================================================
+# Kubeflow SDK - Post-Training Cleanup
+# =============================================================================
+upload_final_model_to_cloud()
+"""
+
+    return header, footer

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -2558,7 +2558,7 @@ with open(os.path.join(checkpoint_path, "model.bin"), "w", encoding="utf-8") as 
     f.write("data")
 
 callback.on_save(MockArgs(), MockState(), None)
-callback._shutdown_upload_worker()
+callback.shutdown_upload_worker()
 
 if True:
     staging_checkpoint = os.path.join(
@@ -3013,6 +3013,231 @@ def test_s3_access_retry_code_generation():
     assert 'self.remote_fs.pipe(test_file, b"test")' in code
     assert "self.remote_fs.cat(test_file)" in code
     assert "self.remote_fs.rm_file(test_file)" in code
+
+
+# ============================================================================
+# Final Model Upload Tests
+# ============================================================================
+
+
+def test_upload_worker_restarts_when_thread_dies():
+    """Test that start_upload_worker() restarts worker when thread is dead."""
+    print("Executing test: upload worker restarts when thread dies")
+
+    from queue import LifoQueue
+    import threading
+    from unittest.mock import Mock
+
+    # Create mock callback with dead thread
+    callback = Mock()
+    callback.upload_queue = LifoQueue()
+    callback._upload_thread = Mock(spec=threading.Thread)
+    callback._upload_thread.is_alive.return_value = False  # Thread is dead
+
+    # Mock the methods that would be called during worker creation
+    callback._upload_worker_loop = Mock()
+
+    # Execute the code from start_upload_worker
+    upload_thread = getattr(callback, "_upload_thread", None)
+    worker_alive = upload_thread is not None and upload_thread.is_alive()
+
+    # Worker should NOT be alive (thread exists but is dead)
+    assert worker_alive is False
+
+    print("test execution complete")
+
+
+def test_upload_worker_restarts_when_thread_none():
+    """Test that start_upload_worker() restarts worker when thread is None."""
+    print("Executing test: upload worker restarts when thread is None")
+
+    from unittest.mock import Mock
+
+    # Create mock callback with None thread
+    callback = Mock()
+    callback._upload_thread = None
+
+    # Execute the check logic
+    upload_thread = getattr(callback, "_upload_thread", None)
+    worker_alive = upload_thread is not None and upload_thread.is_alive()
+
+    # Worker should NOT be alive (thread is None)
+    assert worker_alive is False
+
+    print("test execution complete")
+
+
+def test_upload_worker_skips_restart_when_alive():
+    """Test that start_upload_worker() skips restart when worker is alive."""
+    print("Executing test: upload worker skips restart when alive")
+
+    import threading
+    from unittest.mock import Mock
+
+    # Create mock callback with alive thread
+    callback = Mock()
+    callback._upload_thread = Mock(spec=threading.Thread)
+    callback._upload_thread.is_alive.return_value = True  # Thread is alive
+
+    from queue import LifoQueue
+
+    callback.upload_queue = LifoQueue()
+
+    # Execute the check logic
+    upload_thread = getattr(callback, "_upload_thread", None)
+    worker_alive = upload_thread is not None and upload_thread.is_alive()
+
+    # Worker SHOULD be alive
+    assert worker_alive is True
+    # Queue exists, so worker restart should be skipped
+    should_restart = callback.upload_queue is None or not worker_alive
+    assert should_restart is False
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="save_model uploads only when _internal_call=False",
+            expected_status=SUCCESS,
+            config={"_internal_call": False, "should_upload": True},
+        ),
+        TestCase(
+            name="save_model skips upload when _internal_call=True",
+            expected_status=SUCCESS,
+            config={"_internal_call": True, "should_upload": False},
+        ),
+    ],
+)
+def test_save_model_internal_call_handling(test_case):
+    """Test that patched save_model() only uploads when _internal_call=False."""
+    print(f"Executing test: {test_case.name}")
+
+    from unittest.mock import Mock
+
+    # Mock trainer and callback
+    mock_trainer = Mock()
+    mock_trainer.args = Mock()
+    mock_trainer.args.local_process_index = 0
+
+    mock_callback = Mock()
+    mock_callback.remote_fs = Mock()  # Remote storage configured
+
+    # Simulate the upload condition check
+    _internal_call = test_case.config["_internal_call"]
+    output_dir = "/mnt/checkpoint/final-model"
+
+    # Check if upload should happen
+    should_upload = bool(not _internal_call and mock_callback.remote_fs and output_dir)
+
+    assert should_upload == test_case.config["should_upload"]
+
+    print("test execution complete")
+
+
+def test_save_model_waits_for_upload_completion():
+    """Test that patched save_model() calls shutdown_upload_worker() to wait."""
+    print("Executing test: save_model waits for upload completion")
+
+    from unittest.mock import Mock
+
+    # Mock callback
+    mock_callback = Mock()
+    mock_callback.remote_fs = Mock()
+    mock_callback.upload_queue = Mock()
+    mock_callback.start_upload_worker = Mock()
+    mock_callback.calculate_local_dir_size = Mock(return_value=1000)
+    mock_callback.shutdown_upload_worker = Mock()
+    mock_callback.wait_for_all_ranks = Mock()
+
+    # Simulate the patched save_model logic
+    output_dir = "/mnt/checkpoint/final-model"
+    _internal_call = False
+    local_process_index = 0
+
+    if not _internal_call and mock_callback.remote_fs and output_dir and local_process_index == 0:
+        mock_callback.wait_for_all_ranks("final_save")
+        mock_callback.start_upload_worker()
+        mock_callback.upload_queue.put(("task",))
+        mock_callback.shutdown_upload_worker()  # This is the key call
+
+    # Verify shutdown_upload_worker was called
+    mock_callback.shutdown_upload_worker.assert_called_once()
+
+    print("test execution complete")
+
+
+def test_save_model_only_local_rank_0_uploads():
+    """Test that only local_process_index == 0 triggers upload."""
+    print("Executing test: only local rank 0 uploads")
+
+    from unittest.mock import Mock
+
+    # Test local rank 0 (should upload)
+    mock_trainer_rank0 = Mock()
+    mock_trainer_rank0.args = Mock()
+    mock_trainer_rank0.args.local_process_index = 0
+
+    should_upload_rank0 = mock_trainer_rank0.args.local_process_index == 0
+    assert should_upload_rank0 is True
+
+    # Test local rank 1 (should NOT upload)
+    mock_trainer_rank1 = Mock()
+    mock_trainer_rank1.args = Mock()
+    mock_trainer_rank1.args.local_process_index = 1
+
+    should_upload_rank1 = mock_trainer_rank1.args.local_process_index == 0
+    assert should_upload_rank1 is False
+
+    print("test execution complete")
+
+
+def test_save_model_skips_upload_when_no_remote_storage():
+    """Test that save_model skips upload when remote storage not configured."""
+    print("Executing test: skip upload when no remote storage")
+
+    from unittest.mock import Mock
+
+    mock_callback = Mock()
+    mock_callback.remote_fs = None  # No remote storage
+
+    output_dir = "/mnt/checkpoint/final-model"
+    _internal_call = False
+
+    should_upload = bool(
+        not _internal_call
+        and mock_callback.remote_fs  # This is None
+        and output_dir
+    )
+
+    assert should_upload is False
+
+    print("test execution complete")
+
+
+def test_save_model_signature_matches_original():
+    """Test that patched save_model signature matches Trainer.save_model."""
+    print("Executing test: patched save_model signature matches original")
+
+    # The expected signature from transformers.Trainer.save_model
+    expected_params = ["self", "output_dir", "_internal_call"]
+
+    # Our patched function signature
+    def _patched_save_model(
+        self,
+        output_dir: str | None = None,
+        _internal_call: bool = False,
+    ):
+        pass
+
+    import inspect
+
+    sig = inspect.signature(_patched_save_model)
+    actual_params = list(sig.parameters.keys())
+
+    assert actual_params == expected_params
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -1340,7 +1340,9 @@ def _mock_get_jit_checkpoint_injection_code(
     # Add monkey-patch function
     parts.append("def setup_jit_checkpoint_monkey_patch():\n    pass")
 
-    return "\n\n".join(parts)
+    header = "\n\n".join(parts)
+    footer = "# post-training cleanup placeholder"
+    return header, footer
 
 
 # ============================================================================
@@ -1533,14 +1535,16 @@ def test_checkpoint_code_injection(test_case):
 
     try:
         trainer = test_case.config["trainer"]
-        code = _build_checkpoint_code(trainer)
+        header, footer = _build_checkpoint_code(trainer)
 
         assert test_case.expected_status == SUCCESS
 
         # Check expected output
         if test_case.expected_output == "":
-            assert code == ""
+            assert header == ""
+            assert footer == ""
         elif isinstance(test_case.expected_output, dict):
+            code = header + footer
             assert code != ""
 
             # Check contains
@@ -1573,7 +1577,7 @@ def test_checkpoint_injection_code_execution_jit_enabled(tmp_path):
     )
 
     # Generate the actual checkpoint injection code with JIT enabled
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, checkpoint_footer = get_jit_checkpoint_injection_code(
         output_dir="/mnt/test-checkpoints",
         periodic_checkpoint_config={
             "save_strategy": "epoch",
@@ -1582,6 +1586,7 @@ def test_checkpoint_injection_code_execution_jit_enabled(tmp_path):
         },
         enable_jit_checkpoint=True,
     )
+    checkpoint_code = checkpoint_header
 
     # Create stub torch module
     torch_stub = """
@@ -1761,7 +1766,7 @@ def test_checkpoint_injection_code_execution_jit_disabled(tmp_path):
     from kubeflow.trainer.rhai.transformers import get_jit_checkpoint_injection_code
 
     # Generate checkpoint injection code with JIT disabled (only periodic checkpointing)
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, checkpoint_footer = get_jit_checkpoint_injection_code(
         output_dir="/mnt/test-checkpoints",
         periodic_checkpoint_config={
             "save_strategy": "epoch",
@@ -1770,6 +1775,7 @@ def test_checkpoint_injection_code_execution_jit_disabled(tmp_path):
         },
         enable_jit_checkpoint=False,  # JIT disabled
     )
+    checkpoint_code = checkpoint_header
 
     # Verify that the config contains enable_jit=False
     assert "'enable_jit': False" in checkpoint_code
@@ -2071,26 +2077,26 @@ def test_auto_resume_code_generation():
 
     from kubeflow.trainer.rhai.transformers import get_jit_checkpoint_injection_code
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/tmp/checkpoints",
         periodic_checkpoint_config=None,
         enable_jit_checkpoint=True,
     )
 
     # Verify auto-resume logic is present in generated code
-    assert "_find_latest_checkpoint" in checkpoint_code, "Should include _find_latest_checkpoint"
-    assert "def _patched_train" in checkpoint_code, "Should include _patched_train"
-    assert "resume_from_checkpoint" in checkpoint_code, (
+    assert "_find_latest_checkpoint" in checkpoint_header, "Should include _find_latest_checkpoint"
+    assert "def _patched_train" in checkpoint_header, "Should include _patched_train"
+    assert "resume_from_checkpoint" in checkpoint_header, (
         "Should include resume_from_checkpoint logic"
     )
-    assert "if resume_from_checkpoint is None" in checkpoint_code, "Should check if user set it"
-    assert "Auto-resuming from:" in checkpoint_code, "Should log auto-resume action"
-    assert "self.train = _patched_train" in checkpoint_code, "Should patch train method"
+    assert "if resume_from_checkpoint is None" in checkpoint_header, "Should check if user set it"
+    assert "Auto-resuming from:" in checkpoint_header, "Should log auto-resume action"
+    assert "self.train = _patched_train" in checkpoint_header, "Should patch train method"
 
     # Verify imports needed for auto-resume
-    assert "import re" in checkpoint_code, "Should import re for regex"
-    assert "import shutil" in checkpoint_code, "Should import shutil for rmtree"
-    assert "import os" in checkpoint_code, "Should import os"
+    assert "import re" in checkpoint_header, "Should import re for regex"
+    assert "import shutil" in checkpoint_header, "Should import shutil for rmtree"
+    assert "import os" in checkpoint_header, "Should import os"
 
     print("test execution complete")
 
@@ -2119,18 +2125,18 @@ def test_auto_resume_user_override():
     try:
         from kubeflow.trainer.rhai.transformers import get_jit_checkpoint_injection_code
 
-        checkpoint_code = get_jit_checkpoint_injection_code(
+        checkpoint_header, _ = get_jit_checkpoint_injection_code(
             output_dir="/tmp/checkpoints",
             periodic_checkpoint_config=None,
             enable_jit_checkpoint=True,
         )
 
         # Verify the logic: only auto-resume if resume_from_checkpoint is None
-        assert "if resume_from_checkpoint is None" in checkpoint_code
+        assert "if resume_from_checkpoint is None" in checkpoint_header
 
         assert (
-            "resume_from_checkpoint is None and training_args" in checkpoint_code
-            or "if resume_from_checkpoint is None" in checkpoint_code
+            "resume_from_checkpoint is None and training_args" in checkpoint_header
+            or "if resume_from_checkpoint is None" in checkpoint_header
         )
 
         print("test execution complete")
@@ -2178,12 +2184,12 @@ def test_build_checkpoint_code_with_s3_storage_uri():
         enable_jit_checkpoint=True,
     )
 
-    code = _build_checkpoint_code(trainer)
+    header, footer = _build_checkpoint_code(trainer)
 
     # Verify cloud_remote_storage_uri is included in the generated code
-    assert code != ""
-    assert "cloud_remote_storage_uri" in code
-    assert "s3://my-bucket/checkpoints" in code
+    assert header != ""
+    assert "cloud_remote_storage_uri" in header
+    assert "s3://my-bucket/checkpoints" in header
 
     print("test execution complete")
 
@@ -2192,15 +2198,15 @@ def test_get_jit_checkpoint_injection_code_with_storage_uri():
     """Test get_jit_checkpoint_injection_code includes cloud_remote_storage_uri in config."""
     print("Executing test: get_jit_checkpoint_injection_code with cloud_remote_storage_uri")
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/kubeflow-checkpoints",
         cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
         enable_jit_checkpoint=True,
     )
 
     # Verify cloud_remote_storage_uri is in the generated config
-    assert "cloud_remote_storage_uri" in checkpoint_code
-    assert "s3://my-bucket/model-checkpoints" in checkpoint_code
+    assert "cloud_remote_storage_uri" in checkpoint_header
+    assert "s3://my-bucket/model-checkpoints" in checkpoint_header
 
     print("test execution complete")
 
@@ -2326,7 +2332,7 @@ def test_save_only_model_validation_error(tmp_path):
     """Test save_only_model=True raises a validation error."""
     print("Executing test: save_only_model validation error")
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/kubeflow-checkpoints",
         enable_jit_checkpoint=True,
     )
@@ -2334,7 +2340,7 @@ def test_save_only_model_validation_error(tmp_path):
     returncode, stdout, stderr = _run_checkpoint_validation_subprocess(
         tmp_path=tmp_path,
         test_name="test_save_only_model_validation_error",
-        checkpoint_code=checkpoint_code,
+        checkpoint_code=checkpoint_header,
         training_args_body="    save_only_model = True\n",
     )
 
@@ -2351,7 +2357,7 @@ def test_save_on_each_node_validation_error(tmp_path):
     """Test save_on_each_node=True raises a validation error with S3."""
     print("Executing test: save_on_each_node validation error")
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/kubeflow-checkpoints",
         cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
         enable_jit_checkpoint=True,
@@ -2360,7 +2366,7 @@ def test_save_on_each_node_validation_error(tmp_path):
     returncode, stdout, stderr = _run_checkpoint_validation_subprocess(
         tmp_path=tmp_path,
         test_name="test_save_on_each_node_validation_error",
-        checkpoint_code=checkpoint_code,
+        checkpoint_code=checkpoint_header,
         training_args_body="    save_on_each_node = True\n",
     )
 
@@ -2377,17 +2383,17 @@ def test_async_upload_worker_scaffolding():
     """Test async upload worker scaffolding is present in generated code."""
     print("Executing test: async upload worker scaffolding")
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/kubeflow-checkpoints",
         cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
         enable_jit_checkpoint=True,
     )
 
-    assert "LifoQueue" in checkpoint_code
-    assert "daemon=False" in checkpoint_code
-    assert "KubeflowCheckpointUploader" in checkpoint_code
-    assert "1 hour" in checkpoint_code
-    assert "self._upload_thread.join(timeout=" in checkpoint_code
+    assert "LifoQueue" in checkpoint_header
+    assert "daemon=False" in checkpoint_header
+    assert "KubeflowCheckpointUploader" in checkpoint_header
+    assert "1 hour" in checkpoint_header
+    assert "self._upload_thread.join(timeout=" in checkpoint_header
 
     print("test execution complete")
 
@@ -2396,15 +2402,15 @@ def test_async_parallel_upload_scaffolding():
     """Test parallel upload scaffolding is present in generated code."""
     print("Executing test: async parallel upload scaffolding")
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/kubeflow-checkpoints",
         cloud_remote_storage_uri="s3://my-bucket/model-checkpoints",
         enable_jit_checkpoint=True,
     )
 
-    assert "ThreadPoolExecutor" in checkpoint_code
-    assert "as_completed" in checkpoint_code
-    assert "_parallel_upload_files" in checkpoint_code
+    assert "ThreadPoolExecutor" in checkpoint_header
+    assert "as_completed" in checkpoint_header
+    assert "_parallel_upload_files" in checkpoint_header
 
     print("test execution complete")
 
@@ -2420,11 +2426,12 @@ def test_async_upload_execution(tmp_path):
 
     output_dir = tmp_path / "checkpoints"
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir=str(output_dir),
         cloud_remote_storage_uri="s3://test-bucket/model-checkpoints",
         enable_jit_checkpoint=True,
     )
+    checkpoint_code = checkpoint_header
 
     fsspec_stub = """
 class MockS3FileSystem:
@@ -2679,11 +2686,12 @@ def test_s3_download_execution(test_case, tmp_path):
     from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER
     from kubeflow.trainer.rhai.transformers import get_jit_checkpoint_injection_code
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/checkpoints",
         cloud_remote_storage_uri="s3://test-bucket/model-checkpoints",
         enable_jit_checkpoint=True,
     )
+    checkpoint_code = checkpoint_header
 
     # Create fsspec stub based on test config
     checkpoints = test_case.config["checkpoints"]
@@ -2992,12 +3000,13 @@ def test_s3_access_retry_code_generation():
     print("Executing test: S3 retry logic in generated code")
 
     # Generate checkpoint injection code with S3 config
-    code = get_jit_checkpoint_injection_code(
+    checkpoint_header, _ = get_jit_checkpoint_injection_code(
         output_dir="/mnt/checkpoints",
         cloud_remote_storage_uri="s3://test-bucket/path",
         enable_jit_checkpoint=True,
         verify_cloud_storage_access=True,
     )
+    code = checkpoint_header
 
     # Verify retry logic is present in generated code
     assert "for attempt in range(1, 4):" in code, "3-attempt retry loop not found"
@@ -3096,148 +3105,540 @@ def test_upload_worker_skips_restart_when_alive():
     print("test execution complete")
 
 
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="save_model uploads only when _internal_call=False",
-            expected_status=SUCCESS,
-            config={"_internal_call": False, "should_upload": True},
-        ),
-        TestCase(
-            name="save_model skips upload when _internal_call=True",
-            expected_status=SUCCESS,
-            config={"_internal_call": True, "should_upload": False},
-        ),
-    ],
-)
-def test_save_model_internal_call_handling(test_case):
-    """Test that patched save_model() only uploads when _internal_call=False."""
-    print(f"Executing test: {test_case.name}")
+def _run_final_model_upload_subprocess(
+    tmp_path: Path,
+    test_name: str,
+    output_dir: str,
+    local_rank: str = "0",
+    cloud_remote_storage_uri: str = "s3://test-bucket/model-output",
+    setup_files: str = "",
+    extra_fsspec_methods: str = "",
+) -> tuple[int, str, str]:
+    """Run upload_final_model_to_cloud in a subprocess and return output.
 
-    from unittest.mock import Mock
+    Args:
+        tmp_path: Pytest tmp_path fixture for temp files.
+        test_name: Unique name for the test file.
+        output_dir: Path to the output directory with model artifacts.
+        local_rank: LOCAL_RANK env var value (default "0").
+        cloud_remote_storage_uri: Cloud storage URI for config.
+        setup_files: Extra Python code to create files/dirs in output_dir before upload.
+        extra_fsspec_methods: Additional methods to add to MockS3FileSystem.
 
-    # Mock trainer and callback
-    mock_trainer = Mock()
-    mock_trainer.args = Mock()
-    mock_trainer.args.local_process_index = 0
+    Returns:
+        Tuple of (exit_code, stdout, stderr).
+    """
+    import subprocess
+    import sys
 
-    mock_callback = Mock()
-    mock_callback.remote_fs = Mock()  # Remote storage configured
-
-    # Simulate the upload condition check
-    _internal_call = test_case.config["_internal_call"]
-    output_dir = "/mnt/checkpoint/final-model"
-
-    # Check if upload should happen
-    should_upload = bool(not _internal_call and mock_callback.remote_fs and output_dir)
-
-    assert should_upload == test_case.config["should_upload"]
-
-    print("test execution complete")
-
-
-def test_save_model_waits_for_upload_completion():
-    """Test that patched save_model() calls shutdown_upload_worker() to wait."""
-    print("Executing test: save_model waits for upload completion")
-
-    from unittest.mock import Mock
-
-    # Mock callback
-    mock_callback = Mock()
-    mock_callback.remote_fs = Mock()
-    mock_callback.upload_queue = Mock()
-    mock_callback.start_upload_worker = Mock()
-    mock_callback.calculate_local_dir_size = Mock(return_value=1000)
-    mock_callback.shutdown_upload_worker = Mock()
-    mock_callback.wait_for_all_ranks = Mock()
-
-    # Simulate the patched save_model logic
-    output_dir = "/mnt/checkpoint/final-model"
-    _internal_call = False
-    local_process_index = 0
-
-    if not _internal_call and mock_callback.remote_fs and output_dir and local_process_index == 0:
-        mock_callback.wait_for_all_ranks("final_save")
-        mock_callback.start_upload_worker()
-        mock_callback.upload_queue.put(("task",))
-        mock_callback.shutdown_upload_worker()  # This is the key call
-
-    # Verify shutdown_upload_worker was called
-    mock_callback.shutdown_upload_worker.assert_called_once()
-
-    print("test execution complete")
-
-
-def test_save_model_only_local_rank_0_uploads():
-    """Test that only local_process_index == 0 triggers upload."""
-    print("Executing test: only local rank 0 uploads")
-
-    from unittest.mock import Mock
-
-    # Test local rank 0 (should upload)
-    mock_trainer_rank0 = Mock()
-    mock_trainer_rank0.args = Mock()
-    mock_trainer_rank0.args.local_process_index = 0
-
-    should_upload_rank0 = mock_trainer_rank0.args.local_process_index == 0
-    assert should_upload_rank0 is True
-
-    # Test local rank 1 (should NOT upload)
-    mock_trainer_rank1 = Mock()
-    mock_trainer_rank1.args = Mock()
-    mock_trainer_rank1.args.local_process_index = 1
-
-    should_upload_rank1 = mock_trainer_rank1.args.local_process_index == 0
-    assert should_upload_rank1 is False
-
-    print("test execution complete")
-
-
-def test_save_model_skips_upload_when_no_remote_storage():
-    """Test that save_model skips upload when remote storage not configured."""
-    print("Executing test: skip upload when no remote storage")
-
-    from unittest.mock import Mock
-
-    mock_callback = Mock()
-    mock_callback.remote_fs = None  # No remote storage
-
-    output_dir = "/mnt/checkpoint/final-model"
-    _internal_call = False
-
-    should_upload = bool(
-        not _internal_call
-        and mock_callback.remote_fs  # This is None
-        and output_dir
+    checkpoint_header, checkpoint_footer = get_jit_checkpoint_injection_code(
+        output_dir=output_dir,
+        cloud_remote_storage_uri=cloud_remote_storage_uri,
+        enable_jit_checkpoint=True,
+        verify_cloud_storage_access=False,
     )
 
-    assert should_upload is False
+    fsspec_stub = f"""
+class MockS3FileSystem:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def ls(self, path, detail=False):
+        return []
+
+    def exists(self, path):
+        return False
+
+    def pipe(self, path, data):
+        pass
+
+    def cat(self, path):
+        return b"test"
+
+    def put_file(self, local, remote, callback=None):
+        print(f"PUT_FILE={{remote}}")
+
+    def put(self, local, remote, recursive=False, callback=None):
+        print(f"PUT_DIR={{remote}}")
+
+    def rm_file(self, path):
+        pass
+
+    def get(self, src, dst, recursive=False, callback=None):
+        pass
+
+    def du(self, path, total=True, maxdepth=None):
+        return 0
+
+{extra_fsspec_methods}
+
+class Callback:
+    def __init__(self):
+        self.size = 0
+        self.value = 0
+
+    def set_size(self, size):
+        self.size = size
+
+    def relative_update(self, inc=1):
+        self.value += inc
+
+class callbacks:
+    Callback = Callback
+
+def filesystem(protocol, **kwargs):
+    return MockS3FileSystem()
+"""
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
+        pass
+
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+"""
+
+    transformers_stub = """
+class TrainerCallback:
+    pass
+
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class TrainerState:
+    def __init__(self):
+        self.global_step = 0
+        self.is_world_process_zero = True
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        self.state = TrainerState()
+        self.model = None
+        self._init_args = args
+        self._init_kwargs = kwargs
+
+    def train(self, resume_from_checkpoint=None):
+        return {{"train_called": True, "resume_from": resume_from_checkpoint}}
+"""
+
+    test_file = tmp_path / f"{test_name}.py"
+    test_code = f"""
+import os
+import sys
+import types
+
+os.environ["LOCAL_RANK"] = "{local_rank}"
+
+fsspec_module = types.ModuleType('fsspec')
+exec('''{fsspec_stub}''', fsspec_module.__dict__)
+sys.modules['fsspec'] = fsspec_module
+
+callbacks_module = types.ModuleType('fsspec.callbacks')
+callbacks_module.Callback = fsspec_module.Callback
+sys.modules['fsspec.callbacks'] = callbacks_module
+fsspec_module.callbacks = callbacks_module
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+# Execute checkpoint instrumentation (header)
+{checkpoint_header}
+
+# Create output_dir and test files
+os.makedirs(r"{output_dir}", exist_ok=True)
+{setup_files}
+
+# Execute post-training cleanup (footer)
+{checkpoint_footer}
+
+print("TEST_COMPLETE=True")
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=15
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def test_final_model_upload_files_and_dirs(tmp_path):
+    """Test that upload_final_model_to_cloud uploads files and directories."""
+    print("Executing test: final model upload files and directories")
+
+    output_dir = str(tmp_path / "model-output")
+
+    setup_files = f"""
+# Create model files in output_dir
+with open(os.path.join(r"{output_dir}", "config.json"), "w") as f:
+    f.write('{{"model_type": "bert"}}')
+with open(os.path.join(r"{output_dir}", "model.safetensors"), "w") as f:
+    f.write("model_weights_data")
+with open(os.path.join(r"{output_dir}", "tokenizer.json"), "w") as f:
+    f.write('{{"type": "BPE"}}')
+
+# Create a subdirectory (e.g., tokenizer subdir)
+os.makedirs(os.path.join(r"{output_dir}", "tokenizer"), exist_ok=True)
+with open(os.path.join(r"{output_dir}", "tokenizer", "vocab.txt"), "w") as f:
+    f.write("vocab_data")
+"""
+
+    returncode, stdout, stderr = _run_final_model_upload_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_final_model_upload_files_and_dirs",
+        output_dir=output_dir,
+        setup_files=setup_files,
+    )
+
+    print(f"stdout: {stdout}")
+    if returncode != 0:
+        print(f"stderr: {stderr}")
+
+    assert returncode == 0, f"Subprocess failed: {stderr}"
+    assert "TEST_COMPLETE=True" in stdout
+    assert "Uploading final model artifacts to S3" in stdout
+    assert "PUT_FILE=config.json" in stdout
+    assert "PUT_FILE=model.safetensors" in stdout
+    assert "PUT_FILE=tokenizer.json" in stdout
+    assert "PUT_DIR=tokenizer" in stdout
+    assert "Final model upload complete" in stdout
 
     print("test execution complete")
 
 
-def test_save_model_signature_matches_original():
-    """Test that patched save_model signature matches Trainer.save_model."""
-    print("Executing test: patched save_model signature matches original")
+def test_final_model_upload_skips_checkpoints_and_staging(tmp_path):
+    """Test that checkpoint dirs, staging dir, and .cache are excluded from upload."""
+    print("Executing test: final model upload skips checkpoints and staging")
 
-    # The expected signature from transformers.Trainer.save_model
-    expected_params = ["self", "output_dir", "_internal_call"]
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_STAGING_DIR
 
-    # Our patched function signature
-    def _patched_save_model(
-        self,
-        output_dir: str | None = None,
-        _internal_call: bool = False,
-    ):
+    output_dir = str(tmp_path / "model-output")
+
+    setup_files = f"""
+# Create a regular model file (should be uploaded)
+with open(os.path.join(r"{output_dir}", "training_args.bin"), "w") as f:
+    f.write("training_args_data")
+
+# Create checkpoint dirs (should be skipped)
+os.makedirs(os.path.join(r"{output_dir}", "checkpoint-100"), exist_ok=True)
+with open(os.path.join(r"{output_dir}", "checkpoint-100", "model.bin"), "w") as f:
+    f.write("checkpoint_data")
+
+os.makedirs(os.path.join(r"{output_dir}", "checkpoint-200"), exist_ok=True)
+
+# Create staging dir (should be skipped)
+os.makedirs(os.path.join(r"{output_dir}", "{CHECKPOINT_STAGING_DIR}"), exist_ok=True)
+
+# Create .cache dir (should be skipped)
+os.makedirs(os.path.join(r"{output_dir}", ".cache"), exist_ok=True)
+with open(os.path.join(r"{output_dir}", ".cache", "cached_file"), "w") as f:
+    f.write("cached_data")
+"""
+
+    returncode, stdout, stderr = _run_final_model_upload_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_final_model_upload_skips_checkpoints",
+        output_dir=output_dir,
+        setup_files=setup_files,
+    )
+
+    print(f"stdout: {stdout}")
+    if returncode != 0:
+        print(f"stderr: {stderr}")
+
+    assert returncode == 0, f"Subprocess failed: {stderr}"
+    assert "TEST_COMPLETE=True" in stdout
+    assert "PUT_FILE=training_args.bin" in stdout
+    # Verify checkpoint dirs, staging, and cache are NOT uploaded
+    assert (
+        "checkpoint-100"
+        not in stdout.replace("Initializing checkpoint instrumentation", "").split(
+            "Uploading final model artifacts"
+        )[1]
+    )
+    assert "checkpoint-200" not in stdout.split("Uploading final model artifacts")[1]
+    assert CHECKPOINT_STAGING_DIR not in stdout.split("Uploading final model artifacts")[1]
+    assert ".cache" not in stdout.split("Uploading final model artifacts")[1]
+    assert "Final model upload complete" in stdout
+
+    print("test execution complete")
+
+
+def test_final_model_upload_no_cloud_uri(tmp_path):
+    """Test that upload is skipped when cloud_remote_storage_uri is not configured."""
+    print("Executing test: final model upload no cloud URI")
+
+    output_dir = str(tmp_path / "model-output")
+
+    # When no cloud URI, use local-only checkpoint code
+    checkpoint_header, checkpoint_footer = get_jit_checkpoint_injection_code(
+        output_dir=output_dir,
+        cloud_remote_storage_uri=None,
+        enable_jit_checkpoint=True,
+    )
+
+    import subprocess
+    import sys
+
+    fsspec_stub = """
+class Callback:
+    def __init__(self):
+        self.size = 0
+        self.value = 0
+
+class callbacks:
+    Callback = Callback
+
+def filesystem(protocol, **kwargs):
+    raise RuntimeError("Should not be called")
+"""
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
         pass
 
-    import inspect
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+"""
 
-    sig = inspect.signature(_patched_save_model)
-    actual_params = list(sig.parameters.keys())
+    transformers_stub = """
+class TrainerCallback:
+    pass
 
-    assert actual_params == expected_params
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def train(self, resume_from_checkpoint=None):
+        return {"train_called": True}
+"""
+
+    test_file = tmp_path / "test_no_cloud_uri.py"
+    test_code = f"""
+import os
+import sys
+import types
+
+fsspec_module = types.ModuleType('fsspec')
+exec('''{fsspec_stub}''', fsspec_module.__dict__)
+sys.modules['fsspec'] = fsspec_module
+
+callbacks_module = types.ModuleType('fsspec.callbacks')
+callbacks_module.Callback = fsspec_module.Callback
+sys.modules['fsspec.callbacks'] = callbacks_module
+fsspec_module.callbacks = callbacks_module
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+os.makedirs(r"{output_dir}", exist_ok=True)
+with open(os.path.join(r"{output_dir}", "model.bin"), "w") as f:
+    f.write("model_data")
+
+{checkpoint_header}
+
+{checkpoint_footer}
+
+print("TEST_COMPLETE=True")
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=15
+    )
+
+    print(f"stdout: {result.stdout}")
+    if result.returncode != 0:
+        print(f"stderr: {result.stderr}")
+
+    assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
+    assert "TEST_COMPLETE=True" in result.stdout
+    # Should NOT attempt any upload
+    assert "Uploading final model artifacts" not in result.stdout
+    assert "PUT_FILE" not in result.stdout
+
+    print("test execution complete")
+
+
+def test_final_model_upload_non_rank_zero(tmp_path):
+    """Test that upload is skipped on non-rank-0 processes."""
+    print("Executing test: final model upload non-rank-zero")
+
+    output_dir = str(tmp_path / "model-output")
+
+    setup_files = f"""
+with open(os.path.join(r"{output_dir}", "model.bin"), "w") as f:
+    f.write("model_data")
+"""
+
+    returncode, stdout, stderr = _run_final_model_upload_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_final_model_upload_non_rank_zero",
+        output_dir=output_dir,
+        local_rank="1",
+        setup_files=setup_files,
+    )
+
+    print(f"stdout: {stdout}")
+    if returncode != 0:
+        print(f"stderr: {stderr}")
+
+    assert returncode == 0, f"Subprocess failed: {stderr}"
+    assert "TEST_COMPLETE=True" in stdout
+    # Should NOT attempt any upload on non-rank-0
+    assert "Uploading final model artifacts" not in stdout
+    assert "PUT_FILE" not in stdout
+
+    print("test execution complete")
+
+
+def test_final_model_upload_empty_output_dir(tmp_path):
+    """Test that upload logs 'no artifacts' when only excluded items are present."""
+    print("Executing test: final model upload empty output dir")
+
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_STAGING_DIR
+
+    output_dir = str(tmp_path / "model-output")
+
+    setup_files = f"""
+# Only create items that should be excluded
+os.makedirs(os.path.join(r"{output_dir}", "checkpoint-500"), exist_ok=True)
+os.makedirs(os.path.join(r"{output_dir}", ".cache"), exist_ok=True)
+os.makedirs(os.path.join(r"{output_dir}", "{CHECKPOINT_STAGING_DIR}"), exist_ok=True)
+"""
+
+    returncode, stdout, stderr = _run_final_model_upload_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_final_model_upload_empty_dir",
+        output_dir=output_dir,
+        setup_files=setup_files,
+    )
+
+    print(f"stdout: {stdout}")
+    if returncode != 0:
+        print(f"stderr: {stderr}")
+
+    assert returncode == 0, f"Subprocess failed: {stderr}"
+    assert "TEST_COMPLETE=True" in stdout
+    assert "No final model artifacts to upload" in stdout
+    assert "PUT_FILE" not in stdout
+    assert "PUT_DIR" not in stdout
+
+    print("test execution complete")
+
+
+def test_final_model_upload_failure_is_non_fatal(tmp_path):
+    """Test that upload failure does not crash the process."""
+    print("Executing test: final model upload failure is non-fatal")
+
+    output_dir = str(tmp_path / "model-output")
+
+    setup_files = f"""
+with open(os.path.join(r"{output_dir}", "model.bin"), "w") as f:
+    f.write("model_data")
+"""
+
+    extra_methods = """
+    def put_file(self, local, remote, callback=None):
+        raise ConnectionError("S3 connection lost")
+"""
+
+    returncode, stdout, stderr = _run_final_model_upload_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_final_model_upload_failure",
+        output_dir=output_dir,
+        setup_files=setup_files,
+        extra_fsspec_methods=extra_methods,
+    )
+
+    print(f"stdout: {stdout}")
+    if returncode != 0:
+        print(f"stderr: {stderr}")
+
+    assert returncode == 0, f"Subprocess failed: {stderr}"
+    assert "TEST_COMPLETE=True" in stdout
+    assert "Warning: Final model upload failed" in stdout
+    assert "S3 connection lost" in stdout
+    assert "Training completed successfully" in stdout
+
+    print("test execution complete")
+
+
+def test_final_model_upload_nonexistent_output_dir(tmp_path):
+    """Test that upload is skipped when output_dir does not exist."""
+    print("Executing test: final model upload nonexistent output dir")
+
+    output_dir = str(tmp_path / "nonexistent-dir")
+
+    # Don't create the output_dir, but don't set up files either
+    returncode, stdout, stderr = _run_final_model_upload_subprocess(
+        tmp_path=tmp_path,
+        test_name="test_final_model_upload_nonexistent",
+        output_dir=output_dir,
+        setup_files="# Don't create output_dir - it should not exist\nimport shutil\nshutil.rmtree"
+        f'(r"{output_dir}", ignore_errors=True)',
+    )
+
+    print(f"stdout: {stdout}")
+    if returncode != 0:
+        print(f"stderr: {stderr}")
+
+    assert returncode == 0, f"Subprocess failed: {stderr}"
+    assert "TEST_COMPLETE=True" in stdout
+    # Should silently return without uploading
+    assert "Uploading final model artifacts" not in stdout
 
     print("test execution complete")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatically uploads final model artifacts to S3 after the user's training code completes. This ensures the final trained model is persisted to remote storage alongside periodic checkpoints.                                     
                                                                                                                                                                                                                                        
  - Add upload_final_model_to_cloud() as a post-training cleanup function that runs after user code finishes (via generated footer code)
  - Upload all remaining files/directories in output_dir to S3, preserving the exact local filesystem structure
  - Skip already-uploaded checkpoint-* dirs, internal cloud-upload-staging dir, and .cache
  - Only local rank 0 uploads to avoid race conditions in distributed training

Node 0:
<img width="707" height="247" alt="image" src="https://github.com/user-attachments/assets/cfe16e6a-151b-49df-9c5c-2b9f24a5ccb2" />

Node 1:
<img width="713" height="295" alt="image" src="https://github.com/user-attachments/assets/38d0358a-19d9-4687-a8bb-5a281579e43e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Final models are now uploaded to cloud storage automatically after training/save; uploads run as pre/post instrumentation and are gated to the primary process.

* **Public API**
  * Background upload lifecycle is now exposed and more robust, improving reliability of uploads, restarts and shutdown behavior.
  * Instrumentation now uses distinct header/footer hooks (two-part injection) and small API surface adjustments to control uploads.

* **Tests**
  * Expanded coverage for final-model upload, restart/resume logic, worker lifecycle, storage interactions and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->