### PR TITLE
feat: pin dependency versions in release workflow

### DIFF
--- a/.github/scripts/pin_dependencies.py
+++ b/.github/scripts/pin_dependencies.py
@@ -11,6 +11,13 @@ The [dependency-groups] section is not modified (dev deps stay unpinned).
 Requires Python >= 3.11 (for tomllib). This script is only invoked in CI
 where Python 3.11+ is guaranteed by the workflow's setup-python step.
 
+Limitation: This script uses line-based regex parsing for pyproject.toml because
+Python's stdlib tomllib is read-only (no write support). This assumes one
+dependency per line and may break on valid TOML constructs like multi-line
+dependency strings, inline tables, or single-line arrays (e.g.,
+dependencies = ["kubernetes>=1.0"]). This is acceptable for a CI-only script
+operating on a controlled pyproject.toml.
+
 Usage:
     python pin_dependencies.py [--pyproject pyproject.toml] [--lockfile uv.lock]
 """

--- a/.github/scripts/pin_dependencies.py
+++ b/.github/scripts/pin_dependencies.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Pin dependency versions in pyproject.toml from uv.lock.
+
+Reads the resolved versions from uv.lock and replaces version specifiers
+in pyproject.toml's [project.dependencies] and [project.optional-dependencies]
+with exact == pins. Environment markers and extras are preserved.
+
+The [dependency-groups] section is not modified (dev deps stay unpinned).
+
+Requires Python >= 3.11 (for tomllib). This script is only invoked in CI
+where Python 3.11+ is guaranteed by the workflow's setup-python step.
+
+Usage:
+    python pin_dependencies.py [--pyproject pyproject.toml] [--lockfile uv.lock]
+"""
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+import tomllib
+
+
+def normalize_name(name: str) -> str:
+    """Normalize a package name per PEP 503.
+
+    Args:
+        name: The package name to normalize.
+
+    Returns:
+        Lowercase name with runs of [-_.] replaced by a single hyphen.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def parse_lock_versions(lock_path: Path) -> dict[str, str]:
+    """Build a package-name-to-version map from uv.lock.
+
+    For packages with multiple resolved versions (different Python markers),
+    the version compatible with Python >= 3.10 is preferred.
+
+    Args:
+        lock_path: Path to the uv.lock file.
+
+    Returns:
+        Dict mapping normalized package names to their resolved version strings.
+    """
+    with open(lock_path, "rb") as f:
+        lock_data = tomllib.load(f)
+
+    # Collect all versions per package: {normalized_name: [(version, markers)]}
+    packages: dict[str, list[tuple[str, list[str] | None]]] = {}
+    for pkg in lock_data.get("package", []):
+        # Skip packages without a version (e.g., editable/workspace packages).
+        if "version" not in pkg:
+            continue
+        name = normalize_name(pkg["name"])
+        version = pkg["version"]
+        markers = pkg.get("resolution-markers")
+        packages.setdefault(name, []).append((version, markers))
+
+    # Resolve to a single version per package
+    resolved: dict[str, str] = {}
+    for name, versions in packages.items():
+        if len(versions) == 1:
+            resolved[name] = versions[0][0]
+            continue
+
+        # Multiple versions: pick the one compatible with Python >= 3.10.
+        # Exclude versions whose markers are exclusively for Python < 3.10.
+        for version, markers in versions:
+            if markers is None:
+                # No markers means universal — use it.
+                resolved[name] = version
+                break
+            # Check if any marker includes Python >= 3.10.
+            has_compat_marker = False
+            for marker in markers:
+                # Markers that restrict to old Python look like:
+                #   "python_full_version < '3.10'"
+                # We want markers that don't exclude >= 3.10.
+                if not re.search(r"python_full_version\s*<\s*'3\.10'", marker):
+                    has_compat_marker = True
+                    break
+            if has_compat_marker:
+                resolved[name] = version
+                break
+
+        # No compatible version found — warn and skip.
+        if name not in resolved:
+            print(
+                f"WARNING: No Python >=3.10 compatible version found for '{name}' "
+                f"in lock file. Available versions: "
+                f"{', '.join(v for v, _ in versions)}",
+                file=sys.stderr,
+            )
+
+    return resolved
+
+
+def pin_dependencies(pyproject_path: Path, lock_path: Path) -> list[str]:
+    """Pin dependency versions in pyproject.toml using resolved versions from uv.lock.
+
+    Only modifies [project.dependencies] and [project.optional-dependencies].
+    The [dependency-groups] section is left untouched.
+
+    Args:
+        pyproject_path: Path to pyproject.toml.
+        lock_path: Path to uv.lock.
+
+    Returns:
+        List of pinned dependency descriptions (for logging).
+
+    Raises:
+        SystemExit: If a dependency cannot be found in the lock file.
+    """
+    resolved = parse_lock_versions(lock_path)
+    content = pyproject_path.read_text()
+
+    # Regex to match a quoted dependency string with a version specifier.
+    # Captures: name (with optional extras), version operator+specifier, rest (marker etc.)
+    # Example: "kubernetes>=27.2.0" or "fsspec>=2025.3.0" or "pkg[extra]>=1.0; marker"
+    # NOTE: URL-based deps (e.g., "pkg @ https://...") and bare names without version
+    # specifiers are intentionally not matched and will be left unchanged.
+    dep_pattern = re.compile(
+        r'"'
+        r"(?P<name>[a-zA-Z0-9][-a-zA-Z0-9_.]*(?:\[[^\]]*\])?)"  # name with optional extras
+        r"(?P<verspec>[><=!~][^;\"]*?)"  # version specifier(s)
+        r"(?P<rest>;[^\"]*)?"  # optional environment markers
+        r'"'
+    )
+
+    pinned_deps: list[str] = []
+    errors: list[str] = []
+
+    # Track which TOML section we're in.
+    # "project" = [project] section (contains dependencies = [...])
+    # "optional" = [project.optional-dependencies] section
+    # "depgroups" = [dependency-groups] section (skip)
+    # "other" = any other section
+    current_section = "other"
+    in_dep_array = False  # True when inside a dependencies = [ ... ] array
+
+    lines = content.split("\n")
+    result_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Detect TOML section headers like [project], [project.optional-dependencies], etc.
+        section_match = re.match(r"^\[\s*([a-zA-Z0-9._-]+)\s*\]", stripped)
+        if section_match:
+            section_name = section_match.group(1)
+            if section_name == "project":
+                current_section = "project"
+            elif section_name == "project.optional-dependencies":
+                current_section = "optional"
+            elif section_name == "dependency-groups":
+                current_section = "depgroups"
+            else:
+                current_section = "other"
+            in_dep_array = False
+
+        # Detect start of a dependency array (e.g., "dependencies = [" or "docker = [")
+        if current_section in ("project", "optional") and re.match(
+            r"^[a-zA-Z_-]+\s*=\s*\[", stripped
+        ):
+            in_dep_array = True
+
+        # Detect end of array.
+        if in_dep_array and stripped == "]":
+            in_dep_array = False
+
+        # Skip dependency-groups entirely.
+        if current_section == "depgroups":
+            result_lines.append(line)
+            continue
+
+        # Only process lines inside dependency arrays in project/optional sections.
+        if not in_dep_array:
+            result_lines.append(line)
+            continue
+
+        # Check if this line has a dependency string to pin.
+        match = dep_pattern.search(line)
+        if match:
+            raw_name = match.group("name")
+            verspec = match.group("verspec")
+            rest = match.group("rest") or ""
+
+            # Extract the bare name (without extras) for lookup.
+            bare_name = re.sub(r"\[.*\]", "", raw_name)
+            normalized = normalize_name(bare_name)
+
+            if normalized not in resolved:
+                errors.append(f"Package '{bare_name}' not found in {lock_path}")
+                result_lines.append(line)
+                continue
+
+            pinned_version = resolved[normalized]
+
+            # Skip if already pinned to the exact version.
+            if verspec.strip() == f"=={pinned_version}":
+                result_lines.append(line)
+                continue
+
+            # Build the new dependency string.
+            new_dep = f'"{raw_name}=={pinned_version}{rest}"'
+            new_line = line[: match.start()] + new_dep + line[match.end() :]
+            result_lines.append(new_line)
+            pinned_deps.append(f"{bare_name}: {verspec.strip()} -> =={pinned_version}")
+        else:
+            result_lines.append(line)
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    pyproject_path.write_text("\n".join(result_lines))
+    return pinned_deps
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Pin dependency versions in pyproject.toml from uv.lock."
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml (default: ./pyproject.toml)",
+    )
+    parser.add_argument(
+        "--lockfile",
+        type=Path,
+        default=Path("uv.lock"),
+        help="Path to uv.lock (default: ./uv.lock)",
+    )
+    args = parser.parse_args()
+
+    if not args.pyproject.exists():
+        print(f"Error: {args.pyproject} not found", file=sys.stderr)
+        sys.exit(1)
+    if not args.lockfile.exists():
+        print(f"Error: {args.lockfile} not found", file=sys.stderr)
+        sys.exit(1)
+
+    pinned = pin_dependencies(args.pyproject, args.lockfile)
+
+    if pinned:
+        print(f"Pinned {len(pinned)} dependencies:")
+        for dep in pinned:
+            print(f"  {dep}")
+    else:
+        print("All dependencies already pinned.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -8,6 +8,7 @@ Run with: uv run pytest .github/scripts/test_scripts.py -v
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -304,6 +305,283 @@ override-dependencies = ["pkg1==1.0.0", "pkg2==2.0.0"]
         assert "override-dependencies = [\n" in updated
         # Should not have duplicate override-dependencies
         assert updated.count("override-dependencies") == 1
+
+
+class TestPinDependencies:
+    """Tests for pin_dependencies.py"""
+
+    # Minimal uv.lock content for testing.
+    LOCK_TEMPLATE = """\
+version = 1
+revision = 2
+requires-python = ">=3.10"
+
+[[package]]
+name = "kubernetes"
+version = "35.0.0"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "kubeflow-trainer-api"
+version = "2.1.0"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "kubeflow-katib-api"
+version = "0.19.0"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = {{ registry = "https://pypi.org/simple" }}
+
+[[package]]
+name = "model-registry"
+version = "0.3.6"
+source = {{ registry = "https://pypi.org/simple" }}
+
+{extra_packages}
+"""
+
+    PYPROJECT_BASIC = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "kubernetes>=27.2.0",
+  "pydantic>=2.10.0",
+  "kubeflow-trainer-api>=2.0.0",
+  "kubeflow-katib-api>=0.19.0",
+]
+
+[project.optional-dependencies]
+docker = [
+  "docker>=6.1.3",
+]
+hub = [
+  "model-registry>=0.3.6",
+]
+
+[dependency-groups]
+dev = [
+  "pytest>=7.0",
+  "ruff>=0.12.2",
+]
+"""
+
+    def _run_pin(self, pyproject_content: str, lock_content: str) -> tuple[int, str, str, str]:
+        """Helper to run pin_dependencies.py with temp files.
+
+        Returns:
+            Tuple of (exit_code, updated_pyproject, stdout, stderr).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pyproject_path = Path(tmpdir) / "pyproject.toml"
+            lock_path = Path(tmpdir) / "uv.lock"
+            pyproject_path.write_text(pyproject_content)
+            lock_path.write_text(lock_content)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    SCRIPTS_DIR / "pin_dependencies.py",
+                    "--pyproject",
+                    str(pyproject_path),
+                    "--lockfile",
+                    str(lock_path),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            updated = pyproject_path.read_text()
+            return result.returncode, updated, result.stdout, result.stderr
+
+    def test_core_dependencies_pinned(self):
+        """Core dependencies get == pinned from lock file."""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, updated, stdout, _ = self._run_pin(self.PYPROJECT_BASIC, lock)
+
+        assert exit_code == 0
+        assert '"kubernetes==35.0.0"' in updated
+        assert '"pydantic==2.12.5"' in updated
+        assert '"kubeflow-trainer-api==2.1.0"' in updated
+        assert '"kubeflow-katib-api==0.19.0"' in updated
+        assert "Pinned" in stdout
+
+    def test_optional_dependencies_pinned(self):
+        """Optional dependencies get == pinned."""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, updated, _, _ = self._run_pin(self.PYPROJECT_BASIC, lock)
+
+        assert exit_code == 0
+        assert '"docker==7.1.0"' in updated
+        # model-registry was already at 0.3.6 with >=, should pin to ==
+        assert '"model-registry==0.3.6"' in updated
+
+    def test_already_pinned_unchanged(self):
+        """Dependencies already using == are left unchanged."""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "kubernetes==35.0.0",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, updated, stdout, _ = self._run_pin(pyproject, lock)
+
+        assert exit_code == 0
+        assert '"kubernetes==35.0.0"' in updated
+        assert "already pinned" in stdout.lower()
+
+    def test_multi_version_resolution(self):
+        """Multi-version packages resolve to the >=3.10 version."""
+        extra = """\
+[[package]]
+name = "fsspec"
+version = "2025.10.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
+    "python_full_version >= '3.10' and python_full_version < '3.12'",
+]
+"""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "fsspec>=2025.3.0",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages=extra)
+        exit_code, updated, _, _ = self._run_pin(pyproject, lock)
+
+        assert exit_code == 0
+        assert '"fsspec==2026.2.0"' in updated
+
+    def test_multi_version_no_compatible_version_fails(self):
+        """Multi-version package with no >=3.10 version fails with warning."""
+        extra = """\
+[[package]]
+name = "oldpkg"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "oldpkg"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+"""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "oldpkg>=1.0.0",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages=extra)
+        exit_code, _, _, stderr = self._run_pin(pyproject, lock)
+
+        assert exit_code == 1
+        assert "WARNING" in stderr
+        assert "not found" in stderr.lower()
+
+    def test_environment_markers_preserved(self):
+        """Environment markers after ; are preserved."""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "kubernetes>=27.2.0; python_version >= '3.11'",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, updated, _, _ = self._run_pin(pyproject, lock)
+
+        assert exit_code == 0
+        assert "\"kubernetes==35.0.0; python_version >= '3.11'\"" in updated
+
+    def test_missing_dependency_fails(self):
+        """Missing dependency in lock file causes exit code 1."""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "nonexistent-pkg>=1.0.0",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, _, _, stderr = self._run_pin(pyproject, lock)
+
+        assert exit_code == 1
+        assert "not found" in stderr.lower()
+
+    def test_dependency_groups_untouched(self):
+        """[dependency-groups] section is not modified."""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, updated, _, _ = self._run_pin(self.PYPROJECT_BASIC, lock)
+
+        assert exit_code == 0
+        # Dev deps should keep their original >= specifiers.
+        assert '"pytest>=7.0"' in updated
+        assert '"ruff>=0.12.2"' in updated
+
+    def test_comments_preserved(self):
+        """Comments in pyproject.toml are preserved."""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  # Core Kubernetes client
+  "kubernetes>=27.2.0",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages="")
+        exit_code, updated, _, _ = self._run_pin(pyproject, lock)
+
+        assert exit_code == 0
+        assert "# Core Kubernetes client" in updated
+        assert '"kubernetes==35.0.0"' in updated
+
+    def test_extras_preserved(self):
+        """Package extras like [security] are preserved."""
+        extra = """\
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+        pyproject = """\
+[project]
+name = "testpkg"
+dependencies = [
+  "requests[security]>=2.28.0",
+]
+"""
+        lock = self.LOCK_TEMPLATE.format(extra_packages=extra)
+        exit_code, updated, _, _ = self._run_pin(pyproject, lock)
+
+        assert exit_code == 0
+        assert '"requests[security]==2.31.0"' in updated
 
 
 if __name__ == "__main__":

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -112,11 +112,6 @@ jobs:
           echo "Updated kubeflow/__init__.py:"
           cat kubeflow/__init__.py
 
