### PR TITLE
feat: Add lora_grpo implementation to training hub algorithms

### DIFF
--- a/kubeflow/trainer/algorithms.py
+++ b/kubeflow/trainer/algorithms.py
@@ -147,6 +147,15 @@ ALGORITHMS: dict[str, AlgorithmSpec] = {
         # LoRA expects to run inside a torchrun process
         entrypoint=constants.TORCH_COMMAND,
     ),
+    "lora_grpo": AlgorithmSpec(
+        name="lora_grpo",
+        metrics_file_patterns=("training_metrics.jsonl",),
+        validate=_no_op_validate,
+        # ART does not use torchrun — it is single-GPU and manages its own vLLM
+        # subprocess. torchrun env vars (MASTER_ADDR, WORLD_SIZE) leak into that
+        # subprocess and cause an NCCL timeout.
+        entrypoint=constants.DEFAULT_COMMAND,
+    ),
 }
 
 

--- a/kubeflow/trainer/algorithms_test.py
+++ b/kubeflow/trainer/algorithms_test.py
@@ -226,6 +226,12 @@ def test_all_algorithms_have_callable_validate():
             config={"algorithm": "lora_sft"},
             expected_output="lora_sft",
         ),
+        TestCase(
+            name="valid lora_grpo algorithm returns spec",
+            expected_status=SUCCESS,
+            config={"algorithm": "lora_grpo"},
+            expected_output="lora_grpo",
+        ),
     ],
 )
 def test_get_algorithm_spec(test_case):
@@ -283,7 +289,7 @@ def test_algorithms_registry_not_empty():
 
     # Verify known algorithms exist (baseline check)
     # This ensures we don't accidentally break existing algorithms
-    known_algorithms = {"sft", "osft", "lora_sft"}
+    known_algorithms = {"sft", "osft", "lora_sft", "lora_grpo"}
     for algo in known_algorithms:
         assert algo in ALGORITHMS, f"Known algorithm '{algo}' missing from registry"
 
@@ -595,8 +601,17 @@ def test_registry_keys_are_lowercase():
 
 
 def test_registry_no_duplicate_patterns():
-    """Test that algorithms don't share identical metrics patterns."""
+    """Test that algorithms don't share identical metrics patterns unexpectedly.
+
+    Some algorithms intentionally share the same metrics file (e.g. lora_sft
+    and lora_grpo both write training_metrics.jsonl). This test tracks known
+    shared patterns and fails only on *unexpected* duplicates.
+    """
     print("Executing test: registry_no_duplicate_patterns")
+
+    known_shared = {
+        ("training_metrics.jsonl",): {"lora_sft", "lora_grpo"},
+    }
 
     patterns_seen = {}
 
@@ -606,9 +621,11 @@ def test_registry_no_duplicate_patterns():
 
         if patterns in patterns_seen:
             other_algo = patterns_seen[patterns]
-            pytest.fail(
-                f"Algorithm '{algorithm_name}' has same patterns as '{other_algo}': {patterns}"
-            )
+            shared_set = known_shared.get(patterns, set())
+            if not {algorithm_name, other_algo}.issubset(shared_set):
+                pytest.fail(
+                    f"Algorithm '{algorithm_name}' has same patterns as '{other_algo}': {patterns}"
+                )
 
         patterns_seen[patterns] = algorithm_name
 
@@ -785,6 +802,35 @@ def test_algorithm_without_metrics_integration():
         # Restore original registry
         ALGORITHMS.clear()
         ALGORITHMS.update(original_algorithms)
