### PR TITLE
chore: allow the release branch to be an input param

### DIFF
--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Release version (e.g., v0.2.0+rhai0)'
         required: true
         type: string
+      branch:
+        description: "Release branch to create or update (e.g., release-0.2)"
+        required: true
+        type: string
       acknowledge_cve_risk:
         description: >-
           Set to true to proceed with the release even if Snyk detects
@@ -57,6 +61,7 @@ jobs:
         id: vars
         run: |
           VERSION="${{ github.event.inputs.version }}"
+          BRANCH="${{ github.event.inputs.branch }}"
 
           # Validate version format: vX.Y.Z+rhaiN
           if ! [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+\+rhai[0-9]+$ ]]; then
@@ -64,12 +69,13 @@ jobs:
             exit 1
           fi
 
+          if [[ -z "$BRANCH" ]]; then
+            echo "ERROR: Branch input must not be empty."
+            exit 1
+          fi
+
           # Extract upstream version (e.g., v0.2.0+rhai0 -> 0.2.0)
           UPSTREAM_VERSION=$(echo "$VERSION" | sed 's/^v//' | cut -d'+' -f1)
-
-          # Extract major.minor for branch name (e.g., 0.2.0 -> 0.2)
-          MAJOR_MINOR=$(echo "$UPSTREAM_VERSION" | cut -d. -f1,2)
-          BRANCH="release-$MAJOR_MINOR"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT


### PR DESCRIPTION
allow the release branch to be an input param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now requires explicit specification of the target release branch instead of auto-deriving it from version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->