### PR TITLE
fix: resolve distributed JIT checkpoint intermittent resume failure

### DIFF
--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -296,8 +296,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             self.checkpoint_thread.join(timeout=300)
             if self.checkpoint_thread.is_alive():
                 _log(
-                    "Warning: Checkpoint thread still running after 5 mins timeout. "
-                    "Process will terminate, checkpoint may be incomplete."
+                    "Warning: Checkpoint did not complete within 300s timeout. "
+                    "Kubernetes will send SIGKILL and checkpoint will be incomplete. "
+                    "Increase 'terminationGracePeriodSeconds' in your TrainJob manifest "
+                    "or check for slow disk/S3 issues."
                 )
             else:
                 _log("Checkpoint thread completed")

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -234,7 +234,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             _log_prefix = f"[Kubeflow-node{node}-rank{rank}]"
         print(f"{_log_prefix} {message}", flush=True)
 
-    def _wait_for_all_ranks(operation: str) -> None:
+    def wait_for_all_ranks(operation: str) -> None:
         """Barrier across ranks to synchronize distributed training."""
         if not dist.is_available() or not dist.is_initialized():
             return
@@ -776,7 +776,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     )
 
             # Barrier to wait for local rank 0 checkpoint download to complete
-            self.wait_for_all_ranks("download")
+            wait_for_all_ranks("download")
 
         def on_save(self, args, state, control, **kwargs):
             """Stage checkpoint and queue async upload."""
@@ -785,7 +785,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 return
 
             # Barrier before staging checkpoint to ensure all ranks finished saving their files
-            self.wait_for_all_ranks("save")
+            wait_for_all_ranks("save")
 
             # Check for background upload errors and propagate to main thread
             self._check_upload_error()
@@ -817,7 +817,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     shutil.move(checkpoint_path, staging_checkpoint_path)
 
                     # Calculate directory size for progress tracking
-                    total_size = self.calculate_local_dir_size(staging_checkpoint_path)
+                    total_size = self._calculate_local_dir_size(staging_checkpoint_path)
 
                     # Start upload worker if not yet running
                     self.start_upload_worker()
@@ -1143,7 +1143,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             return
 
         # Ensure all ranks finish writing final artifacts before upload starts.
-        _jit_checkpoint_callback.wait_for_all_ranks("final_model_upload")
+        wait_for_all_ranks("final_model_upload")
 
         local_rank = int(os.environ.get("LOCAL_RANK", "0"))
         if local_rank != 0:
@@ -1176,7 +1176,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     )
                     uploaded_count += 1
                 elif os.path.isdir(local_path):
-                    size = _jit_checkpoint_callback.calculate_local_dir_size(local_path)
+                    size = _jit_checkpoint_callback._calculate_local_dir_size(local_path)
                     _jit_checkpoint_callback.remote_fs.put(
                         local_path,
                         item,

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -233,6 +233,23 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             _log_prefix = f"[Kubeflow-node{node}-rank{rank}]"
         print(f"{_log_prefix} {message}", flush=True)
 
+    def _wait_for_all_ranks(operation: str) -> None:
+        """Barrier across ranks to synchronize distributed training."""
+        if not dist.is_available() or not dist.is_initialized():
+            return
+        try:
+            # Specify device to avoid "guessing device ID" warning
+            if torch.cuda.is_available():
+                dist.barrier(device_ids=[torch.cuda.current_device()])
+            else:
+                dist.barrier()
+        except Exception as e:
+            raise RuntimeError(
+                f"[Kubeflow] Barrier synchronization failed during {operation}: {e}. "
+                "This typically indicates one or more training processes crashed or "
+                "exited early. Check logs to identify which rank failed."
+            ) from e
+
     class CheckpointManager:
         """Manages async just-in-time checkpointing on SIGTERM signal using CUDA streams."""
 
@@ -265,7 +282,10 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             _log("SIGTERM received, starting async checkpoint")
             self.checkpoint_requested = True
 
-            # Start checkpoint thread immediately
+            # Barrier before spawning thread to ensure all ranks start checkpointing at same step
+            _wait_for_all_ranks("sigterm_checkpoint_sync")
+
+            # Start checkpoint thread after barrier
             self.checkpoint_thread = threading.Thread(
                 target=self._async_checkpoint, daemon=True, name="KubeflowJITCheckpoint"
             )
@@ -325,7 +345,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     # Fallback if no CUDA stream
                     self.trainer._save_checkpoint(self.trainer.model, trial=None)
 
-                # Remove sentinel on success (each rank removes its own)
+                # Remove sentinel on success (each rank removes its own independently)
                 if os.path.exists(sentinel_file):
                     try:
                         os.remove(sentinel_file)
@@ -429,26 +449,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         f"This check can be disabled by setting verify_cloud_storage_access=False."
                     ) from e
 
-        def wait_for_all_ranks(self, operation: str) -> None:
-            """Barrier across ranks."""
-            # Avoid barrier in single-process or when torch.distributed is not initialized.
-            if not dist.is_available() or not dist.is_initialized():
-                return
-            try:
-                dist.barrier()
-            except Exception as e:
-                raise RuntimeError(
-                    f"[Kubeflow] Barrier synchronization failed during checkpoint "
-                    f"{operation}: {e}. "
-                    "This typically indicates one or more training processes crashed "
-                    "or exited early. "
-                    "Check your training logs to identify which rank failed, "
-                    "verify all pods are healthy, "
-                    "and ensure distributed training is properly configured. "
-                    "Retrying the training job often resolves transient issues."
-                ) from e
-
-        def calculate_local_dir_size(self, path: str) -> int:
+        def _calculate_local_dir_size(self, path: str) -> int:
             """Calculate total size of local directory."""
             import contextlib
 

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -210,6 +210,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
     import re
     import shutil
     import signal
+    import sys
     import threading
     import time
     from typing import Callable, Optional
@@ -348,12 +349,6 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     # Fallback if no CUDA stream
                     self.trainer._save_checkpoint(self.trainer.model, trial=None)
 
-                # Trigger on_save callback to upload checkpoint if cloud storage
-                self.trainer.callback_handler.on_save(
-                    self.trainer.args, self.trainer.state, self.trainer.control
-                )
-
-                # Remove sentinel on success (each rank removes its own independently)
                 if os.path.exists(sentinel_file):
                     try:
                         os.remove(sentinel_file)
@@ -363,6 +358,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             "Check permissions; a stale marker may cause this checkpoint "
                             f"to be skipped. Remove it manually from: {sentinel_file}"
                         )
+
+                # Trigger on_save callback to upload checkpoint if cloud storage
+                self.trainer.callback_handler.on_save(
+                    self.trainer.args, self.trainer.state, self.trainer.control
+                )
 
                 _log(
                     f"JIT checkpoint completed at step {current_step} in node {node} rank {local_rank}"
@@ -897,8 +897,19 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 control.should_training_stop = True
 
         def on_train_end(self, args, state, control, **kwargs):
-            """Clean up staging directory after training."""
+            """Clean up S3 staging directory and wait for pending uploads.
+
+            If JIT checkpoint was taken, exits via sys.exit(0) to prevent
+            redundant user code from running during graceful shutdown.
+            """
             if not self.remote_fs:
+                if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                    _log(
+                        "JIT checkpoint complete. Exiting to avoid redundant "
+                        "operations during graceful shutdown.",
+                        args=args,
+                    )
+                    sys.exit(0)
                 return
 
             is_local_rank_0 = args.local_process_index == 0
@@ -921,6 +932,16 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             "Staging data will be cleaned up when the pod terminates.",
                             args=args,
                         )