+
+    print("test execution complete")
+
+
+def test_get_algorithm_pod_metadata_lora_grpo():
+    """Test get_algorithm_pod_metadata returns correct metadata for GRPO."""
+    print("Executing test: get_algorithm_pod_metadata_lora_grpo")
+
+    metadata = get_algorithm_pod_metadata("lora_grpo")
+
+    assert metadata["name"] == "lora_grpo"
+    assert metadata["metrics_file_pattern"] == "training_metrics.jsonl"
+    assert metadata["metrics_file_rank0"] == "training_metrics.jsonl"
+
+    print("test execution complete")
+
+
+def test_lora_grpo_uses_python_entrypoint():
+    """Test that lora_grpo uses DEFAULT_COMMAND (python), not torchrun.
+
+    ART manages its own subprocess via mp.spawn; torchrun env vars leak
+    into vLLM's EngineCore and cause NCCL timeouts.
+    """
+    print("Executing test: lora_grpo uses python entrypoint")
+
+    spec = get_algorithm_spec("lora_grpo")
+    assert spec.entrypoint == constants.DEFAULT_COMMAND, (
+        f"lora_grpo should use DEFAULT_COMMAND, got {spec.entrypoint}"
+    )
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/traininghub.py
+++ b/kubeflow/trainer/rhai/traininghub.py
@@ -18,6 +18,7 @@ class TrainingHubAlgorithms(Enum):
     SFT = "sft"
     OSFT = "osft"
     LORA_SFT = "lora_sft"
+    LORA_GRPO = "lora_grpo"
 
 
 @dataclass
@@ -222,8 +223,9 @@ def _create_training_hub_progression_instrumentation(
                 return self._read_osft_metrics()
             elif algorithm == "lora_sft":
                 return self._read_lora_sft_metrics()
+            elif algorithm == "lora_grpo":
+                return self._read_lora_grpo_metrics()
             else:
-                # Algorithm not yet supported for metrics reading
                 return {}
 
         def _read_osft_metrics(self):
@@ -392,6 +394,8 @@ def _create_training_hub_progression_instrumentation(
                 return self._transform_osft(metrics)
             elif algorithm == "lora_sft":
                 return self._transform_lora_sft(metrics)
+            elif algorithm == "lora_grpo":
+                return self._transform_lora_grpo(metrics)
             else:
                 return {}
 
@@ -569,6 +573,110 @@ def _create_training_hub_progression_instrumentation(
                     "loss": f"{loss_val:.4f}" if loss_val is not None else None,
                     "learning_rate": f"{lr_val:.6f}" if lr_val is not None else None,
                     "grad_norm": f"{grad_norm_val:.4f}" if grad_norm_val is not None else None,
+                },
+                "evalMetrics": {},
+            }
+
+        def _read_lora_grpo_metrics(self):
+            """Read GRPO metrics from training_metrics.jsonl.
+
+            GRPO writes two lines per iteration (rollout + train phase).
+            Read the last 2 lines and merge them into a single dict.
+            """
+            metrics_file = f"{ckpt_output_dir}/{metrics_file_rank0}"
+
+            try:
+                if not os.path.exists(metrics_file):
+                    return {}
+
+                try:
+                    result = subprocess.run(
+                        ["tail", "-n", "2", metrics_file],
+                        capture_output=True,
+                        text=True,
+                        check=True,
+                        timeout=2,
+                    )
+                    lines = result.stdout.strip().split("\n")
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                    return {}
+
+                parsed = []
+                for line in lines:
+                    line = line.strip()
+                    if line:
+                        try:
+                            parsed.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            continue
+
+                if not parsed:
+                    return {}
+
+                merged = {}
+                latest_step = parsed[-1].get("step")
+                for obj in parsed:
+                    if latest_step is None or obj.get("step") == latest_step:
+                        merged.update(obj)
+
+                return merged
+
+            except Exception:
+                print("[Kubeflow] Error reading GRPO metrics", flush=True)
+                return {}
+
+        def _transform_lora_grpo(self, metrics):
+            """Transform GRPO schema to controller-compatible format.
+
+            GRPO metrics (merged from rollout + train phase lines):
+                Rollout fields: step, epoch, phase, mean_reward, full_match_rate, ...
+                Train fields: step, epoch, phase, loss, grad_norm, learning_rate, entropy, ...
+            """
+            step = metrics.get("step", 0)
+            epoch = metrics.get("epoch", 0)
+            max_steps = metrics.get("max_steps")
+
+            if max_steps and max_steps > 0:
+                progress = step / max_steps * 100
+                percent_int = int(round(progress))
+                percent_int = min(99, percent_int) if step < max_steps else min(100, percent_int)
+            else:
+                percent_int = None
+
+            loss_val = metrics.get("loss")
+            lr_val = metrics.get("learning_rate")
+            grad_norm_val = metrics.get("grad_norm")
+            mean_reward_val = metrics.get("mean_reward")
+            full_match_rate_val = metrics.get("full_match_rate")
+            entropy_val = metrics.get("entropy")
+            wall_time_s = metrics.get("wall_time_s")
+
+            estimated_remaining_sec = None
+            if max_steps and step > 0 and wall_time_s and wall_time_s > 0:
+                remaining_steps = max_steps - step
+                if remaining_steps > 0:
+                    estimated_remaining_sec = int((wall_time_s / step) * remaining_steps)
+                else:
+                    estimated_remaining_sec = 0
+
+            return {
+                "progressPercentage": percent_int,
+                "estimatedRemainingSeconds": estimated_remaining_sec,
+                "currentStep": step,
+                "totalSteps": max_steps if max_steps else None,
+                "currentEpoch": max(1, math.ceil(epoch)),
+                "totalEpochs": 1,
+                "trainMetrics": {
+                    "loss": f"{loss_val:.4f}" if loss_val is not None else None,
+                    "learning_rate": f"{lr_val:.6f}" if lr_val is not None else None,
+                    "grad_norm": (f"{grad_norm_val:.4f}" if grad_norm_val is not None else None),
+                    "mean_reward": (
+                        f"{mean_reward_val:.4f}" if mean_reward_val is not None else None
+                    ),
+                    "full_match_rate": (
+                        f"{full_match_rate_val:.4f}" if full_match_rate_val is not None else None
+                    ),
+                    "entropy": f"{entropy_val:.4f}" if entropy_val is not None else None,
                 },
                 "evalMetrics": {},
             }
@@ -818,16 +926,19 @@ def _render_algorithm_wrapper(algorithm_metadata: dict, func_args: dict | None) 
         metrics_file_rank0=metrics_file_rank0,
     )
 