-          # Regenerate requirements.txt from current lock file.
-          # --locked fails if uv.lock is stale vs pyproject.toml, preventing
-          # silent re-resolution during a release.
-          uv export --locked --format requirements-txt > requirements.txt
-
           # Pin dependency versions from lock file for reproducible release.
           python .github/scripts/pin_dependencies.py
 
@@ -125,6 +120,11 @@ jobs:
           # build job would fail because pyproject.toml now says ==X.Y.Z
           # but the lock file still records >=X.Y.Z as the input constraint.
           uv lock
+
+          # Regenerate requirements.txt from the pinned lock file.
+          # --locked fails if uv.lock is stale vs pyproject.toml, preventing
+          # silent re-resolution during a release.
+          uv export --locked --format requirements-txt > requirements.txt
 
           # Verify pinned dependencies install correctly.
           uv sync --frozen

--- a/.github/workflows/odh-release.yaml
+++ b/.github/workflows/odh-release.yaml
@@ -117,8 +117,20 @@ jobs:
           # silent re-resolution during a release.
           uv export --locked --format requirements-txt > requirements.txt
 
-          git add kubeflow/__init__.py requirements.txt
-          git commit -m "chore: Set version to $VERSION for release" || echo "No changes to commit"
+          # Pin dependency versions from lock file for reproducible release.
+          python .github/scripts/pin_dependencies.py
+
+          # Regenerate lock file so its recorded constraints match the
+          # pinned pyproject.toml. Without this, `uv lock --check` in the
+          # build job would fail because pyproject.toml now says ==X.Y.Z
+          # but the lock file still records >=X.Y.Z as the input constraint.
+          uv lock
+
+          # Verify pinned dependencies install correctly.
+          uv sync --frozen
+
+          git add kubeflow/__init__.py requirements.txt pyproject.toml uv.lock
+          git commit -m "chore: Set version to $VERSION and pin dependencies for release" || echo "No changes to commit"
           git push origin "$BRANCH"
 
   build:

--- a/odh-release.md
+++ b/odh-release.md
@@ -55,6 +55,8 @@ The automated workflow will:
    - Create release branch from main if it doesn't exist (e.g., `release-0.2`)
    - Or use existing release branch as-is
    - Update `__init__.py` on release branch with rhai version
+   - Pin all `[project.dependencies]` and `[project.optional-dependencies]` to exact (`==`) versions resolved from `uv.lock`
+   - Regenerate `uv.lock` and `requirements.txt` to reflect the pinned versions
 
 2. **Build**:
    - Set up Python environment
@@ -69,6 +71,36 @@ The automated workflow will:
 4. **GitHub Release**:
    - Create GitHub release with auto-generated release notes
    - Attach build artifacts to release
+
+## Dependency Pinning
+
+During the prepare step, the workflow runs `.github/scripts/pin_dependencies.py` to replace
+version specifiers (`>=`, `<=`, `>`, `<`, `!=`, `~=`) in `pyproject.toml` with exact `==`
+pins derived from `uv.lock`. This ensures reproducible builds — the release ships with the
+exact dependency versions that were tested.
+
+**What gets pinned:**
+- `[project.dependencies]`
+- `[project.optional-dependencies]`
+
+**What stays unpinned:**
+- `[dependency-groups]` (dev dependencies)
+
+### Known Limitations
+
+**Transitive dependencies are not pinned.** Only direct dependencies listed in `pyproject.toml`
+are pinned. Transitive dependencies are constrained by `uv.lock` (committed to the release
+branch), but not by `pyproject.toml` itself. If a user installs with `pip` instead of `uv`,
+transitive dependency versions may differ from what was tested.
+
+**Pinning is a one-way transformation on the release branch.** Once pinned and committed, there
+is no automated mechanism to "un-pin" for a subsequent patch release. This is fine for the
+expected workflow: create a new release branch from `main` for each minor release and
+cherry-pick fixes. However, if multiple releases are cut from the same branch (e.g.,
+`v0.3.0+rhaiv.1` then `v0.3.0+rhaiv.2` from `release-0.3`), the second release starts from
+already-pinned deps. The script handles this as a no-op (already-pinned versions are left
+unchanged), meaning patches are locked to the exact versions from the first release unless
+someone manually updates them on the release branch.
 
 ### 3. Verification
 