+
+            # After JIT checkpoint + S3 upload + cleanup, exit the process to prevent
+            # user code (e.g. trainer.save_model()) from running during shutdown.
+            if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                _log(
+                    "JIT checkpoint and upload complete. Exiting to avoid redundant "
+                    "operations during graceful shutdown.",
+                    args=args,
+                )
+                sys.exit(0)
 
     # Create callback instance at outer scope so both apply_checkpointing()
     # and upload_final_model_to_cloud() can reference it via closure.
@@ -952,10 +973,14 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
                 checkpoint_path = os.path.join(output_dir, name)
 
-                # Check for any incomplete marker files (supports per-rank markers)
-                has_incomplete = any(
-                    f.startswith(CHECKPOINT_INCOMPLETE_MARKER) for f in os.listdir(checkpoint_path)
-                )
+                try:
+                    has_incomplete = any(
+                        f.startswith(CHECKPOINT_INCOMPLETE_MARKER)
+                        for f in os.listdir(checkpoint_path)
+                    )
+                except (FileNotFoundError, OSError):
+                    _log(f"Skipping checkpoint {name} directory was removed by another rank")
+                    continue
 
                 # Delete incomplete checkpoints (global rank 0 only to avoid race condition)
                 if has_incomplete:
@@ -1076,7 +1101,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                         args=training_args,
                     )
                     try:
-                        dist.barrier()
+                        # Specify device to avoid "guessing device ID" warning
+                        if torch.cuda.is_available():
+                            dist.barrier(device_ids=[torch.cuda.current_device()])
+                        else:
+                            dist.barrier()
                     except Exception as e:
                         raise RuntimeError(
                             "[Kubeflow] Barrier synchronization failed during train-start: "

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -293,8 +293,14 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             # Wait for checkpoint to complete before allowing process to terminate
             _log("Waiting for checkpoint thread to complete...")
-            self.checkpoint_thread.join()
-            _log("Checkpoint thread completed")
+            self.checkpoint_thread.join(timeout=300)
+            if self.checkpoint_thread.is_alive():
+                _log(
+                    "Warning: Checkpoint thread still running after 5 mins timeout. "
+                    "Process will terminate, checkpoint may be incomplete."
+                )
+            else:
+                _log("Checkpoint thread completed")
 
         def _async_checkpoint(self):
             """Execute checkpoint asynchronously, waiting if in optimizer step."""
@@ -324,7 +330,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 sentinel_file = os.path.join(checkpoint_path, sentinel_name)
                 try:
                     with open(sentinel_file, "w") as f:
-                        f.write(f"Checkpoint started at step {current_step}")
+                        f.write(
+                            f"Checkpoint started at step {current_step} in node {node} rank {local_rank}"
+                        )
                 except Exception as e:
                     _log(
                         f"Warning: Failed to write sentinel file: {e}. "
@@ -361,7 +369,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                             f"to be skipped. Remove it manually from: {sentinel_file}"
                         )
 
-                _log(f"JIT checkpoint completed at step {current_step}")
+                _log(
+                    f"JIT checkpoint completed at step {current_step} in node {node} rank {local_rank}"
+                )
 
             except Exception as e:
                 _log(

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -291,19 +291,6 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             )
             self.checkpoint_thread.start()
 
-            # Wait for checkpoint to complete before allowing process to terminate
-            _log("Waiting for checkpoint thread to complete...")
-            self.checkpoint_thread.join(timeout=300)
-            if self.checkpoint_thread.is_alive():
-                _log(
-                    "Warning: Checkpoint did not complete within 300s timeout. "
-                    "Kubernetes will send SIGKILL and checkpoint will be incomplete. "
-                    "Increase 'terminationGracePeriodSeconds' in your TrainJob manifest "
-                    "or check for slow disk/S3 issues."
-                )
-            else:
-                _log("Checkpoint thread completed")
-
         def _async_checkpoint(self):
             """Execute checkpoint asynchronously, waiting if in optimizer step."""
             try:
@@ -898,7 +885,22 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 control.should_training_stop = True
 
         def on_train_end(self, args, state, control, **kwargs):
-            """Clean up staging directory after training."""
+            """Wait for JIT checkpoint completion and clean up staging directory."""
+            # Wait for JIT checkpoint thread if one is running
+            if self.jit_manager and self.jit_manager.checkpoint_thread:
+                _log("Waiting for JIT checkpoint to complete...", args=args)
+                self.jit_manager.checkpoint_thread.join(timeout=300)
+                if self.jit_manager.checkpoint_thread.is_alive():
+                    _log(
+                        "Warning: Checkpoint did not complete within 300s timeout. "
+                        "Kubernetes will send SIGKILL and checkpoint will be incomplete. "
+                        "Increase 'terminationGracePeriodSeconds' in your TrainJob manifest "
+                        "or check for slow disk/S3 issues.",
+                        args=args,
+                    )
+                else:
+                    _log("JIT checkpoint completed", args=args)
+
             if not self.remote_fs:
                 return
 

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -256,9 +256,9 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
         def __init__(self, trainer):
             self.trainer = trainer
             self.checkpoint_requested = False
+            self._checkpoint_deferred = False
             self._original_sigterm_handler = None
             self.checkpoint_stream = None
-            self.checkpoint_thread = None
             self._in_optimizer_step = False
 
             # Initialize CUDA stream for async checkpoint operations
@@ -275,29 +275,30 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             _log("JIT checkpoint signal handler registered for SIGTERM")
 
         def _sigterm_handler(self, signum, frame):
-            """Start async checkpoint on SIGTERM."""
+            """Start checkpoint on SIGTERM.
+
+            If SIGTERM arrives outside an optimizer step, checkpoint is performed
+            directly. If SIGTERM arrives during an optimizer step, checkpoint is
+            deferred to the on_optimizer_step callback to avoid deadlock.
+            """
             if self.checkpoint_requested:
                 return
 
-            _log("SIGTERM received, starting async checkpoint")
+            _log("SIGTERM received, starting JIT checkpoint")
             self.checkpoint_requested = True
 
-            # Barrier before spawning thread to ensure all ranks start checkpointing at same step
-            _wait_for_all_ranks("sigterm_checkpoint_sync")
+            if self._in_optimizer_step:
+                # Unsafe to checkpoint during optimizer step - defer to callback
+                _log("In optimizer step, deferring checkpoint to callback")
+                self._checkpoint_deferred = True
+                return
 
-            # Start checkpoint thread after barrier
-            self.checkpoint_thread = threading.Thread(
-                target=self._async_checkpoint, daemon=False, name="KubeflowJITCheckpoint"
-            )
-            self.checkpoint_thread.start()
+            # Safe to checkpoint directly - blocks main thread
+            self._save_jit_checkpoint()
 
-        def _async_checkpoint(self):
-            """Execute checkpoint asynchronously, waiting if in optimizer step."""
+        def _save_jit_checkpoint(self):
+            """Execute checkpoint, saving model state and training artifacts."""
             try:
-                # Wait if we're currently in optimizer step (unsafe to checkpoint)
-                while self._in_optimizer_step:
-                    time.sleep(0.5)
-
                 current_step = self.trainer.state.global_step
                 _log(f"Starting JIT checkpoint at step {current_step}")
 
@@ -346,6 +347,11 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 else:
                     # Fallback if no CUDA stream
                     self.trainer._save_checkpoint(self.trainer.model, trial=None)
+
+                # Trigger on_save callback to upload checkpoint if cloud storage
+                self.trainer.callback_handler.on_save(
+                    self.trainer.args, self.trainer.state, self.trainer.control
+                )
 
                 # Remove sentinel on success (each rank removes its own independently)
                 if os.path.exists(sentinel_file):
@@ -874,6 +880,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 # Mark that optimizer step completed (safe for checkpoint again)
                 self.jit_manager._in_optimizer_step = False
 
+                # If SIGTERM arrived during optimizer step, checkpoint now
+                if self.jit_manager._checkpoint_deferred:
+                    self.jit_manager._checkpoint_deferred = False
+                    self.jit_manager._save_jit_checkpoint()
+                    control.should_training_stop = True
+
         def on_step_end(self, args, state, control, **kwargs):
             if self.jit_manager and self.jit_manager.checkpoint_in_progress():
                 control.should_save = False
@@ -885,22 +897,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 control.should_training_stop = True
 
         def on_train_end(self, args, state, control, **kwargs):
-            """Wait for JIT checkpoint completion and clean up staging directory."""
-            # Wait for JIT checkpoint thread if one is running
-            if self.jit_manager and self.jit_manager.checkpoint_thread:
-                _log("Waiting for JIT checkpoint to complete...", args=args)
-                self.jit_manager.checkpoint_thread.join(timeout=300)
-                if self.jit_manager.checkpoint_thread.is_alive():
-                    _log(
-                        "Warning: Checkpoint did not complete within 300s timeout. "
-                        "Kubernetes will send SIGKILL and checkpoint will be incomplete. "
-                        "Increase 'terminationGracePeriodSeconds' in your TrainJob manifest "
-                        "or check for slow disk/S3 issues.",
-                        args=args,
-                    )
-                else:
-                    _log("JIT checkpoint completed", args=args)
-
+            """Clean up staging directory after training."""
             if not self.remote_fs:
                 return
 

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -252,15 +252,14 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             ) from e
 
     class CheckpointManager:
-        """Manages async just-in-time checkpointing on SIGTERM signal using CUDA streams."""
+        """Manages just-in-time checkpointing on SIGTERM signal using CUDA streams."""
 
         def __init__(self, trainer):
             self.trainer = trainer
             self.checkpoint_requested = False
-            self._checkpoint_deferred = False
+            self._should_exit = False
             self._original_sigterm_handler = None
             self.checkpoint_stream = None
-            self._in_optimizer_step = False
 
             # Initialize CUDA stream for async checkpoint operations
             try:
@@ -276,29 +275,21 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             _log("JIT checkpoint signal handler registered for SIGTERM")
 
         def _sigterm_handler(self, signum, frame):
-            """Start checkpoint on SIGTERM.
+            """Mark checkpoint requested on SIGTERM.
 
-            If SIGTERM arrives outside an optimizer step, checkpoint is performed
-            directly. If SIGTERM arrives during an optimizer step, checkpoint is
-            deferred to the on_optimizer_step callback to avoid deadlock.
+            Checkpoint is deferred to the next training callback (on_step_end /
+            on_epoch_end) to avoid reentrancy deadlocks when SIGTERM arrives
+            during an in-progress periodic checkpoint.
             """
             if self.checkpoint_requested:
                 return
 
-            _log("SIGTERM received, starting JIT checkpoint")
+            _log("SIGTERM received, checkpoint will be saved at next safe point")
             self.checkpoint_requested = True
-
-            if self._in_optimizer_step:
-                # Unsafe to checkpoint during optimizer step - defer to callback
-                _log("In optimizer step, deferring checkpoint to callback")
-                self._checkpoint_deferred = True
-                return
-
-            # Safe to checkpoint directly - blocks main thread
-            self._save_jit_checkpoint()
 
         def _save_jit_checkpoint(self):
             """Execute checkpoint, saving model state and training artifacts."""
+            self.checkpoint_requested = False
             try:
                 current_step = self.trainer.state.global_step
                 _log(f"Starting JIT checkpoint at step {current_step}")
@@ -367,6 +358,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 _log(
                     f"JIT checkpoint completed at step {current_step} in node {node} rank {local_rank}"
                 )
+                self._should_exit = True
 
             except Exception as e:
                 _log(
@@ -867,32 +859,27 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     args=args,
                 )
 
-        def on_pre_optimizer_step(self, args, state, control, **kwargs):
-            if self.jit_manager:
-                # Mark that we're entering optimizer step (unsafe for checkpoint)
-                self.jit_manager._in_optimizer_step = True
+        def on_step_begin(self, args, state, control, **kwargs):
+            if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                control.should_training_stop = True
 
-                if self.jit_manager.checkpoint_in_progress():
-                    control.should_training_stop = True
+        def on_pre_optimizer_step(self, args, state, control, **kwargs):
+            if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                control.should_training_stop = True
 
         def on_optimizer_step(self, args, state, control, **kwargs):
-            if self.jit_manager:
-                # Mark that optimizer step completed (safe for checkpoint again)
-                self.jit_manager._in_optimizer_step = False
-
-                # If SIGTERM arrived during optimizer step, checkpoint now
-                if self.jit_manager._checkpoint_deferred:
-                    self.jit_manager._checkpoint_deferred = False
-                    self.jit_manager._save_jit_checkpoint()
-                    control.should_training_stop = True
+            if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                control.should_training_stop = True
 
         def on_step_end(self, args, state, control, **kwargs):
             if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                self.jit_manager._save_jit_checkpoint()
                 control.should_save = False
                 control.should_training_stop = True
 
         def on_epoch_end(self, args, state, control, **kwargs):
             if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                self.jit_manager._save_jit_checkpoint()
                 control.should_save = False
                 control.should_training_stop = True
 
@@ -903,7 +890,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
             redundant user code from running during graceful shutdown.
             """
             if not self.remote_fs:
-                if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+                if self.jit_manager and self.jit_manager._should_exit:
                     _log(
                         "JIT checkpoint complete. Exiting to avoid redundant "
                         "operations during graceful shutdown.",
@@ -935,7 +922,7 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             # After JIT checkpoint + S3 upload + cleanup, exit the process to prevent
             # user code (e.g. trainer.save_model()) from running during shutdown.
-            if self.jit_manager and self.jit_manager.checkpoint_in_progress():
+            if self.jit_manager and self.jit_manager._should_exit:
                 _log(
                     "JIT checkpoint and upload complete. Exiting to avoid redundant "
                     "operations during graceful shutdown.",

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -281,11 +281,12 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 current_step = self.trainer.state.global_step
                 _log(f"Starting JIT checkpoint at step {current_step}")
 
-                # Get global rank 0 for distributed training.
-                # Fall back to True for single-process runs.
-                is_global_rank0 = True
-                if dist.is_available() and dist.is_initialized():
-                    is_global_rank0 = dist.get_rank() == 0
+                # Build per-rank marker filename
+                node = os.environ.get("NODE_RANK") or os.environ.get("GROUP_RANK") or "0"
+                try:
+                    local_rank = self.trainer.args.local_process_index
+                except Exception:
+                    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
 
                 output_dir = self.trainer._get_output_dir(trial=None)
                 checkpoint_path = os.path.join(
@@ -293,20 +294,20 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                 )
                 os.makedirs(checkpoint_path, exist_ok=True)
 
-                # Create sentinel file to mark incomplete checkpoint (only global rank 0)
-                sentinel_file = os.path.join(checkpoint_path, CHECKPOINT_INCOMPLETE_MARKER)
-                if is_global_rank0:
-                    try:
-                        with open(sentinel_file, "w") as f:
-                            f.write(f"Checkpoint started at step {current_step}")
-                    except Exception as e:
-                        _log(
-                            f"Warning: Failed to write sentinel file: {e}. "
-                            "Check local disk space and write permissions in output_dir; "
-                            "this checkpoint will be treated as complete during resume."
-                            "Please manually verify if the checkpoint is indeed complete"
-                            f"{checkpoint_path}"
-                        )
+                # Each rank creates its own sentinel to track per-rank completion
+                sentinel_name = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-{node}-rank-{local_rank}"
+                sentinel_file = os.path.join(checkpoint_path, sentinel_name)
+                try:
+                    with open(sentinel_file, "w") as f:
+                        f.write(f"Checkpoint started at step {current_step}")
+                except Exception as e:
+                    _log(
+                        f"Warning: Failed to write sentinel file: {e}. "
+                        "Check local disk space and write permissions in output_dir; "
+                        "this checkpoint will be treated as complete during resume. "
+                        "Please manually verify if the checkpoint is indeed complete: "
+                        f"{checkpoint_path}"
+                    )
 
                 # Checkpoint using dedicated CUDA stream
                 if self.checkpoint_stream is not None:
@@ -324,8 +325,8 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     # Fallback if no CUDA stream
                     self.trainer._save_checkpoint(self.trainer.model, trial=None)
 
-                # Remove sentinel on success (only global rank 0)
-                if is_global_rank0 and os.path.exists(sentinel_file):
+                # Remove sentinel on success (each rank removes its own)
+                if os.path.exists(sentinel_file):
                     try:
                         os.remove(sentinel_file)
                     except Exception as e:
@@ -933,10 +934,14 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
                     continue
 
                 checkpoint_path = os.path.join(output_dir, name)
-                incomplete_marker = os.path.join(checkpoint_path, CHECKPOINT_INCOMPLETE_MARKER)
+
+                # Check for any incomplete marker files (supports per-rank markers)
+                has_incomplete = any(
+                    f.startswith(CHECKPOINT_INCOMPLETE_MARKER) for f in os.listdir(checkpoint_path)
+                )
 
                 # Delete incomplete checkpoints (global rank 0 only to avoid race condition)
-                if os.path.exists(incomplete_marker):
+                if has_incomplete:
                     if is_global_rank_0:
                         try:
                             _log(f"Deleting incomplete checkpoint: {checkpoint_path}")

--- a/kubeflow/trainer/rhai/transformers.py
+++ b/kubeflow/trainer/rhai/transformers.py
@@ -287,9 +287,14 @@ def _create_checkpoint_instrumentation(checkpoint_config: dict) -> tuple:
 
             # Start checkpoint thread after barrier
             self.checkpoint_thread = threading.Thread(
-                target=self._async_checkpoint, daemon=True, name="KubeflowJITCheckpoint"
+                target=self._async_checkpoint, daemon=False, name="KubeflowJITCheckpoint"
             )
             self.checkpoint_thread.start()
+
+            # Wait for checkpoint to complete before allowing process to terminate
+            _log("Waiting for checkpoint thread to complete...")
+            self.checkpoint_thread.join()
+            _log("Checkpoint thread completed")
 
         def _async_checkpoint(self):
             """Execute checkpoint asynchronously, waiting if in optimizer step."""

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -1985,13 +1985,15 @@ def test_find_latest_checkpoint(test_case, tmp_path):
         checkpoint_path.mkdir()
 
         if checkpoint_config.get("incomplete"):
-            (checkpoint_path / CHECKPOINT_INCOMPLETE_MARKER).write_text("incomplete")
+            # Use per-rank marker format matching production code
+            marker_name = f"{CHECKPOINT_INCOMPLETE_MARKER}.node-0-rank-0"
+            (checkpoint_path / marker_name).write_text("incomplete")
 
     # Also create a file named checkpoint-200 to test directory check
     if "not-a-checkpoint" in test_case.config["checkpoints"]:
         (tmp_path / "checkpoint-200").write_text("file, not dir")
 
-    # Implement the _find_latest_checkpoint logic
+    # Implement the _find_latest_checkpoint logic (matches production code)
     checkpoint_pattern = re.compile(r"^checkpoint-(\d+)$")
     checkpoints = []
 
@@ -2001,10 +2003,14 @@ def test_find_latest_checkpoint(test_case, tmp_path):
             continue
 
         checkpoint_path = os.path.join(tmp_path, name)
-        incomplete_marker = os.path.join(checkpoint_path, CHECKPOINT_INCOMPLETE_MARKER)
+
+        # Check for any incomplete marker files (supports per-rank markers)
+        has_incomplete = any(
+            f.startswith(CHECKPOINT_INCOMPLETE_MARKER) for f in os.listdir(checkpoint_path)
+        )
 
         # Delete incomplete checkpoints
-        if os.path.exists(incomplete_marker):
+        if has_incomplete:
             print(f"[Test] Deleting incomplete checkpoint: {checkpoint_path}")
             shutil.rmtree(checkpoint_path)
             continue

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -3649,5 +3649,651 @@ def test_final_model_upload_nonexistent_output_dir(tmp_path):
     print("test execution complete")
 
 
+def test_sigterm_handler_paths(tmp_path):
+    """Test SIGTERM handler dispatches correctly for all three paths.
+
+    Path 1: Normal - calls _save_jit_checkpoint() directly.
+    Path 2: During optimizer step - defers via _checkpoint_deferred flag.
+    Path 3: During periodic save - skips JIT (sets checkpoint_requested only).
+    """
+    print("Executing test: SIGTERM handler paths")
+
+    import subprocess
+    import sys
+
+    output_dir = tmp_path / "checkpoints"
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir=str(output_dir),
+        enable_jit_checkpoint=True,
+    )
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
+        pass
+
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+"""
+
+    transformers_stub = """
+class TrainerCallback:
+    pass
+
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class TrainerState:
+    def __init__(self):
+        self.global_step = 42
+        self.is_world_process_zero = True
+
+class TrainingArguments:
+    def __init__(self):
+        self.local_process_index = 0
+
+class CallbackHandler:
+    def on_save(self, args, state, control):
+        pass
+
+class MockControl:
+    should_save = False
+    should_training_stop = False
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        self.state = TrainerState()
+        self.args = TrainingArguments()
+        self.control = MockControl()
+        self.model = type('MockModel', (), {'parameters': lambda self: []})()
+        self.callback_handler = CallbackHandler()
+        self._init_args = args
+        self._init_kwargs = kwargs
+        self._save_checkpoint_called = False
+
+    def _get_output_dir(self, trial=None):
+        return OUTPUT_DIR
+
+    def _save_checkpoint(self, model, trial=None):
+        self._save_checkpoint_called = True
+
+    def train(self, resume_from_checkpoint=None):
+        return {"train_called": True}
+"""
+
+    test_file = tmp_path / "test_sigterm_paths.py"
+    test_code = f"""
+import os
+import sys
+import signal
+import types
+
+OUTPUT_DIR = r"{output_dir}"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+{checkpoint_code}
+
+from transformers import Trainer, TrainerCallback, TrainingArguments, TrainerState
+
+# Find JITCheckpointCallback
+callback_class = None
+for name, obj in list(globals().items()):
+    if isinstance(obj, type) and issubclass(obj, TrainerCallback) and name != 'TrainerCallback':
+        callback_class = obj
+        break
+
+if not callback_class:
+    print("ERROR: JITCheckpointCallback not found")
+    sys.exit(1)
+
+def create_jit_manager():
+    \"\"\"Create a JIT manager via the callback lifecycle.\"\"\"
+    trainer = Trainer(None, TrainingArguments())
+    trainer._get_output_dir = lambda trial=None: OUTPUT_DIR
+    trainer._save_checkpoint_called = False
+
+    cb = callback_class()
+    cb._trainer_ref = trainer
+    cb.on_train_begin(TrainingArguments(), TrainerState(), None)
+    return cb.jit_manager
+
+# --- Test Path 1: Normal SIGTERM (no optimizer step, no periodic save) ---
+mgr = create_jit_manager()
+mgr._sigterm_handler(signal.SIGTERM, None)
+assert mgr.checkpoint_requested == True, "checkpoint_requested not set"
+assert mgr.trainer._save_checkpoint_called == True, "Path 1: _save_checkpoint should be called"
+assert mgr._checkpoint_deferred == False, "Path 1: should not defer"
+print("PATH_1_NORMAL=PASS")
+
+# --- Test Path 2: SIGTERM during optimizer step ---
+mgr2 = create_jit_manager()
+mgr2._in_optimizer_step = True
+mgr2._sigterm_handler(signal.SIGTERM, None)
+assert mgr2.checkpoint_requested == True, "checkpoint_requested not set"
+assert mgr2._checkpoint_deferred == True, "Path 2: should defer"
+assert mgr2.trainer._save_checkpoint_called == False, "Path 2: should NOT call _save_checkpoint"
+print("PATH_2_OPTIMIZER_STEP=PASS")
+
+# --- Test: Second SIGTERM is idempotent ---
+mgr4 = create_jit_manager()
+mgr4.checkpoint_requested = True  # Already set
+mgr4._sigterm_handler(signal.SIGTERM, None)
+assert mgr4.trainer._save_checkpoint_called == False, "Idempotent: should not save again"
+print("IDEMPOTENT=PASS")
+
+print("TEST_COMPLETE=True")
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=10
+    )
+
+    output = result.stdout
+    print(f"Test output:\n{output}")
+
+    if result.returncode != 0:
+        print(f"Test stderr:\n{result.stderr}")
+
+    assert result.returncode == 0, f"Execution failed: {result.stderr}"
+    assert "PATH_1_NORMAL=PASS" in output
+    assert "PATH_2_OPTIMIZER_STEP=PASS" in output
+    assert "IDEMPOTENT=PASS" in output
+    assert "TEST_COMPLETE=True" in output
+
+    print("test execution complete")
+
+
+def test_callback_guards_and_deferred_checkpoint(tmp_path):
+    """Test JITCheckpointCallback guards and deferred checkpoint processing.
+
+    Verifies:
+    - on_step_end/on_epoch_end set should_save=False and should_training_stop=True
+      when checkpoint is in progress.
+    - on_optimizer_step processes deferred checkpoint.
+    - on_pre_optimizer_step sets _in_optimizer_step flag.
+    """
+    print("Executing test: callback guards and deferred checkpoint")
+
+    import subprocess
+    import sys
+
+    output_dir = tmp_path / "checkpoints"
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir=str(output_dir),
+        enable_jit_checkpoint=True,
+    )
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
+        pass
+
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+"""
+
+    transformers_stub = """
+class TrainerCallback:
+    pass
+
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class TrainerState:
+    def __init__(self):
+        self.global_step = 50
+        self.is_world_process_zero = True
+
+class TrainingArguments:
+    def __init__(self):
+        self.local_process_index = 0
+
+class CallbackHandler:
+    def on_save(self, args, state, control):
+        pass
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        self.state = TrainerState()
+        self.args = TrainingArguments()
+        self.model = type('MockModel', (), {'parameters': lambda self: []})()
+        self.callback_handler = CallbackHandler()
+        self._init_args = args
+        self._init_kwargs = kwargs
+
+    def _get_output_dir(self, trial=None):
+        return OUTPUT_DIR
+
+    def _save_checkpoint(self, model, trial=None):
+        pass
+
+    def train(self, resume_from_checkpoint=None):
+        return {"train_called": True}
+"""
+
+    test_file = tmp_path / "test_callback_guards.py"
+    test_code = f"""
+import os
+import sys
+import types
+
+OUTPUT_DIR = r"{output_dir}"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+{checkpoint_code}
+
+from transformers import Trainer, TrainerCallback, TrainingArguments, TrainerState
+
+# Find JITCheckpointCallback
+callback_class = None
+for name, obj in list(globals().items()):
+    if isinstance(obj, type) and issubclass(obj, TrainerCallback) and name != 'TrainerCallback':
+        callback_class = obj
+        break
+
+if not callback_class:
+    print("ERROR: JITCheckpointCallback not found")
+    sys.exit(1)
+
+# Setup: create callback with a trainer reference
+trainer = Trainer(None, TrainingArguments())
+trainer._get_output_dir = lambda trial=None: OUTPUT_DIR
+
+callback = callback_class()
+callback._trainer_ref = trainer
+
+# Simulate on_train_begin to create JIT manager
+callback.on_train_begin(TrainingArguments(), TrainerState(), None)
+assert callback.jit_manager is not None, "JIT manager not created"
+
+args = TrainingArguments()
+state = TrainerState()
+
+# === Test 1: on_step_end guard when checkpoint in progress ===
+callback.jit_manager.checkpoint_requested = True
+
+class MockControl:
+    should_save = True
+    should_training_stop = False
+
+control = MockControl()
+callback.on_step_end(args, state, control)
+assert control.should_save == False, "on_step_end should clear should_save"
+assert control.should_training_stop == True, "on_step_end should set should_training_stop"
+print("GUARD_ON_STEP_END=PASS")
+
+# === Test 2: on_epoch_end guard when checkpoint in progress ===
+control2 = MockControl()
+control2.should_save = True
+control2.should_training_stop = False
+callback.on_epoch_end(args, state, control2)
+assert control2.should_save == False, "on_epoch_end should clear should_save"
+assert control2.should_training_stop == True, "on_epoch_end should set should_training_stop"
+print("GUARD_ON_EPOCH_END=PASS")
+
+# === Test 3: on_optimizer_step processes deferred checkpoint ===
+callback.jit_manager.checkpoint_requested = True
+callback.jit_manager._checkpoint_deferred = True
+callback.jit_manager._in_optimizer_step = True
+
+control6 = MockControl()
+control6.should_training_stop = False
+callback.on_optimizer_step(args, state, control6)
+assert callback.jit_manager._in_optimizer_step == False, (
+    "on_optimizer_step should clear _in_optimizer_step"
+)
+assert callback.jit_manager._checkpoint_deferred == False, (
+    "on_optimizer_step should clear _checkpoint_deferred"
+)
+assert control6.should_training_stop == True, (
+    "on_optimizer_step should stop training after deferred checkpoint"
+)
+print("DEFERRED_CHECKPOINT_PROCESSED=PASS")
+
+# === Test 4: on_pre_optimizer_step sets _in_optimizer_step ===
+callback.jit_manager._in_optimizer_step = False
+control7 = MockControl()
+callback.on_pre_optimizer_step(args, state, control7)
+assert callback.jit_manager._in_optimizer_step == True, (
+    "on_pre_optimizer_step should set _in_optimizer_step"
+)
+print("PRE_OPTIMIZER_STEP_FLAG=PASS")
+
+print("TEST_COMPLETE=True")
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=10
+    )
+
+    output = result.stdout
+    print(f"Test output:\n{output}")
+
+    if result.returncode != 0:
+        print(f"Test stderr:\n{result.stderr}")
+
+    assert result.returncode == 0, f"Execution failed: {result.stderr}"
+    assert "GUARD_ON_STEP_END=PASS" in output
+    assert "GUARD_ON_EPOCH_END=PASS" in output
+    assert "DEFERRED_CHECKPOINT_PROCESSED=PASS" in output
+    assert "PRE_OPTIMIZER_STEP_FLAG=PASS" in output
+    assert "TEST_COMPLETE=True" in output
+
+    print("test execution complete")
+
+
+def test_find_latest_checkpoint_race_condition(tmp_path):
+    """Test checkpoint discovery handles concurrent directory removal gracefully.
+
+    Simulates the race where global rank 0 deletes an incomplete checkpoint
+    directory while another rank is scanning it with os.listdir().
+    """
+    print("Executing test: checkpoint discovery race condition")
+
+    import os
+    import re
+    import shutil
+
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER
+
+    # Create a checkpoint directory then remove it between listdir calls
+    # to simulate the race condition
+    checkpoint_path = tmp_path / "checkpoint-100"
+    checkpoint_path.mkdir()
+    (checkpoint_path / "model.bin").write_text("data")
+
+    # Also create a valid checkpoint that should be found
+    valid_path = tmp_path / "checkpoint-50"
+    valid_path.mkdir()
+    (valid_path / "model.bin").write_text("data")
+
+    # Implement the checkpoint discovery logic with race condition handling
+    checkpoint_pattern = re.compile(r"^checkpoint-(\d+)$")
+    checkpoints = []
+
+    entries = os.listdir(tmp_path)
+
+    # Remove checkpoint-100 AFTER listdir but BEFORE processing it
+    # (simulates race with rank 0 deleting it)
+    shutil.rmtree(checkpoint_path)
+
+    for name in entries:
+        match = checkpoint_pattern.match(name)
+        full_path = os.path.join(tmp_path, name)
+        if not match or not os.path.isdir(full_path):
+            continue
+
+        try:
+            has_incomplete = any(
+                f.startswith(CHECKPOINT_INCOMPLETE_MARKER) for f in os.listdir(full_path)
+            )
+        except (FileNotFoundError, OSError):
+            # This is the race condition path - directory was removed
+            print(f"Skipping checkpoint {name} directory was removed by another rank")
+            continue
+
+        if not has_incomplete:
+            checkpoints.append((int(match.group(1)), full_path))
+
+    # checkpoint-100 was removed (race condition), checkpoint-50 should be found
+    assert len(checkpoints) == 1, f"Expected 1 checkpoint, got {len(checkpoints)}"
+    assert checkpoints[0][0] == 50, f"Expected step 50, got {checkpoints[0][0]}"
+
+    print("test execution complete")
+
+
+def test_sentinel_lifecycle_during_jit_checkpoint(tmp_path):
+    """Test sentinel file lifecycle: created before save, removed after save.
+
+    Verifies:
+    1. Sentinel file exists DURING _save_checkpoint() (created before save).
+    2. Sentinel file is removed AFTER _save_checkpoint() completes.
+    3. No CHECKPOINT_INCOMPLETE_MARKER files remain (checkpoint is resume-ready).
+    """
+    print("Executing test: sentinel lifecycle during JIT checkpoint")
+
+    import subprocess
+    import sys
+
+    from kubeflow.trainer.rhai.constants import CHECKPOINT_INCOMPLETE_MARKER
+
+    output_dir = tmp_path / "checkpoints"
+
+    checkpoint_code = get_jit_checkpoint_injection_code(
+        output_dir=str(output_dir),
+        enable_jit_checkpoint=True,
+    )
+
+    torch_stub = """
+class distributed:
+    @staticmethod
+    def is_available():
+        return False
+
+    @staticmethod
+    def is_initialized():
+        return False
+
+    @staticmethod
+    def barrier():
+        pass
+
+class cuda:
+    @staticmethod
+    def is_available():
+        return False
+"""
+
+    transformers_stub = f"""
+import os
+
+CHECKPOINT_INCOMPLETE_MARKER = "{CHECKPOINT_INCOMPLETE_MARKER}"
+_OUTPUT_DIR = r"{output_dir}"
+
+class TrainerCallback:
+    pass
+
+class trainer_utils:
+    PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+PREFIX_CHECKPOINT_DIR = "checkpoint"
+
+class TrainerState:
+    def __init__(self):
+        self.global_step = 10
+        self.is_world_process_zero = True
+
+class TrainingArguments:
+    def __init__(self):
+        self.local_process_index = 0
+
+class CallbackHandler:
+    def on_save(self, args, state, control):
+        pass
+
+class MockControl:
+    should_save = False
+    should_training_stop = False
+
+class Trainer:
+    def __init__(self, *args, **kwargs):
+        self.state = TrainerState()
+        self.args = TrainingArguments()
+        self.control = MockControl()
+        self.model = type('MockModel', (), {{'parameters': lambda self: []}})()
+        self.callback_handler = CallbackHandler()
+        self._init_args = args
+        self._init_kwargs = kwargs
+
+    def _get_output_dir(self, trial=None):
+        return _OUTPUT_DIR
+
+    def _save_checkpoint(self, model, trial=None):
+        # During save, verify sentinel file EXISTS
+        checkpoint_path = os.path.join(_OUTPUT_DIR, "checkpoint-10")
+        sentinel_files = [
+            f for f in os.listdir(checkpoint_path)
+            if f.startswith(CHECKPOINT_INCOMPLETE_MARKER)
+        ]
+        if sentinel_files:
+            print("SENTINEL_EXISTS_DURING_SAVE=True")
+            print(f"SENTINEL_NAME={{sentinel_files[0]}}")
+        else:
+            print("SENTINEL_EXISTS_DURING_SAVE=False")
+
+    def train(self, resume_from_checkpoint=None):
+        return {{"train_called": True}}
+"""
+
+    test_file = tmp_path / "test_sentinel_lifecycle.py"
+    test_code = f"""
+import os
+import sys
+import signal
+import types
+
+OUTPUT_DIR = r"{output_dir}"
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+torch_module = types.ModuleType('torch')
+exec('''{torch_stub}''', torch_module.__dict__)
+sys.modules['torch'] = torch_module
+sys.modules['torch.distributed'] = torch_module.distributed
+
+transformers_module = types.ModuleType('transformers')
+exec('''{transformers_stub}''', transformers_module.__dict__)
+sys.modules['transformers'] = transformers_module
+
+trainer_utils_module = types.ModuleType('transformers.trainer_utils')
+trainer_utils_module.PREFIX_CHECKPOINT_DIR = "checkpoint"
+sys.modules['transformers.trainer_utils'] = trainer_utils_module
+
+{checkpoint_code}
+
+from transformers import Trainer, TrainerCallback, TrainingArguments, TrainerState
+
+CHECKPOINT_INCOMPLETE_MARKER = "{CHECKPOINT_INCOMPLETE_MARKER}"
+
+# Find JITCheckpointCallback
+callback_class = None
+for name, obj in list(globals().items()):
+    if isinstance(obj, type) and issubclass(obj, TrainerCallback) and name != 'TrainerCallback':
+        callback_class = obj
+        break
+
+if not callback_class:
+    print("ERROR: JITCheckpointCallback not found")
+    sys.exit(1)
+
+# Create trainer and JIT manager
+trainer = Trainer(None, TrainingArguments())
+trainer._get_output_dir = lambda trial=None: OUTPUT_DIR
+
+cb = callback_class()
+cb._trainer_ref = trainer
+cb.on_train_begin(TrainingArguments(), TrainerState(), None)
+
+mgr = cb.jit_manager
+assert mgr is not None, "JIT manager not created"
+
+# Trigger SIGTERM handler (will call _save_jit_checkpoint)
+mgr._sigterm_handler(signal.SIGTERM, None)
+
+# After _save_jit_checkpoint completes, verify sentinel is REMOVED
+checkpoint_path = os.path.join(OUTPUT_DIR, "checkpoint-10")
+remaining_sentinels = [
+    f for f in os.listdir(checkpoint_path)
+    if f.startswith(CHECKPOINT_INCOMPLETE_MARKER)
+]
+if not remaining_sentinels:
+    print("SENTINEL_REMOVED_AFTER_SAVE=True")
+else:
+    print(f"SENTINEL_REMOVED_AFTER_SAVE=False (remaining: {{remaining_sentinels}})")
+
+print("TEST_COMPLETE=True")
+"""
+
+    test_file.write_text(test_code)
+
+    result = subprocess.run(
+        [sys.executable, str(test_file)], capture_output=True, text=True, timeout=10
+    )
+
+    output = result.stdout
+    print(f"Test output:\n{output}")
+
+    if result.returncode != 0:
+        print(f"Test stderr:\n{result.stderr}")
+
+    assert result.returncode == 0, f"Execution failed: {result.stderr}"
+    # Sentinel existed DURING _save_checkpoint
+    assert "SENTINEL_EXISTS_DURING_SAVE=True" in output
+    # Sentinel name matches per-rank format
+    assert f"SENTINEL_NAME={CHECKPOINT_INCOMPLETE_MARKER}.node-0-rank-0" in output
+    # Sentinel removed AFTER save (checkpoint is resume-ready)
+    assert "SENTINEL_REMOVED_AFTER_SAVE=True" in output
+    assert "TEST_COMPLETE=True" in output
+
+    print("test execution complete")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -3784,22 +3784,12 @@ def create_jit_manager():
     cb.on_train_begin(TrainingArguments(), TrainerState(), None)
     return cb.jit_manager
 