+    # Wrap the call in if __name__ == '__main__' to prevent re-execution
+    # when algorithms use multiprocessing.spawn (e.g. ART's lora_grpo).
+    # Harmless for algorithms that don't use spawn (SFT, OSFT, LoRA SFT).
     if func_args is None:
-        call_line = "training_func({})\n"
+        call_line = "if __name__ == '__main__':\n    training_func({})\n"
     elif isinstance(func_args, dict):
-        params_lines: list[str] = ["training_func({\n"]
+        params_lines: list[str] = ["if __name__ == '__main__':\n    training_func({\n"]
         for key, value in func_args.items():
-            params_lines.append(f"    {repr(key)}: {repr(value)},\n")
-        params_lines.append("})\n")
+            params_lines.append(f"        {repr(key)}: {repr(value)},\n")
+        params_lines.append("    })\n")
         call_line = "".join(params_lines)
     else:
-        call_line = f"training_func({func_args})\n"
+        raise ValueError("func_args must be a dict or None")
 
     return base_script + call_line
 

--- a/kubeflow/trainer/rhai/traininghub_test.py
+++ b/kubeflow/trainer/rhai/traininghub_test.py
@@ -253,10 +253,12 @@ def test_metrics_port_validation(test_case):
                 ("def _read_osft_metrics", True),
                 ("def _read_sft_metrics", True),
                 ("def _read_lora_sft_metrics", True),
+                ("def _read_lora_grpo_metrics", True),
                 ("def _transform_schema", True),
                 ("def _transform_osft", True),
                 ("def _transform_sft", True),
                 ("def _transform_lora_sft", True),
+                ("def _transform_lora_grpo", True),
                 ("def do_GET", True),
             ],
         ),
@@ -544,8 +546,16 @@ def _install_dummy_training_hub(raises: Exception) -> None:
     def osft(**kwargs):  # type: ignore[unused-argument]
         raise raises
 
