### PR TITLE
fix: use kwargs unpacking in _render_user_func_code for dict func_args

### DIFF
--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -751,7 +751,7 @@ def _render_user_func_code(func: Callable, func_args: dict | None) -> tuple[str,
     if func_args is None:
         call_block = f"{func.__name__}()"
     elif isinstance(func_args, dict):
-        params_lines: list[str] = [f"{func.__name__}({{"]
+        params_lines: list[str] = [f"{func.__name__}(**{{"]
         for key, value in func_args.items():
             params_lines.append(f"    {repr(key)}: {repr(value)},")
         params_lines.append("})")

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -23,6 +23,7 @@ from kubeflow.trainer.constants import constants
 from kubeflow.trainer.rhai.traininghub import (
     TrainingHubAlgorithms,
     TrainingHubTrainer,
+    _render_user_func_code,
     get_training_hub_instrumentation_wrapper,
 )
 from kubeflow.trainer.test.common import SUCCESS, TestCase
@@ -935,6 +936,48 @@ def test_osft_algorithm_uses_python_entrypoint():
 
     assert "python" in command_str, f"OSFT should use python: {command_str}"
     assert "torchrun" not in command_str, f"OSFT should NOT use torchrun: {command_str}"
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dict func_args generates kwargs unpacking",
+            expected_status=SUCCESS,
+            config={"func_args": {"lr": 0.001, "batch_size": 32}},
+            expected_output=[
+                ("**{", True),
+                ("sample_func({", False),
+            ],
+        ),
+        TestCase(
+            name="None func_args generates no-arg call",
+            expected_status=SUCCESS,
+            config={"func_args": None},
+            expected_output=[
+                ("sample_func()", True),
+            ],
+        ),
+    ],
+)
+def test_render_user_func_code(test_case):
+    """Test _render_user_func_code generates correct function calls."""
+    print(f"Executing test: {test_case.name}")
+
+    def sample_func(lr, batch_size):
+        pass
+
+    code, func_file = _render_user_func_code(sample_func, test_case.config["func_args"])
+
+    for substring, should_contain in test_case.expected_output:
+        if should_contain:
+            assert substring in code, f"Expected '{substring}' in generated code, got:\n{code}"
+        else:
+            assert substring not in code, (
+                f"Did not expect '{substring}' in generated code, got:\n{code}"
+            )
 
     print("test execution complete")
 


### PR DESCRIPTION
## Summary

- `_render_user_func_code` in `traininghub.py` generated `my_func({"lr": 0.001})` — passing a dict as a positional arg instead of unpacking as kwargs. Functions with keyword parameters failed at runtime with `TypeError`.
- Fixed to generate `my_func(**{"lr": 0.001})`, matching the `TransformersTrainer` pattern in `transformers.py`.
- Added parametrized tests for `_render_user_func_code` covering dict and None func_args cases.

Resolves: [RHOAIENG-55051](https://redhat.atlassian.net/browse/RHOAIENG-55051)

## Test plan

- [x] New parametrized test `test_render_user_func_code` verifies `**{` is present in generated code for dict func_args
- [x] New test verifies `sample_func()` is generated when func_args is None
- [x] All existing traininghub tests pass (42 passed)
- [x] `make verify` passes (lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Training functions with dictionary-based parameters now receive their arguments as keyword arguments instead of being passed a single dictionary object.

* **Tests**
  * Added comprehensive test coverage for training function parameter passing to verify correct behavior with both dictionary and no-argument cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->