-# --- Test Path 1: Normal SIGTERM (no optimizer step, no periodic save) ---
+# --- Test Path 1: SIGTERM only sets flag (checkpoint deferred to callback) ---
 mgr = create_jit_manager()
 mgr._sigterm_handler(signal.SIGTERM, None)
 assert mgr.checkpoint_requested == True, "checkpoint_requested not set"
-assert mgr.trainer._save_checkpoint_called == True, "Path 1: _save_checkpoint should be called"
-assert mgr._checkpoint_deferred == False, "Path 1: should not defer"
-print("PATH_1_NORMAL=PASS")
-
-# --- Test Path 2: SIGTERM during optimizer step ---
-mgr2 = create_jit_manager()
-mgr2._in_optimizer_step = True
-mgr2._sigterm_handler(signal.SIGTERM, None)
-assert mgr2.checkpoint_requested == True, "checkpoint_requested not set"
-assert mgr2._checkpoint_deferred == True, "Path 2: should defer"
-assert mgr2.trainer._save_checkpoint_called == False, "Path 2: should NOT call _save_checkpoint"
-print("PATH_2_OPTIMIZER_STEP=PASS")
+assert mgr.trainer._save_checkpoint_called == False, "Path 1: signal handler should NOT call _save_checkpoint"
+print("PATH_1_FLAG_ONLY=PASS")
 
 # --- Test: Second SIGTERM is idempotent ---
 mgr4 = create_jit_manager()