+    def lora_sft(**kwargs):  # type: ignore[unused-argument]
+        raise raises
+
+    def lora_grpo(**kwargs):  # type: ignore[unused-argument]
+        raise raises
+
     module.sft = sft  # type: ignore[attr-defined]
     module.osft = osft  # type: ignore[attr-defined]
+    module.lora_sft = lora_sft  # type: ignore[attr-defined]
+    module.lora_grpo = lora_grpo  # type: ignore[attr-defined]
     sys.modules["training_hub"] = module
 
 
@@ -590,7 +600,7 @@ def test_traininghub_wrapper_reraises_failure(test_case: TestCase, capsys):
     # training_hub module that raises, the wrapper should re-raise the same exception.
     # This validates failure propagation (so the container exits non‑zero in real runs).
     with pytest.raises(test_case.expected_error):
-        exec(code, {})  # nosec: B102 - executing generated test-only code
+        exec(code, {"__name__": "__main__"})  # nosec: B102 - executing generated test-only code
 
     # Additionally, verify that the wrapper printed the expected human-readable
     # error message (useful for debugging in container logs).
@@ -1180,6 +1190,223 @@ def test_lora_metrics_transformer_empty_metrics(tmp_path):
     assert result["progressPercentage"] is None
     assert result["currentStep"] is None
     assert result["trainMetrics"] is None
