### PR TITLE
chore: add lora metrics file support

### DIFF
--- a/kubeflow/trainer/algorithms.py
+++ b/kubeflow/trainer/algorithms.py
@@ -142,7 +142,7 @@ ALGORITHMS: dict[str, AlgorithmSpec] = {
     ),
     "lora_sft": AlgorithmSpec(
         name="lora_sft",
-        metrics_file_patterns=(),  # LoRA uses HF Trainer logging, not JSONL metrics files
+        metrics_file_patterns=("training_metrics.jsonl",),
         validate=_no_op_validate,
         # LoRA expects to run inside a torchrun process
         entrypoint=constants.TORCH_COMMAND,
@@ -220,9 +220,9 @@ def get_algorithm_pod_metadata(name: str) -> dict:
         >>> metadata["metrics_file_rank0"]
         'training_params_and_metrics_global0.jsonl'
 
-        >>> metadata = get_algorithm_pod_metadata("lora_sft")  # No metrics
+        >>> metadata = get_algorithm_pod_metadata("lora_sft")
         >>> metadata["metrics_file_pattern"]
-        None
+        'training_metrics.jsonl'
     """
     # get_algorithm_spec() validates the name parameter
     spec = get_algorithm_spec(name)

--- a/kubeflow/trainer/algorithms_test.py
+++ b/kubeflow/trainer/algorithms_test.py
@@ -220,6 +220,12 @@ def test_all_algorithms_have_callable_validate():
             config={"algorithm": "osft"},
             expected_output="osft",
         ),
+        TestCase(
+            name="valid lora_sft algorithm returns spec",
+            expected_status=SUCCESS,
+            config={"algorithm": "lora_sft"},
+            expected_output="lora_sft",
+        ),
     ],
 )
 def test_get_algorithm_spec(test_case):
@@ -360,6 +366,33 @@ def test_get_algorithm_pod_metadata_osft():
     assert metadata["name"] == "osft"
     assert metadata["metrics_file_pattern"] == "training_metrics_*.jsonl"
     assert metadata["metrics_file_rank0"] == "training_metrics_0.jsonl"
+
+    print("test execution complete")
+
+
+def test_get_algorithm_pod_metadata_lora():
+    """Test get_algorithm_pod_metadata returns correct metadata for LoRA."""
+    print("Executing test: get_algorithm_pod_metadata_lora")
+
+    metadata = get_algorithm_pod_metadata("lora_sft")
+
+    assert metadata["name"] == "lora_sft"
+    assert metadata["metrics_file_pattern"] == "training_metrics.jsonl"
+    # No wildcard in pattern, so rank0 is the same as pattern
+    assert metadata["metrics_file_rank0"] == "training_metrics.jsonl"
+
+    print("test execution complete")
+
+
+def test_lora_metrics_patterns_match_constants():
+    """Test that LoRA metrics patterns match the expected file pattern."""
+    print("Executing test: lora_metrics_patterns_match_constants")
+
+    spec = get_algorithm_spec("lora_sft")
+    patterns = list(spec.metrics_file_patterns)
+
+    # LoRA produces training_metrics.jsonl (no wildcard, single file)
+    assert "training_metrics.jsonl" in patterns
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -415,6 +415,8 @@ def _create_training_hub_progression_instrumentation(
             percent_int = int(round(progress))
             if current_step_absolute < step_total:
                 percent_int = min(99, percent_int)
+            else:
+                percent_int = min(100, percent_int)
 
             time_per_batch = metrics.get("time_per_batch", 0)
             remaining_steps = step_total - current_step_absolute
@@ -495,6 +497,8 @@ def _create_training_hub_progression_instrumentation(
             percent_int = int(round(progress))
             if current_step_absolute < step_total:
                 percent_int = min(99, percent_int)
+            else:
+                percent_int = min(100, percent_int)
 
             throughput = metrics.get("overall_throughput", 0)
             remaining_steps = step_total - current_step_absolute
@@ -533,18 +537,24 @@ def _create_training_hub_progression_instrumentation(
             """Transform LoRA SFT schema to controller-compatible format.
 
             LoRA metrics format (from training_metrics.jsonl):
-                {"step": 1, "epoch": 0.015625, "loss": 4.2727, "learning_rate": 2e-6,
-                 "max_steps": 100}
+                {"step": 1, "epoch": 0.015625, "loss": 4.2727, "learning_rate": 2e-6}
+
+            max_steps is optionally present when the training_hub callback
+            includes it (via state.max_steps). When absent, progressPercentage
+            is reported as None (unknown) rather than 0.
             """
             step = metrics.get("step", 0)
             epoch = metrics.get("epoch", 0)
-            max_steps = metrics.get("max_steps", 0)
+            max_steps = metrics.get("max_steps")
 
-            # Calculate progress based on steps, clamping to 99 until final step
-            progress = (step / max_steps * 100) if max_steps > 0 else 0
-            percent_int = int(round(progress))
-            if step < max_steps:
-                percent_int = min(99, percent_int)
+            # Calculate progress based on steps, clamping to 99 until final step.
+            # When max_steps is unavailable, report None (unknown) instead of 0.
+            if max_steps and max_steps > 0:
+                progress = step / max_steps * 100
+                percent_int = int(round(progress))
+                percent_int = min(99, percent_int) if step < max_steps else min(100, percent_int)
+            else:
+                percent_int = None
 
             loss_val = metrics.get("loss")
             lr_val = metrics.get("learning_rate")
@@ -554,7 +564,7 @@ def _create_training_hub_progression_instrumentation(
                 "progressPercentage": percent_int,
                 "estimatedRemainingSeconds": None,
                 "currentStep": step,
-                "totalSteps": max_steps if max_steps > 0 else None,
+                "totalSteps": max_steps if max_steps else None,
                 "currentEpoch": max(1, math.ceil(epoch)),
                 "totalEpochs": None,
                 "trainMetrics": {

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -410,12 +410,15 @@ def _create_training_hub_progression_instrumentation(
             step_total = steps_per_epoch * total_epochs if steps_per_epoch > 0 else 0
 
             current_step_absolute = step
-            percent = min(100, (current_step_absolute / step_total * 100)) if step_total > 0 else 0
+            progress = (current_step_absolute / step_total * 100) if step_total > 0 else 0
+            percent_int = int(round(progress))
+            if current_step_absolute < step_total:
+                percent_int = min(99, percent_int)
 
             time_per_batch = metrics.get("time_per_batch", 0)
             remaining_steps = step_total - current_step_absolute
 
-            if percent >= 100 or remaining_steps <= 0:
+            if percent_int >= 100 or remaining_steps <= 0:
                 estimated_remaining_sec = 0
             else:
                 estimated_remaining_sec = (
@@ -429,7 +432,7 @@ def _create_training_hub_progression_instrumentation(
             val_loss_val = metrics.get("val_loss")
 
             return {
-                "progressPercentage": int(round(percent)),
+                "progressPercentage": percent_int,
                 "estimatedRemainingSeconds": estimated_remaining_sec,
                 "currentStep": current_step_absolute,
                 "totalSteps": step_total,
@@ -487,12 +490,15 @@ def _create_training_hub_progression_instrumentation(
             else:
                 step_total = max(step, step + 10)
 
-            percent = min(100, (current_step_absolute / step_total * 100)) if step_total > 0 else 0
+            progress = (current_step_absolute / step_total * 100) if step_total > 0 else 0
+            percent_int = int(round(progress))
+            if current_step_absolute < step_total:
+                percent_int = min(99, percent_int)
 
             throughput = metrics.get("overall_throughput", 0)
             remaining_steps = step_total - current_step_absolute
 
-            if percent >= 100 or remaining_steps <= 0:
+            if percent_int >= 100 or remaining_steps <= 0:
                 estimated_remaining_sec = 0
             else:
                 estimated_remaining_sec = (
@@ -507,7 +513,7 @@ def _create_training_hub_progression_instrumentation(
             throughput_val = metrics.get("overall_throughput")
 
             return {
-                "progressPercentage": int(round(percent)),
+                "progressPercentage": percent_int,
                 "estimatedRemainingSeconds": estimated_remaining_sec,
                 "currentStep": current_step_absolute,
                 "totalSteps": step_total,
@@ -533,15 +539,18 @@ def _create_training_hub_progression_instrumentation(
             epoch = metrics.get("epoch", 0)
             max_steps = metrics.get("max_steps", 0)
 
-            # Calculate progress based on steps
-            percent = min(100, step / max_steps * 100) if max_steps > 0 else 0
+            # Calculate progress based on steps, clamping to 99 until final step
+            progress = (step / max_steps * 100) if max_steps > 0 else 0
+            percent_int = int(round(progress))
+            if step < max_steps:
+                percent_int = min(99, percent_int)
 
             loss_val = metrics.get("loss")
             lr_val = metrics.get("learning_rate")
             grad_norm_val = metrics.get("grad_norm")
 
             return {
-                "progressPercentage": int(round(percent)),
+                "progressPercentage": percent_int,
                 "estimatedRemainingSeconds": None,
                 "currentStep": step,
                 "totalSteps": max_steps if max_steps > 0 else None,

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -143,6 +143,7 @@ def _create_training_hub_progression_instrumentation(
     import glob
     import http.server
     import json
+    import math
     import os
     import subprocess
     import threading
@@ -554,7 +555,7 @@ def _create_training_hub_progression_instrumentation(
                 "estimatedRemainingSeconds": None,
                 "currentStep": step,
                 "totalSteps": max_steps if max_steps > 0 else None,
-                "currentEpoch": int(epoch) + 1,
+                "currentEpoch": max(1, math.ceil(epoch)),
                 "totalEpochs": None,
                 "trainMetrics": {
                     "loss": f"{loss_val:.4f}" if loss_val is not None else None,

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -219,6 +219,8 @@ def _create_training_hub_progression_instrumentation(
                 return self._read_sft_metrics()
             elif algorithm == "osft":
                 return self._read_osft_metrics()
+            elif algorithm == "lora_sft":
+                return self._read_lora_sft_metrics()
             else:
                 # Algorithm not yet supported for metrics reading
                 return {}
@@ -332,6 +334,44 @@ def _create_training_hub_progression_instrumentation(
 
             return {}
 
+        def _read_lora_sft_metrics(self):
+            """Read LoRA SFT metrics from training_metrics.jsonl.
+
+            LoRA writes a single metrics file (no per-rank wildcard).
+            Each line is a JSON object with step, epoch, loss, learning_rate.
+            """
+            metrics_file = f"{ckpt_output_dir}/{metrics_file_rank0}"
+
+            try:
+                if not os.path.exists(metrics_file):
+                    return {}
+
+                # Read last line of metrics using tail
+                try:
+                    result = subprocess.run(
+                        ["tail", "-n", "1", metrics_file],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                    )
+                    last_line = result.stdout.strip()
+                except subprocess.CalledProcessError:
+                    return {}
+
+                if last_line:
+                    return json.loads(last_line)
+
+            except FileNotFoundError:
+                return {}
+            except json.JSONDecodeError:
+                print("[Kubeflow] Warning: Failed to parse LoRA metrics JSON", flush=True)
+                return {}
+            except Exception:
+                print("[Kubeflow] Error reading LoRA metrics", flush=True)
+                return {}
+
+            return {}
+
         def _transform_schema(self, metrics):
             """Transform backend schema to controller-compatible progress format."""
             if not metrics:
@@ -351,8 +391,9 @@ def _create_training_hub_progression_instrumentation(
                 return self._transform_sft(metrics)
             elif algorithm == "osft":
                 return self._transform_osft(metrics)
+            elif algorithm == "lora_sft":
+                return self._transform_lora_sft(metrics)
             else:
-                # Algorithms without metrics files (e.g., lora_sft) return empty dict
                 return {}
 
         def _transform_osft(self, metrics):
@@ -477,6 +518,39 @@ def _create_training_hub_progression_instrumentation(
                     "learning_rate": f"{lr_val:.6f}" if lr_val is not None else None,
                     "grad_norm": f"{grad_norm_val:.4f}" if grad_norm_val is not None else None,
                     "throughput": f"{throughput_val:.2f}" if throughput_val is not None else None,
+                },
+                "evalMetrics": {},
+            }
+
+        def _transform_lora_sft(self, metrics):
+            """Transform LoRA SFT schema to controller-compatible format.
+
+            LoRA metrics format (from training_metrics.jsonl):
+                {"step": 1, "epoch": 0.015625, "loss": 4.2727, "learning_rate": 2e-6,
+                 "max_steps": 100}
+            """
+            step = metrics.get("step", 0)
+            epoch = metrics.get("epoch", 0)
+            max_steps = metrics.get("max_steps", 0)
+
+            # Calculate progress based on steps
+            percent = min(100, step / max_steps * 100) if max_steps > 0 else 0
+
+            loss_val = metrics.get("loss")
+            lr_val = metrics.get("learning_rate")
+            grad_norm_val = metrics.get("grad_norm")
+
+            return {
+                "progressPercentage": int(round(percent)),
+                "estimatedRemainingSeconds": None,
+                "currentStep": step,
+                "totalSteps": max_steps if max_steps > 0 else None,
+                "currentEpoch": int(epoch) + 1,
+                "totalEpochs": None,
+                "trainMetrics": {
+                    "loss": f"{loss_val:.4f}" if loss_val is not None else None,
+                    "learning_rate": f"{lr_val:.6f}" if lr_val is not None else None,
+                    "grad_norm": f"{grad_norm_val:.4f}" if grad_norm_val is not None else None,
                 },
                 "evalMetrics": {},
             }
@@ -616,7 +690,7 @@ def _render_algorithm_wrapper(algorithm_metadata: dict, func_args: dict | None) 
         import json
         import os
 
-        # Skip termination message for algorithms without metrics files (e.g., LoRA)
+        # Skip termination message for algorithms without metrics files
         if metrics_file_rank0 is None:
             print(
                 "[Kubeflow] Algorithm produces no metrics files - skipping termination message",

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -362,8 +362,6 @@ def _create_training_hub_progression_instrumentation(
                 if last_line:
                     return json.loads(last_line)
 
-            except FileNotFoundError:
-                return {}
             except json.JSONDecodeError:
                 print("[Kubeflow] Warning: Failed to parse LoRA metrics JSON", flush=True)
                 return {}

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -980,6 +980,8 @@ def test_render_user_func_code(test_case):
             assert substring not in code, (
                 f"Did not expect '{substring}' in generated code, got:\n{code}"
             )
+
+
 def test_instrumentation_cleans_lora_metrics_on_startup(tmp_path):
     """Test that LoRA metrics files are cleaned before training starts."""
     print("Executing test: LoRA metrics cleanup on startup")
@@ -1096,6 +1098,78 @@ def test_lora_metrics_transformer(tmp_path):
     assert result["trainMetrics"]["learning_rate"] == "0.000002"
     assert result["trainMetrics"]["grad_norm"] == "1.5678"
     assert result["evalMetrics"] == {}
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="step == max_steps - 1 must not reach 100%",
+            expected_status=SUCCESS,
+            config={
+                "step": 99,
+                "epoch": 0.99,
+                "loss": 1.0,
+                "learning_rate": 1e-6,
+                "grad_norm": 0.5,
+                "max_steps": 100,
+            },
+            expected_output=99,
+        ),
+        TestCase(
+            name="step == max_steps reports exactly 100%",
+            expected_status=SUCCESS,
+            config={
+                "step": 100,
+                "epoch": 1.0,
+                "loss": 0.5,
+                "learning_rate": 1e-6,
+                "grad_norm": 0.3,
+                "max_steps": 100,
+            },
+            expected_output=100,
+        ),
+        TestCase(
+            name="step 1 of 1 reports 100%",
+            expected_status=SUCCESS,
+            config={
+                "step": 1,
+                "epoch": 1.0,
+                "loss": 0.5,
+                "learning_rate": 1e-6,
+                "grad_norm": 0.3,
+                "max_steps": 1,
+            },
+            expected_output=100,
+        ),
+    ],
+)
+def test_lora_progress_clamped_below_100_until_final_step(test_case, tmp_path):
+    """Regression: progressPercentage must not reach 100 before the final step."""
+    print(f"Executing test: {test_case.name}")
+
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
+    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
+        algorithm_metadata=algorithm_metadata,
+        ckpt_output_dir=str(ckpt_dir),
+        metrics_port=0,
+    )
+
+    handler = handler_class.__new__(handler_class)
+    result = handler._transform_schema(test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+    assert result["progressPercentage"] == test_case.expected_output, (
+        f"Expected {test_case.expected_output}%, got {result['progressPercentage']}%"
+    )
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -250,9 +250,11 @@ def test_metrics_port_validation(test_case):
                 ("def _read_latest_metrics", True),
                 ("def _read_osft_metrics", True),
                 ("def _read_sft_metrics", True),
+                ("def _read_lora_sft_metrics", True),
                 ("def _transform_schema", True),
                 ("def _transform_osft", True),
                 ("def _transform_sft", True),
+                ("def _transform_lora_sft", True),
                 ("def do_GET", True),
             ],
         ),
@@ -978,6 +980,151 @@ def test_render_user_func_code(test_case):
             assert substring not in code, (
                 f"Did not expect '{substring}' in generated code, got:\n{code}"
             )
+def test_instrumentation_cleans_lora_metrics_on_startup(tmp_path):
+    """Test that LoRA metrics files are cleaned before training starts."""
+    print("Executing test: LoRA metrics cleanup on startup")
+
+    # Create stale metrics file (LoRA uses a single file, no per-rank wildcard)
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    stale_metrics_file = ckpt_dir / "training_metrics.jsonl"
+    stale_metrics_file.write_text('{"step": 50, "loss": 1.2}\n')
+
+    # Call instrumentation directly (no exec) with port 0 for random available port
+    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
+    apply_fn, _handler = _create_training_hub_progression_instrumentation(
+        algorithm_metadata=algorithm_metadata,
+        ckpt_output_dir=str(ckpt_dir),
+        metrics_port=0,  # Use port 0 for random available port
+    )
+
+    # Set JOB_COMPLETION_INDEX=0 to simulate primary pod (required for cleanup)
+    with patch.dict(os.environ, {"JOB_COMPLETION_INDEX": "0"}):
+        # Call the function to trigger cleanup and start server
+        server = apply_fn()
+
+        try:
+            # Verify stale metrics file was removed
+            assert not stale_metrics_file.exists(), "Stale LoRA metrics file should be removed"
+        finally:
+            # Always shut down server to avoid port conflicts
+            if server:
+                server.shutdown()
+
+    print("test execution complete")
+
+
+def test_lora_metrics_reader(tmp_path):
+    """Test that LoRA metrics reader correctly reads training_metrics.jsonl."""
+    print("Executing test: LoRA metrics reader")
+
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    # Write metrics file with multiple lines (reader should return last line)
+    metrics_file = ckpt_dir / "training_metrics.jsonl"
+    metrics_file.write_text(
+        '{"step": 1, "epoch": 0.01, "loss": 4.27, "learning_rate": 2e-6}\n'
+        '{"step": 2, "epoch": 0.02, "loss": 3.85, "learning_rate": 2e-6}\n'
+    )
+
+    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
+    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
+        algorithm_metadata=algorithm_metadata,
+        ckpt_output_dir=str(ckpt_dir),
+        metrics_port=0,
+    )
+
+    # Create handler instance to test reader method
+    # handler_class is the TrainingHubMetricsHandler class
+    # We can call _read_latest_metrics and _transform_schema as unbound-style
+    # by creating a minimal instance
+    handler = handler_class.__new__(handler_class)
+    metrics = handler._read_latest_metrics()
+
+    assert metrics["step"] == 2
+    assert metrics["epoch"] == 0.02
+    assert metrics["loss"] == 3.85
+
+    print("test execution complete")
+
+
+def test_lora_metrics_transformer(tmp_path):
+    """Test that LoRA metrics transformer produces correct controller format."""
+    print("Executing test: LoRA metrics transformer")
+
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
+    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
+        algorithm_metadata=algorithm_metadata,
+        ckpt_output_dir=str(ckpt_dir),
+        metrics_port=0,
+    )
+
+    handler = handler_class.__new__(handler_class)
+
+    # Test with typical LoRA metrics
+    metrics = {
+        "step": 50,
+        "epoch": 0.5,
+        "loss": 2.1234,
+        "learning_rate": 0.000002,
+        "grad_norm": 1.5678,
+        "max_steps": 100,
+    }
+
+    result = handler._transform_schema(metrics)
+
+    assert result["progressPercentage"] == 50
+    assert result["currentStep"] == 50
+    assert result["totalSteps"] == 100
+    assert result["currentEpoch"] == 1
+    assert result["totalEpochs"] is None
+    assert result["trainMetrics"]["loss"] == "2.1234"
+    assert result["trainMetrics"]["learning_rate"] == "0.000002"
+    assert result["trainMetrics"]["grad_norm"] == "1.5678"
+    assert result["evalMetrics"] == {}
+
+    print("test execution complete")
+
+
+def test_lora_metrics_transformer_empty_metrics(tmp_path):
+    """Test that LoRA metrics transformer handles empty metrics correctly."""
+    print("Executing test: LoRA metrics transformer with empty metrics")
+
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
+    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
+        algorithm_metadata=algorithm_metadata,
+        ckpt_output_dir=str(ckpt_dir),
+        metrics_port=0,
+    )
+
+    handler = handler_class.__new__(handler_class)
+
+    # Empty metrics should return null progress
+    result = handler._transform_schema({})
+
+    assert result["progressPercentage"] is None
+    assert result["currentStep"] is None
+    assert result["trainMetrics"] is None
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -1144,6 +1144,17 @@ def test_lora_metrics_transformer(tmp_path):
             },
             expected_output=100,
         ),
+        TestCase(
+            name="missing max_steps reports None (unknown progress)",
+            expected_status=SUCCESS,
+            config={
+                "step": 50,
+                "epoch": 0.5,
+                "loss": 2.0,
+                "learning_rate": 1e-6,
+            },
+            expected_output=None,
+        ),
     ],
 )
 def test_lora_progress_clamped_below_100_until_final_step(test_case, tmp_path):

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -19,10 +19,12 @@ from unittest.mock import patch
 
 import pytest
 
+from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.rhai.traininghub import (
     TrainingHubAlgorithms,
     TrainingHubTrainer,
+    _create_training_hub_progression_instrumentation,
     _render_user_func_code,
     get_training_hub_instrumentation_wrapper,
 )
@@ -982,27 +984,36 @@ def test_render_user_func_code(test_case):
             )
 
 
-def test_instrumentation_cleans_lora_metrics_on_startup(tmp_path):
-    """Test that LoRA metrics files are cleaned before training starts."""
-    print("Executing test: LoRA metrics cleanup on startup")
+@pytest.fixture
+def lora_handler(tmp_path):
+    """Create a LoRA metrics handler for testing.
 
-    # Create stale metrics file (LoRA uses a single file, no per-rank wildcard)
+    Returns:
+        Tuple of (apply_fn, handler_instance, ckpt_dir).
+    """
     ckpt_dir = tmp_path / "checkpoints"
     ckpt_dir.mkdir()
 
-    stale_metrics_file = ckpt_dir / "training_metrics.jsonl"
-    stale_metrics_file.write_text('{"step": 50, "loss": 1.2}\n')
-
-    # Call instrumentation directly (no exec) with port 0 for random available port
-    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
-    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
-
     algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
-    apply_fn, _handler = _create_training_hub_progression_instrumentation(
+    apply_fn, handler_class = _create_training_hub_progression_instrumentation(
         algorithm_metadata=algorithm_metadata,
         ckpt_output_dir=str(ckpt_dir),
-        metrics_port=0,  # Use port 0 for random available port
+        metrics_port=0,
     )
+
+    handler = handler_class.__new__(handler_class)
+    return apply_fn, handler, ckpt_dir
+
+
+def test_instrumentation_cleans_lora_metrics_on_startup(lora_handler):
+    """Test that LoRA metrics files are cleaned before training starts."""
+    print("Executing test: LoRA metrics cleanup on startup")
+
+    apply_fn, _handler, ckpt_dir = lora_handler
+
+    # Create stale metrics file (LoRA uses a single file, no per-rank wildcard)
+    stale_metrics_file = ckpt_dir / "training_metrics.jsonl"
+    stale_metrics_file.write_text('{"step": 50, "loss": 1.2}\n')
 
     # Set JOB_COMPLETION_INDEX=0 to simulate primary pod (required for cleanup)
     with patch.dict(os.environ, {"JOB_COMPLETION_INDEX": "0"}):
@@ -1020,12 +1031,11 @@ def test_instrumentation_cleans_lora_metrics_on_startup(tmp_path):
     print("test execution complete")
 
 
-def test_lora_metrics_reader(tmp_path):
+def test_lora_metrics_reader(lora_handler):
     """Test that LoRA metrics reader correctly reads training_metrics.jsonl."""
     print("Executing test: LoRA metrics reader")
 
-    ckpt_dir = tmp_path / "checkpoints"
-    ckpt_dir.mkdir()
+    _apply_fn, handler, ckpt_dir = lora_handler
 
     # Write metrics file with multiple lines (reader should return last line)
     metrics_file = ckpt_dir / "training_metrics.jsonl"
@@ -1034,21 +1044,6 @@ def test_lora_metrics_reader(tmp_path):
         '{"step": 2, "epoch": 0.02, "loss": 3.85, "learning_rate": 2e-6}\n'
     )
 
-    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
-    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
-
-    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
-    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
-        algorithm_metadata=algorithm_metadata,
-        ckpt_output_dir=str(ckpt_dir),
-        metrics_port=0,
-    )
-
-    # Create handler instance to test reader method
-    # handler_class is the TrainingHubMetricsHandler class
-    # We can call _read_latest_metrics and _transform_schema as unbound-style
-    # by creating a minimal instance
-    handler = handler_class.__new__(handler_class)
     metrics = handler._read_latest_metrics()
 
     assert metrics["step"] == 2
@@ -1058,24 +1053,11 @@ def test_lora_metrics_reader(tmp_path):
     print("test execution complete")
 
 
-def test_lora_metrics_transformer(tmp_path):
+def test_lora_metrics_transformer(lora_handler):
     """Test that LoRA metrics transformer produces correct controller format."""
     print("Executing test: LoRA metrics transformer")
 
-    ckpt_dir = tmp_path / "checkpoints"
-    ckpt_dir.mkdir()
-
-    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
-    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
-
-    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
-    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
-        algorithm_metadata=algorithm_metadata,
-        ckpt_output_dir=str(ckpt_dir),
-        metrics_port=0,
-    )
-
-    handler = handler_class.__new__(handler_class)
+    _apply_fn, handler, _ckpt_dir = lora_handler
 
     # Test with typical LoRA metrics
     metrics = {
@@ -1157,24 +1139,12 @@ def test_lora_metrics_transformer(tmp_path):
         ),
     ],
 )
-def test_lora_progress_clamped_below_100_until_final_step(test_case, tmp_path):
+def test_lora_progress_clamped_below_100_until_final_step(test_case, lora_handler):
     """Regression: progressPercentage must not reach 100 before the final step."""
     print(f"Executing test: {test_case.name}")
 
-    ckpt_dir = tmp_path / "checkpoints"
-    ckpt_dir.mkdir()
+    _apply_fn, handler, _ckpt_dir = lora_handler
 
-    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
-    from kubeflow.trainer.rhai.traininghub import _create_training_hub_progression_instrumentation
-
-    algorithm_metadata = get_algorithm_pod_metadata("lora_sft")
-    _apply_fn, handler_class = _create_training_hub_progression_instrumentation(
-        algorithm_metadata=algorithm_metadata,
-        ckpt_output_dir=str(ckpt_dir),
-        metrics_port=0,
-    )
-
-    handler = handler_class.__new__(handler_class)
     result = handler._transform_schema(test_case.config)
 
     assert test_case.expected_status == SUCCESS


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following on from training hub [PR #40](https://github.com/Red-Hat-AI-Innovation-Team/training_hub/pull/40) this PR adds LoRA metrics file support.

Summary
- Add LoRA metrics file support (training_metrics.jsonl) to the algorithm registry, enabling progression tracking for LoRA training jobs 
- Add _read_lora_sft_metrics and _transform_lora_sft methods for reading and transforming LoRA metrics to the controller-compatible progress format
- Update docstrings and comments that referenced LoRA as having no metrics

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes # [RHOAIENG-49760](https://redhat.atlassian.net/browse/RHOAIENG-49760) 

**Verification steps** _(required; provide valid, reproducible steps for reviewers to verify your changes, e.g. setup, commands, expected outcome, notebooks)_:

Verified on team cluster via notebook using this branch. 
<img width="1114" height="937" alt="Screenshot 2026-03-26 at 16 12 48" src="https://github.com/user-attachments/assets/bbd9af0a-d328-44e3-83fd-48c3925f770a" />
Tested: 
 - addition of file when none exists 
 - removal of existing file and addition of new one
 
Can be tested using this notebook:
[test_lora_metrics.ipynb](https://github.com/user-attachments/files/26281458/test_lora_metrics.ipynb)



**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metrics tracking for LoRA SFT so controllers can read training metrics and report progress.

* **Improvements**
  * Progress reporting now rounds and clamps percentages (remains <100% until final step) and handles missing/malformed metrics gracefully.
  * Wrapper startup now removes stale single-file metrics before processing.

* **Tests**
  * Expanded tests for LoRA: metrics reading, transformation, progress clamping, startup cleanup and completeness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->