@@ -3824,8 +3814,7 @@ print("TEST_COMPLETE=True")
         print(f"Test stderr:\n{result.stderr}")
 
     assert result.returncode == 0, f"Execution failed: {result.stderr}"
-    assert "PATH_1_NORMAL=PASS" in output
-    assert "PATH_2_OPTIMIZER_STEP=PASS" in output
+    assert "PATH_1_FLAG_ONLY=PASS" in output
     assert "IDEMPOTENT=PASS" in output
     assert "TEST_COMPLETE=True" in output
 
@@ -3833,13 +3822,12 @@ print("TEST_COMPLETE=True")
 
 
 def test_callback_guards_and_deferred_checkpoint(tmp_path):
-    """Test JITCheckpointCallback guards and deferred checkpoint processing.
+    """Test JITCheckpointCallback guards and checkpoint behavior.
 
     Verifies:
-    - on_step_end/on_epoch_end set should_save=False and should_training_stop=True
-      when checkpoint is in progress.
-    - on_optimizer_step processes deferred checkpoint.
-    - on_pre_optimizer_step sets _in_optimizer_step flag.
+    - on_step_end/on_epoch_end call _save_jit_checkpoint and set
+      should_save=False, should_training_stop=True when checkpoint in progress.
+    - on_optimizer_step only sets should_training_stop=True (no checkpoint).
     """
     print("Executing test: callback guards and deferred checkpoint")
 
@@ -3903,12 +3891,13 @@ class Trainer:
         self.callback_handler = CallbackHandler()
         self._init_args = args
         self._init_kwargs = kwargs
+        self._save_checkpoint_called = False
 
     def _get_output_dir(self, trial=None):
         return OUTPUT_DIR
 
     def _save_checkpoint(self, model, trial=None):
-        pass
+        self._save_checkpoint_called = True
 
     def train(self, resume_from_checkpoint=None):
         return {"train_called": True}
@@ -3965,7 +3954,7 @@ assert callback.jit_manager is not None, "JIT manager not created"
 args = TrainingArguments()
 state = TrainerState()
 
-# === Test 1: on_step_end guard when checkpoint in progress ===
+# === Test 1: on_step_end saves checkpoint and prevents redundant save ===
 callback.jit_manager.checkpoint_requested = True
 
 class MockControl:
@@ -3974,46 +3963,48 @@ class MockControl:
 
 control = MockControl()
 callback.on_step_end(args, state, control)
-assert control.should_save == False, "on_step_end should clear should_save"
 assert control.should_training_stop == True, "on_step_end should set should_training_stop"
+assert control.should_save == False, "on_step_end should set should_save=False to prevent redundant save"
+assert trainer._save_checkpoint_called == True, "on_step_end should call _save_jit_checkpoint"
 print("GUARD_ON_STEP_END=PASS")
 
-# === Test 2: on_epoch_end guard when checkpoint in progress ===
+# === Test 2: on_epoch_end saves checkpoint and prevents redundant save ===
+trainer2 = Trainer(None, TrainingArguments())
+trainer2._get_output_dir = lambda trial=None: OUTPUT_DIR
+trainer2._save_checkpoint_called = False
+callback2 = callback_class()
+callback2._trainer_ref = trainer2
+callback2.on_train_begin(TrainingArguments(), TrainerState(), None)
+callback2.jit_manager.checkpoint_requested = True
+
 control2 = MockControl()
 control2.should_save = True
 control2.should_training_stop = False
-callback.on_epoch_end(args, state, control2)
-assert control2.should_save == False, "on_epoch_end should clear should_save"
+callback2.on_epoch_end(args, state, control2)
 assert control2.should_training_stop == True, "on_epoch_end should set should_training_stop"
+assert control2.should_save == False, "on_epoch_end should set should_save=False to prevent redundant save"
+assert trainer2._save_checkpoint_called == True, "on_epoch_end should call _save_jit_checkpoint"
 print("GUARD_ON_EPOCH_END=PASS")
 
-# === Test 3: on_optimizer_step processes deferred checkpoint ===
-callback.jit_manager.checkpoint_requested = True
-callback.jit_manager._checkpoint_deferred = True
-callback.jit_manager._in_optimizer_step = True
+# === Test 3: on_optimizer_step only stops training (no checkpoint) ===
+trainer3 = Trainer(None, TrainingArguments())
+trainer3._get_output_dir = lambda trial=None: OUTPUT_DIR
+trainer3._save_checkpoint_called = False
+callback3 = callback_class()
+callback3._trainer_ref = trainer3
+callback3.on_train_begin(TrainingArguments(), TrainerState(), None)
+callback3.jit_manager.checkpoint_requested = True
 
 control6 = MockControl()
 control6.should_training_stop = False
-callback.on_optimizer_step(args, state, control6)
-assert callback.jit_manager._in_optimizer_step == False, (
-    "on_optimizer_step should clear _in_optimizer_step"
-)
-assert callback.jit_manager._checkpoint_deferred == False, (
-    "on_optimizer_step should clear _checkpoint_deferred"
-)
+callback3.on_optimizer_step(args, state, control6)
 assert control6.should_training_stop == True, (
-    "on_optimizer_step should stop training after deferred checkpoint"
+    "on_optimizer_step should stop training"
 )
-print("DEFERRED_CHECKPOINT_PROCESSED=PASS")
-
-# === Test 4: on_pre_optimizer_step sets _in_optimizer_step ===
-callback.jit_manager._in_optimizer_step = False
-control7 = MockControl()
-callback.on_pre_optimizer_step(args, state, control7)
-assert callback.jit_manager._in_optimizer_step == True, (
-    "on_pre_optimizer_step should set _in_optimizer_step"
+assert trainer3._save_checkpoint_called == False, (
+    "on_optimizer_step should NOT call _save_jit_checkpoint"
 )
-print("PRE_OPTIMIZER_STEP_FLAG=PASS")
+print("OPTIMIZER_STEP_GUARD=PASS")
 
 print("TEST_COMPLETE=True")
 """