+
+    print("test execution complete")
+
+
+def test_traininghub_lora_grpo_enum_value():
+    """Test that LORA_GRPO enum exists and has correct value."""
+    print("Executing test: LORA_GRPO enum value")
+
+    assert TrainingHubAlgorithms.LORA_GRPO.value == "lora_grpo"
+
+    print("test execution complete")
+
+
+def test_lora_grpo_entrypoint_uses_python():
+    """Test that LORA_GRPO uses python entrypoint, not torchrun."""
+    print("Executing test: LORA_GRPO entrypoint uses python")
+
+    from kubeflow.trainer.rhai.traininghub import get_trainer_cr_from_training_hub_trainer
+    from kubeflow.trainer.types import types
+
+    runtime = types.Runtime(
+        name="torch-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="pytorch/pytorch:latest",
+        ),
+    )
+    runtime.trainer.set_command(constants.TORCH_COMMAND)
+
+    trainer = TrainingHubTrainer(
+        algorithm=TrainingHubAlgorithms.LORA_GRPO,
+        func_args={"data_path": "/data/train.jsonl", "ckpt_output_dir": "/tmp/checkpoints"},
+    )
+
+    trainer_crd = get_trainer_cr_from_training_hub_trainer(runtime, trainer)
+    command_str = " ".join(trainer_crd.command)
+
+    assert "python" in command_str, f"LORA_GRPO should use python: {command_str}"
+    assert "torchrun" not in command_str, f"LORA_GRPO should NOT use torchrun: {command_str}"
+
+    print("test execution complete")
+
+
+def test_algorithm_wrapper_main_guard():
+    """Test that generated wrapper includes if __name__ == '__main__' guard."""
+    print("Executing test: Algorithm wrapper __main__ guard")
+
+    from kubeflow.trainer.algorithms import get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _render_algorithm_wrapper
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_grpo")
+    wrapper = _render_algorithm_wrapper(algorithm_metadata, {"ckpt_output_dir": "/tmp"})
+
+    assert "if __name__ == '__main__':" in wrapper, (
+        "Wrapper must include __main__ guard for multiprocessing.spawn compatibility"
+    )
+
+    print("test execution complete")
+
+
+def test_main_guard_present_for_all_algorithms():
+    """Test that __main__ guard is present for all algorithms (harmless for non-spawn)."""
+    print("Executing test: __main__ guard present for all algorithms")
+
+    from kubeflow.trainer.algorithms import ALGORITHMS, get_algorithm_pod_metadata
+    from kubeflow.trainer.rhai.traininghub import _render_algorithm_wrapper
+
+    for algorithm_name in ALGORITHMS:
+        algorithm_metadata = get_algorithm_pod_metadata(algorithm_name)
+        wrapper = _render_algorithm_wrapper(algorithm_metadata, {"ckpt_output_dir": "/tmp"})
+
+        assert "if __name__ == '__main__':" in wrapper, (
+            f"Algorithm '{algorithm_name}' wrapper should include __main__ guard"
+        )
+
+    print("test execution complete")
+
+
+@pytest.fixture
+def grpo_handler(tmp_path):
+    """Create a GRPO metrics handler for testing."""
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+
+    algorithm_metadata = get_algorithm_pod_metadata("lora_grpo")
+    apply_fn, handler_class = _create_training_hub_progression_instrumentation(
+        algorithm_metadata=algorithm_metadata,
+        ckpt_output_dir=str(ckpt_dir),
+        metrics_port=0,
+    )
+
+    handler = handler_class.__new__(handler_class)
+    return apply_fn, handler, ckpt_dir
+
+
+def test_grpo_metrics_reader_two_phase(grpo_handler):
+    """Test that GRPO metrics reader merges rollout + train phase lines."""
+    print("Executing test: GRPO metrics reader two-phase merge")
+
+    _apply_fn, handler, ckpt_dir = grpo_handler
+
+    metrics_file = ckpt_dir / "training_metrics.jsonl"
+    metrics_file.write_text(
+        '{"step": 1, "epoch": 1, "phase": "rollout", "mean_reward": 0.42, "full_match_rate": 0.15}\n'
+        '{"step": 1, "epoch": 1, "phase": "train", "loss": 2.5, "grad_norm": 1.2, "learning_rate": 1e-5}\n'
+    )
+
+    metrics = handler._read_latest_metrics()
+
+    assert metrics["step"] == 1
+    assert metrics["phase"] == "train"
+    assert metrics["mean_reward"] == 0.42
+    assert metrics["full_match_rate"] == 0.15
+    assert metrics["loss"] == 2.5
+    assert metrics["grad_norm"] == 1.2
+    assert metrics["learning_rate"] == 1e-5
+
+    print("test execution complete")
+
+
+def test_grpo_metrics_reader_empty_file(grpo_handler):
+    """Test that GRPO metrics reader returns empty dict for missing file."""
+    print("Executing test: GRPO metrics reader empty file")
+
+    _apply_fn, handler, _ckpt_dir = grpo_handler
+
+    metrics = handler._read_latest_metrics()
+    assert metrics == {}
+
+    print("test execution complete")
+
+
+def test_grpo_metrics_transformer(grpo_handler):
+    """Test that GRPO metrics transformer produces correct controller format."""
+    print("Executing test: GRPO metrics transformer")
+
+    _apply_fn, handler, _ckpt_dir = grpo_handler
+
+    metrics = {
+        "step": 5,
+        "epoch": 1,
+        "phase": "train",
+        "loss": 1.2345,
+        "grad_norm": 0.8765,
+        "learning_rate": 0.00001,
+        "mean_reward": 0.65,
+        "full_match_rate": 0.30,
+        "entropy": 0.9512,
+        "max_steps": 10,
+        "wall_time_s": 500.0,
+    }
+
+    result = handler._transform_schema(metrics)
+
+    assert result["progressPercentage"] == 50
+    assert result["estimatedRemainingSeconds"] == 500
+    assert result["currentStep"] == 5
+    assert result["totalSteps"] == 10
+    assert result["currentEpoch"] == 1
+    assert result["totalEpochs"] == 1
+    assert result["trainMetrics"]["loss"] == "1.2345"
+    assert result["trainMetrics"]["learning_rate"] == "0.000010"
+    assert result["trainMetrics"]["grad_norm"] == "0.8765"
+    assert result["trainMetrics"]["mean_reward"] == "0.6500"
+    assert result["trainMetrics"]["full_match_rate"] == "0.3000"
+    assert result["trainMetrics"]["entropy"] == "0.9512"
+    assert result["evalMetrics"] == {}
+
+    print("test execution complete")
+
+
+def test_grpo_metrics_transformer_no_max_steps(grpo_handler):
+    """Test that GRPO transformer reports None progress when max_steps absent."""
+    print("Executing test: GRPO transformer without max_steps")
+
+    _apply_fn, handler, _ckpt_dir = grpo_handler
+
+    metrics = {
+        "step": 5,
+        "epoch": 1,
+        "loss": 1.5,
+        "mean_reward": 0.4,
+    }
+
+    result = handler._transform_schema(metrics)
+
+    assert result["progressPercentage"] is None
+    assert result["estimatedRemainingSeconds"] is None
+    assert result["currentStep"] == 5
+    assert result["totalSteps"] is None
+    assert result["totalEpochs"] == 1
+    assert result["trainMetrics"]["entropy"] is None
+
+    print("test execution complete")
+
+
+def test_grpo_instrumentation_cleans_metrics_on_startup(grpo_handler):
+    """Test that GRPO metrics files are cleaned before training starts."""
+    print("Executing test: GRPO metrics cleanup on startup")
+
+    apply_fn, _handler, ckpt_dir = grpo_handler
+
+    stale_metrics_file = ckpt_dir / "training_metrics.jsonl"
+    stale_metrics_file.write_text(
+        '{"step": 1, "phase": "rollout", "mean_reward": 0.1}\n'
+        '{"step": 1, "phase": "train", "loss": 3.0}\n'
+    )
+
+    with patch.dict(os.environ, {"JOB_COMPLETION_INDEX": "0"}):
+        server = apply_fn()
+
+        try:
+            assert not stale_metrics_file.exists(), "Stale GRPO metrics file should be removed"
+        finally:
+            if server:
+                server.shutdown()
 
     print("test execution complete")
 