### PR DESCRIPTION
## Summary

- Add `pin_dependencies.py` script that reads resolved versions from `uv.lock` and replaces `>=` specifiers with exact `==` pins in `pyproject.toml`
- Update the `odh-release.yaml` workflow to run the pinning script, regenerate `uv.lock`, and verify with `uv sync --frozen` before committing to the release branch
- Only `[project.dependencies]` and `[project.optional-dependencies]` are pinned; `[dependency-groups]` (dev deps) are left unchanged
- Handles multi-version packages (picks the Python >=3.10 compatible version), preserves environment markers, extras, and comments
- Add 10 unit tests covering core pinning, optional deps, already-pinned deps, multi-version resolution, environment markers, missing deps, extras, comments, and dependency-groups isolation

## Test plan

- [x] `uv run pytest .github/scripts/test_scripts.py -v` — 31 tests pass (10 new + 21 existing)
- [x] `uv run ruff check` — no lint errors
- [x] Dry-run against real `pyproject.toml` + `uv.lock` — all 10 deps pinned correctly, `[dependency-groups]` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated dependency-pinning step to release automation that converts project and optional dependency specifiers into exact resolved versions, regenerates lock/requirements, verifies installability, and commits the updated files.

* **Tests**
  * Added tests covering pinning behavior, marker/extras preservation, resolution selection, and failure cases when lock data is incompatible or missing.

* **Documentation**
  * Updated release docs describing the pinning step, scope (direct/optional deps only), and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->