@@ -4033,8 +4024,7 @@ print("TEST_COMPLETE=True")
     assert result.returncode == 0, f"Execution failed: {result.stderr}"
     assert "GUARD_ON_STEP_END=PASS" in output
     assert "GUARD_ON_EPOCH_END=PASS" in output
-    assert "DEFERRED_CHECKPOINT_PROCESSED=PASS" in output
-    assert "PRE_OPTIMIZER_STEP_FLAG=PASS" in output
+    assert "OPTIMIZER_STEP_GUARD=PASS" in output
     assert "TEST_COMPLETE=True" in output
 
     print("test execution complete")
@@ -4254,8 +4244,16 @@ cb.on_train_begin(TrainingArguments(), TrainerState(), None)
 mgr = cb.jit_manager
 assert mgr is not None, "JIT manager not created"
 
-# Trigger SIGTERM handler (will call _save_jit_checkpoint)
+# Trigger SIGTERM handler (sets checkpoint_requested flag)
 mgr._sigterm_handler(signal.SIGTERM, None)
+assert mgr.checkpoint_requested == True, "checkpoint_requested not set"
+
+# Simulate on_step_end which calls _save_jit_checkpoint
+from transformers import MockControl
+control = MockControl()
+cb.on_step_end(TrainingArguments(), TrainerState(), control)
+assert control.should_training_stop == True, "should_training_stop not set"
+assert control.should_save == False, "should_save should be False to prevent redundant save"
 
 # After _save_jit_checkpoint completes, verify sentinel is REMOVED
 checkpoint_path = os.path.join(OUTPUT_DIR, "checkpoint-10")