### PR DESCRIPTION
[RHOAIENG-62928](https://redhat.atlassian.net/browse/RHOAIENG-62928) 
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Add LORA_GRPO algorithm for RLVR/GRPO training
Adds support for Group Relative Policy Optimization (GRPO) via the ART backend as a new Training Hub algorithm.

**Changes**
Algorithm registration (algorithms.py)

 - Register lora_grpo in the algorithm registry with DEFAULT_COMMAND entrypoint (not torchrun — ART is single-GPU and manages its own vLLM subprocess; torchrun env vars leak into it and cause NCCL timeouts)
 - Metrics file pattern: training_metrics.jsonl (shared with lora_sft)
RHAI Training Hub integration (rhai/traininghub.py)

 - Add LORA_GRPO to TrainingHubAlgorithms enum
 - Add _read_lora_grpo_metrics() — reads ART's two-phase JSONL format (rollout + train lines per iteration), merges them into a single dict
 - Add _transform_lora_grpo() — maps GRPO metrics to controller schema (progressPercentage, currentStep, loss, mean_reward, full_match_rate, entropy)
 - Wrap instrumentation activation in if __name__ == '__main__': guard to prevent [Errno 98] Address already in use when ART's multiprocessing.spawn re-executes the script in child processes

**Tests**

 - Algorithm registry: spec lookup, known algorithms set, shared metrics pattern allowlist, pod metadata, python entrypoint assertion
 - RHAI: enum value, entrypoint validation, wrapper script __main__ guard, two-phase metrics reader, empty file handling, metrics transformer (with and without max_steps), cleanup on startup

**Dependencies**
 - Training Hub 0.8.1 release

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Verification steps** _(required; provide valid, reproducible steps for reviewers to verify your changes, e.g. setup, commands, expected outcome, notebooks)_:

_Example: 1. Check out this branch. 2. Run `make test-python`. 3. Confirm that …_

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LoRA GRPO training algorithm with integrated metrics reading and merging, mapping to controller-friendly training metrics (includes progress percentage and remaining-time estimates).
  * Generated runtime wrappers now include a main-entry guard and use a Python entrypoint for improved runtime compatibility and stability.

* **Tests**
  * Extended test coverage for LoRA GRPO: metrics instrumentation, two-phase merged metrics handling, stale/empty metrics behavior, progress/remaining-time calculations, and runtime-wrapper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->