--- a/kubeflow/trainer/rhai/transformers_test.py
+++ b/kubeflow/trainer/rhai/transformers_test.py
@@ -3663,7 +3663,7 @@ def test_sigterm_handler_paths(tmp_path):
 
     output_dir = tmp_path / "checkpoints"
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_code, _ = get_jit_checkpoint_injection_code(
         output_dir=str(output_dir),
         enable_jit_checkpoint=True,
     )
@@ -3848,7 +3848,7 @@ def test_callback_guards_and_deferred_checkpoint(tmp_path):
 
     output_dir = tmp_path / "checkpoints"
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_code, _ = get_jit_checkpoint_injection_code(
         output_dir=str(output_dir),
         enable_jit_checkpoint=True,
     )
@@ -4117,7 +4117,7 @@ def test_sentinel_lifecycle_during_jit_checkpoint(tmp_path):
 
     output_dir = tmp_path / "checkpoints"
 
-    checkpoint_code = get_jit_checkpoint_injection_code(
+    checkpoint_code, _ = get_jit_checkpoint_injection_code(
         output_dir=str(output_dir),
         enable_jit_checkpoint=True,
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes [RHOAIENG-45711](https://issues.redhat.com/browse/RHOAIENG-45711)

Resume training fails because incomplete JIT checkpoints appear complete due to missing sentinel markers. Root cause: race conditions in distributed training during pause/preemption.

Changes

  - Remove checkpoint thread entirely: Replaced daemon thread with direct checkpoint call from SIGTERM handler. If SIGTERM arrives during an optimizer step (where direct checkpoint would deadlock), checkpoint is deferred to the on_optimizer_step callback via a _checkpoint_deferred flag.
  - Fix step desynchronization: Added barrier before reading global_step to ensure all ranks checkpoint at the same training step (prevents checkpoint-29 vs checkpoint-30 splits in multi node training)
  - Fix incomplete marker handling: All ranks now write/remove their own per-rank sentinel markers instead of only global rank 0
  - Fix barrier warnings: Added device specification to all dist.barrier() calls to eliminate PyTorch warnings
  - Exit process after JIT checkpoint: Added sys.exit(0) in on_train_end after checkpoint and S3 upload complete to prevent user code (e.g. trainer.save_model()) from running redundantly during graceful shutdown.
  
  
<img width="1467" height="524" alt="image" src="https://github.com/user-attachments/assets/c3b7a097-496c-400b-aa62-ac687a4fe365" />
<img width="1465" height="551" alt="image" src="https://github.com/user-attachments/assets/dea1f839-a2b6-474f-8431-859eaaa458a6" />
<img width="469" height="788" alt="image" src="https://github.com/user-attachments/assets/9e46ca72-821c-43fe-9dae-dcf9083c3d7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpointing now uses per-rank, per-node coordination to avoid cross-rank conflicts and incomplete saves.
  * Incomplete checkpoints are now detected and skipped to prevent partial restores.
  * Shutdown handling triggers synchronous checkpointing when safe and performs an early checkpoint if shutdown occurs during critical optimizer work to prevent deadlocks.
  * Synchronization tightened at init, save, download, and training start; CUDA-aware barriers avoid device-ID warnings.
  * Logs include node/local-rank context and clearer guidance for manual cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->