### PR TITLE
chore(test): add unit tests for trainer backends and localprocess modules

### DIFF
--- a/kubeflow/trainer/backends/base_test.py
+++ b/kubeflow/trainer/backends/base_test.py
@@ -95,13 +95,10 @@ class PartialBackend(RuntimeBackend):
 def test_runtime_backend_instantiation(test_case):
     """Test RuntimeBackend instantiation rules for abstract base class."""
     print("Executing test:", test_case.name)
-    try:
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            test_case.config["cls"]()
+    else:
         instance = test_case.config["cls"]()
-
-        assert test_case.expected_status == SUCCESS
         assert isinstance(instance, test_case.expected_output)
-
-    except Exception as e:
-        assert test_case.expected_status == FAILED
-        assert type(e) is test_case.expected_error
     print("test execution complete")

--- a/kubeflow/trainer/backends/base_test.py
+++ b/kubeflow/trainer/backends/base_test.py
@@ -1,0 +1,107 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the RuntimeBackend abstract base class."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from kubeflow.trainer.backends.base import RuntimeBackend
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types import types
+
+
+class CompleteBackend(RuntimeBackend):
+    """Concrete implementation of RuntimeBackend with all abstract methods."""
+
+    def list_runtimes(self) -> list[types.Runtime]:
+        return []
+
+    def get_runtime(self, name: str) -> types.Runtime:
+        return types.Runtime(name=name)
+
+    def get_runtime_packages(self, runtime: types.Runtime):
+        return []
+
+    def train(self, runtime=None, initializer=None, trainer=None, options=None) -> str:
+        return "job-id"
+
+    def list_jobs(self, runtime=None) -> list[types.TrainJob]:
+        return []
+
+    def get_job(self, name: str) -> types.TrainJob:
+        return types.TrainJob(name=name)
+
+    def get_job_logs(self, name="", follow=False, step="node-0") -> Iterator[str]:
+        yield "log line"
+
+    def get_job_events(self, name: str) -> list[types.Event]:
+        return []
+
+    def wait_for_job_status(
+        self, name="", status=None, timeout=600, polling_interval=2, callbacks=None
+    ) -> types.TrainJob:
+        return types.TrainJob(name=name)
+
+    def delete_job(self, name: str):
+        pass
+
+
+class PartialBackend(RuntimeBackend):
+    """Partial implementation missing most abstract methods."""
+
+    def list_runtimes(self) -> list[types.Runtime]:
+        return []
+
+    def get_runtime(self, name: str) -> types.Runtime:
+        return types.Runtime(name=name)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="direct instantiation of RuntimeBackend raises TypeError",
+            expected_status=FAILED,
+            config={"cls": RuntimeBackend},
+            expected_error=TypeError,
+        ),
+        TestCase(
+            name="complete subclass instantiates successfully",
+            expected_status=SUCCESS,
+            config={"cls": CompleteBackend},
+            expected_output=CompleteBackend,
+        ),
+        TestCase(
+            name="partial subclass raises TypeError",
+            expected_status=FAILED,
+            config={"cls": PartialBackend},
+            expected_error=TypeError,
+        ),
+    ],
+)
+def test_runtime_backend_instantiation(test_case):
+    """Test RuntimeBackend instantiation rules for abstract base class."""
+    print("Executing test:", test_case.name)
+    try:
+        instance = test_case.config["cls"]()
+
+        assert test_case.expected_status == SUCCESS
+        assert isinstance(instance, test_case.expected_output)
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")

--- a/kubeflow/trainer/backends/container/adapters/base_test.py
+++ b/kubeflow/trainer/backends/container/adapters/base_test.py
@@ -122,13 +122,10 @@ class PartialAdapter(BaseContainerClientAdapter):
 def test_container_adapter_instantiation(test_case):
     """Test BaseContainerClientAdapter instantiation rules for abstract base class."""
     print("Executing test:", test_case.name)
-    try:
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            test_case.config["cls"]()
+    else:
         instance = test_case.config["cls"]()
-
-        assert test_case.expected_status == SUCCESS
         assert isinstance(instance, test_case.expected_output)
-
-    except Exception as e:
-        assert test_case.expected_status == FAILED
-        assert type(e) is test_case.expected_error
     print("test execution complete")

--- a/kubeflow/trainer/backends/container/adapters/base_test.py
+++ b/kubeflow/trainer/backends/container/adapters/base_test.py
@@ -1,0 +1,134 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the BaseContainerClientAdapter abstract base class."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from kubeflow.trainer.backends.container.adapters.base import (
+    BaseContainerClientAdapter,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+
+
+class CompleteAdapter(BaseContainerClientAdapter):
+    """Concrete implementation of BaseContainerClientAdapter with all methods."""
+
+    def ping(self):
+        pass
+
+    def create_network(self, name: str, labels: dict[str, str]) -> str:
+        return "network-id"
+
+    def delete_network(self, network_id: str):
+        pass
+
+    def create_and_start_container(
+        self,
+        image: str,
+        command: list[str],
+        name: str,
+        network_id: str,
+        environment: dict[str, str],
+        labels: dict[str, str],
+        volumes: dict[str, dict[str, str]],
+        working_dir: str,
+    ) -> str:
+        return "container-id"
+
+    def get_container(self, container_id: str):
+        return None
+
+    def container_logs(self, container_id: str, follow: bool) -> Iterator[str]:
+        yield "log"
+
+    def stop_container(self, container_id: str, timeout: int = 10):
+        pass
+
+    def remove_container(self, container_id: str, force: bool = True):
+        pass
+
+    def pull_image(self, image: str):
+        pass
+
+    def image_exists(self, image: str) -> bool:
+        return True
+
+    def run_oneoff_container(self, image: str, command: list[str]) -> str:
+        return "output"
+
+    def container_status(self, container_id: str) -> tuple[str, int | None]:
+        return ("running", None)
+
+    def get_container_ip(self, container_id: str, network_id: str) -> str | None:
+        return "172.17.0.2"
+
+    def list_containers(self, filters: dict[str, list[str]] | None = None) -> list[dict]:
+        return []
+
+    def get_network(self, network_id: str) -> dict | None:
+        return {"id": network_id}
+
+    def wait_for_container(self, container_id: str, timeout: int | None = None) -> int:
+        return 0
+
+
+class PartialAdapter(BaseContainerClientAdapter):
+    """Partial implementation with only ping and create_network."""
+
+    def ping(self):
+        pass
+
+    def create_network(self, name: str, labels: dict[str, str]) -> str:
+        return "network-id"
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="direct instantiation of BaseContainerClientAdapter raises TypeError",
+            expected_status=FAILED,
+            config={"cls": BaseContainerClientAdapter},
+            expected_error=TypeError,
+        ),
+        TestCase(
+            name="complete subclass instantiates successfully",
+            expected_status=SUCCESS,
+            config={"cls": CompleteAdapter},
+            expected_output=CompleteAdapter,
+        ),
+        TestCase(
+            name="partial subclass raises TypeError",
+            expected_status=FAILED,
+            config={"cls": PartialAdapter},
+            expected_error=TypeError,
+        ),
+    ],
+)
+def test_container_adapter_instantiation(test_case):
+    """Test BaseContainerClientAdapter instantiation rules for abstract base class."""
+    print("Executing test:", test_case.name)
+    try:
+        instance = test_case.config["cls"]()
+
+        assert test_case.expected_status == SUCCESS
+        assert isinstance(instance, test_case.expected_output)
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")

--- a/kubeflow/trainer/backends/container/adapters/docker_test.py
+++ b/kubeflow/trainer/backends/container/adapters/docker_test.py
@@ -81,15 +81,14 @@ def test_init(test_case):
 
     if test_case.expected_error:
         with patch.dict(sys.modules, {"docker": None}), pytest.raises(ImportError):
-            from importlib import reload
+            from kubeflow.trainer.backends.container.adapters.docker import (
+                DockerClientAdapter,
+            )
 
-            import kubeflow.trainer.backends.container.adapters.docker as mod
-
-            reload(mod)
-            mod.DockerClientAdapter()
+            DockerClientAdapter()
     else:
         host = test_case.config["host"]
-        adapter, mock_docker = _create_adapter(host=host)
+        _, mock_docker = _create_adapter(host=host)
         if host:
             mock_docker.DockerClient.assert_called_once_with(base_url=host)
         else:

--- a/kubeflow/trainer/backends/container/adapters/docker_test.py
+++ b/kubeflow/trainer/backends/container/adapters/docker_test.py
@@ -1,0 +1,619 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the DockerClientAdapter class."""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+
+
+def _make_mock_docker_module() -> Mock:
+    """Build a fake docker module suitable for sys.modules patching."""
+    mock_docker = Mock()
+    mock_client = Mock()
+    mock_docker.from_env.return_value = mock_client
+    mock_docker.DockerClient.return_value = mock_client
+    return mock_docker
+
+
+def _create_adapter(host: str | None = None):
+    """Create a DockerClientAdapter with the docker module mocked."""
+    mock_docker = _make_mock_docker_module()
+    with patch.dict(sys.modules, {"docker": mock_docker}):
+        from kubeflow.trainer.backends.container.adapters.docker import (
+            DockerClientAdapter,
+        )
+
+        adapter = DockerClientAdapter(host=host)
+    return adapter, mock_docker
+
+
+@pytest.fixture
+def adapter_and_mock():
+    """Provide a DockerClientAdapter with a mocked docker client."""
+    adapter, mock_docker = _create_adapter()
+    return adapter, mock_docker
+
+
+# --------------------------
+# Init tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="init without host uses from_env",
+            expected_status=SUCCESS,
+            config={"host": None},
+        ),
+        TestCase(
+            name="init with host uses DockerClient",
+            expected_status=SUCCESS,
+            config={"host": "tcp://localhost:2375"},
+        ),
+        TestCase(
+            name="init raises ImportError when docker not installed",
+            expected_status=FAILED,
+            expected_error=ImportError,
+        ),
+    ],
+)
+def test_init(test_case):
+    """Test DockerClientAdapter initialization."""
+    print(f"Executing test: {test_case.name}")
+
+    if test_case.expected_error:
+        with patch.dict(sys.modules, {"docker": None}), pytest.raises(ImportError):
+            from importlib import reload
+
+            import kubeflow.trainer.backends.container.adapters.docker as mod
+
+            reload(mod)
+            mod.DockerClientAdapter()
+    else:
+        host = test_case.config["host"]
+        adapter, mock_docker = _create_adapter(host=host)
+        if host:
+            mock_docker.DockerClient.assert_called_once_with(base_url=host)
+        else:
+            mock_docker.from_env.assert_called_once()
+
+    print("test execution complete")
+
+
+# --------------------------
+# Ping test
+# --------------------------
+
+
+def test_ping(adapter_and_mock):
+    """Test ping delegates to docker client."""
+    print("Executing test: ping delegates to client")
+    adapter, _ = adapter_and_mock
+    adapter.ping()
+    adapter.client.ping.assert_called_once()
+    print("test execution complete")
+
+
+# --------------------------
+# Network tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="create_network returns existing network",
+            expected_status=SUCCESS,
+            config={"existing": True},
+            expected_output="test-net",
+        ),
+        TestCase(
+            name="create_network creates new network",
+            expected_status=SUCCESS,
+            config={"existing": False},
+            expected_output="test-net",
+        ),
+    ],
+)
+def test_create_network(adapter_and_mock, test_case):
+    """Test create_network with existing and new networks."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.config["existing"]:
+        adapter.client.networks.get.return_value = Mock()
+    else:
+        adapter.client.networks.get.side_effect = Exception("not found")
+
+    result = adapter.create_network("test-net", {"app": "test"})
+    assert result == test_case.expected_output
+
+    if test_case.config["existing"]:
+        adapter.client.networks.create.assert_not_called()
+    else:
+        adapter.client.networks.create.assert_called_once_with(
+            name="test-net",
+            check_duplicate=True,
+            labels={"app": "test"},
+        )
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="delete_network removes successfully",
+            expected_status=SUCCESS,
+            config={"raises": False},
+        ),
+        TestCase(
+            name="delete_network silences errors",
+            expected_status=SUCCESS,
+            config={"raises": True},
+        ),
+    ],
+)
+def test_delete_network(adapter_and_mock, test_case):
+    """Test delete_network handles success and errors."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.config["raises"]:
+        adapter.client.networks.get.side_effect = Exception("not found")
+    else:
+        mock_net = Mock()
+        adapter.client.networks.get.return_value = mock_net
+
+    adapter.delete_network("net-1")
+
+    if not test_case.config["raises"]:
+        mock_net.remove.assert_called_once()
+    print("test execution complete")
+
+
+# --------------------------
+# Container lifecycle tests
+# --------------------------
+
+
+def test_create_and_start_container(adapter_and_mock):
+    """Test create_and_start_container returns container id."""
+    print("Executing test: create_and_start_container returns container id")
+    adapter, _ = adapter_and_mock
+    mock_container = Mock()
+    mock_container.id = "abc123"
+    adapter.client.containers.run.return_value = mock_container
+
+    result = adapter.create_and_start_container(
+        image="python:3.10",
+        command=["python", "train.py"],
+        name="worker-0",
+        network_id="net-1",
+        environment={"KEY": "val"},
+        labels={"job": "1"},
+        volumes={"/data": {"bind": "/mnt/data", "mode": "rw"}},
+        working_dir="/app",
+    )
+
+    assert result == "abc123"
+    adapter.client.containers.run.assert_called_once_with(
+        image="python:3.10",
+        command=("python", "train.py"),
+        name="worker-0",
+        detach=True,
+        working_dir="/app",
+        network="net-1",
+        environment={"KEY": "val"},
+        labels={"job": "1"},
+        volumes={"/data": {"bind": "/mnt/data", "mode": "rw"}},
+        auto_remove=False,
+    )
+    print("test execution complete")
+
+
+# --------------------------
+# Container logs tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="container_logs follow mode yields decoded chunks",
+            expected_status=SUCCESS,
+            config={"follow": True},
+            expected_output=["hello ", "world"],
+        ),
+        TestCase(
+            name="container_logs non-follow returns full output",
+            expected_status=SUCCESS,
+            config={"follow": False},
+            expected_output=["hello world"],
+        ),
+    ],
+)
+def test_container_logs(adapter_and_mock, test_case):
+    """Test container_logs streaming and non-streaming modes."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+    mock_container = Mock()
+
+    if test_case.config["follow"]:
+        mock_container.logs.return_value = iter([b"hello ", b"world"])
+    else:
+        mock_container.logs.return_value = b"hello world"
+
+    adapter.client.containers.get.return_value = mock_container
+
+    result = list(adapter.container_logs("cid", follow=test_case.config["follow"]))
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# --------------------------
+# Stop / Remove / Pull tests
+# --------------------------
+
+
+def test_stop_container(adapter_and_mock):
+    """Test stop_container delegates to the container."""
+    print("Executing test: stop_container delegates correctly")
+    adapter, _ = adapter_and_mock
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    adapter.stop_container("cid", timeout=5)
+    mock_container.stop.assert_called_once_with(timeout=5)
+    print("test execution complete")
+
+
+def test_remove_container(adapter_and_mock):
+    """Test remove_container delegates to the container."""
+    print("Executing test: remove_container delegates correctly")
+    adapter, _ = adapter_and_mock
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    adapter.remove_container("cid", force=True)
+    mock_container.remove.assert_called_once_with(force=True)
+    print("test execution complete")
+
+
+def test_pull_image(adapter_and_mock):
+    """Test pull_image delegates to docker client."""
+    print("Executing test: pull_image delegates correctly")
+    adapter, _ = adapter_and_mock
+
+    adapter.pull_image("python:3.10")
+    adapter.client.images.pull.assert_called_once_with("python:3.10")
+    print("test execution complete")
+
+
+# --------------------------
+# Image exists tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="image_exists returns True when found",
+            expected_status=SUCCESS,
+            expected_output=True,
+        ),
+        TestCase(
+            name="image_exists returns False when not found",
+            expected_status=SUCCESS,
+            config={"raises": True},
+            expected_output=False,
+        ),
+    ],
+)
+def test_image_exists(adapter_and_mock, test_case):
+    """Test image_exists returns correct boolean."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.config.get("raises"):
+        adapter.client.images.get.side_effect = Exception("not found")
+    else:
+        adapter.client.images.get.return_value = Mock()
+
+    result = adapter.image_exists("myimage:latest")
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# --------------------------
+# Run oneoff container tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="run_oneoff_container success with bytes output",
+            expected_status=SUCCESS,
+            expected_output="output text",
+        ),
+        TestCase(
+            name="run_oneoff_container failure raises RuntimeError",
+            expected_status=FAILED,
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_run_oneoff_container(adapter_and_mock, test_case):
+    """Test run_oneoff_container success and failure paths."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.expected_error:
+        adapter.client.containers.run.side_effect = Exception("boom")
+        with pytest.raises(RuntimeError, match="One-off container failed"):
+            adapter.run_oneoff_container("img", ["cmd"])
+    else:
+        adapter.client.containers.run.return_value = b"output text"
+        result = adapter.run_oneoff_container("img", ["cmd"])
+        assert result == test_case.expected_output
+        adapter.client.containers.run.assert_called_once_with(
+            image="img",
+            command=("cmd",),
+            detach=False,
+            remove=True,
+        )
+    print("test execution complete")
+
+
+# --------------------------
+# Container status tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="container_status running",
+            expected_status=SUCCESS,
+            config={"status": "running"},
+            expected_output=("running", None),
+        ),
+        TestCase(
+            name="container_status exited with exit code",
+            expected_status=SUCCESS,
+            config={"status": "exited", "exit_code": 1},
+            expected_output=("exited", 1),
+        ),
+        TestCase(
+            name="container_status error returns unknown",
+            expected_status=SUCCESS,
+            config={"raises": True},
+            expected_output=("unknown", None),
+        ),
+    ],
+)
+def test_container_status(adapter_and_mock, test_case):
+    """Test container_status returns correct tuple."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.config.get("raises"):
+        adapter.client.containers.get.side_effect = Exception("gone")
+    else:
+        mock_container = Mock()
+        mock_container.status = test_case.config["status"]
+        if test_case.config["status"] == "exited":
+            mock_container.attrs = {"State": {"ExitCode": test_case.config["exit_code"]}}
+        adapter.client.containers.get.return_value = mock_container
+
+    result = adapter.container_status("cid")
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# --------------------------
+# Get container IP tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_container_ip found on exact network",
+            expected_status=SUCCESS,
+            config={"network_id": "net-1", "ip": "172.17.0.2"},
+            expected_output="172.17.0.2",
+        ),
+        TestCase(
+            name="get_container_ip not found returns None",
+            expected_status=SUCCESS,
+            config={"raises": True},
+            expected_output=None,
+        ),
+    ],
+)
+def test_get_container_ip(adapter_and_mock, test_case):
+    """Test get_container_ip returns IP or None."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.config.get("raises"):
+        adapter.client.containers.get.side_effect = Exception("gone")
+    else:
+        mock_container = Mock()
+        mock_container.attrs = {
+            "NetworkSettings": {
+                "Networks": {test_case.config["network_id"]: {"IPAddress": test_case.config["ip"]}}
+            }
+        }
+        adapter.client.containers.get.return_value = mock_container
+
+    result = adapter.get_container_ip("cid", "net-1")
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# --------------------------
+# List containers tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="list_containers without filters",
+            expected_status=SUCCESS,
+            config={"filters": None},
+            expected_output=[
+                {
+                    "id": "c1",
+                    "name": "worker-0",
+                    "labels": {"job": "1"},
+                    "status": "running",
+                    "created": "2025-01-01",
+                }
+            ],
+        ),
+        TestCase(
+            name="list_containers with filters",
+            expected_status=SUCCESS,
+            config={"filters": {"label": ["job=1"]}},
+            expected_output=[
+                {
+                    "id": "c1",
+                    "name": "worker-0",
+                    "labels": {"job": "1"},
+                    "status": "running",
+                    "created": "2025-01-01",
+                }
+            ],
+        ),
+    ],
+)
+def test_list_containers(adapter_and_mock, test_case):
+    """Test list_containers returns formatted list."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    mock_c = Mock()
+    mock_c.id = "c1"
+    mock_c.name = "worker-0"
+    mock_c.labels = {"job": "1"}
+    mock_c.status = "running"
+    mock_c.attrs = {"Created": "2025-01-01"}
+    adapter.client.containers.list.return_value = [mock_c]
+
+    result = adapter.list_containers(filters=test_case.config["filters"])
+    assert result == test_case.expected_output
+    adapter.client.containers.list.assert_called_once_with(
+        all=True, filters=test_case.config["filters"]
+    )
+    print("test execution complete")
+
+
+# --------------------------
+# Get network tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_network found",
+            expected_status=SUCCESS,
+            expected_output={
+                "id": "net-1",
+                "name": "test-net",
+                "labels": {"app": "test"},
+            },
+        ),
+        TestCase(
+            name="get_network not found returns None",
+            expected_status=SUCCESS,
+            config={"raises": True},
+            expected_output=None,
+        ),
+    ],
+)
+def test_get_network(adapter_and_mock, test_case):
+    """Test get_network returns dict or None."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+
+    if test_case.config.get("raises"):
+        adapter.client.networks.get.side_effect = Exception("not found")
+    else:
+        mock_net = Mock()
+        mock_net.id = "net-1"
+        mock_net.name = "test-net"
+        mock_net.attrs = {"Labels": {"app": "test"}}
+        adapter.client.networks.get.return_value = mock_net
+
+    result = adapter.get_network("net-1")
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# --------------------------
+# Wait for container tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="wait_for_container success",
+            expected_status=SUCCESS,
+            expected_output=0,
+        ),
+        TestCase(
+            name="wait_for_container timeout raises TimeoutError",
+            expected_status=FAILED,
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_wait_for_container(adapter_and_mock, test_case):
+    """Test wait_for_container returns exit code or raises."""
+    print(f"Executing test: {test_case.name}")
+    adapter, _ = adapter_and_mock
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    if test_case.expected_error:
+        mock_container.wait.side_effect = Exception("timeout exceeded")
+        with pytest.raises(TimeoutError):
+            adapter.wait_for_container("cid", timeout=30)
+    else:
+        mock_container.wait.return_value = {"StatusCode": 0}
+        result = adapter.wait_for_container("cid", timeout=60)
+        assert result == test_case.expected_output
+    print("test execution complete")

--- a/kubeflow/trainer/backends/container/adapters/podman_test.py
+++ b/kubeflow/trainer/backends/container/adapters/podman_test.py
@@ -1,0 +1,672 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for PodmanClientAdapter."""
+
+from contextlib import nullcontext
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+
+
+def _make_podman_module() -> tuple[ModuleType, MagicMock]:
+    """Build a fake ``podman`` module and return (module, MockPodmanClient)."""
+    mock_module = ModuleType("podman")
+    mock_client_cls = MagicMock(name="PodmanClient")
+    mock_module.PodmanClient = mock_client_cls  # type: ignore[attr-defined]
+    return mock_module, mock_client_cls
+
+
+def _create_adapter(
+    host: str | None = None,
+) -> "PodmanClientAdapter":  # noqa: F821
+    """Import and instantiate PodmanClientAdapter with a mocked podman."""
+    mock_module, mock_client_cls = _make_podman_module()
+    with patch.dict(sys.modules, {"podman": mock_module}):
+        from kubeflow.trainer.backends.container.adapters.podman import (
+            PodmanClientAdapter,
+        )
+
+        adapter = PodmanClientAdapter(host=host)
+    adapter._mock_client_cls = mock_client_cls
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="init with host",
+            expected_status=SUCCESS,
+            config={"host": "unix:///run/podman/podman.sock"},
+        ),
+        TestCase(
+            name="init without host",
+            expected_status=SUCCESS,
+            config={"host": None},
+        ),
+        TestCase(
+            name="init import error",
+            expected_status=FAILED,
+            expected_error=ImportError,
+        ),
+    ],
+)
+def test_init(test_case: TestCase) -> None:
+    """Test PodmanClientAdapter initialization."""
+    print(f"Executing test: {test_case.name}")
+
+    if test_case.expected_error is ImportError:
+        with (
+            patch.dict(sys.modules, {"podman": None}),
+            pytest.raises(ImportError, match="podman"),
+        ):
+            from kubeflow.trainer.backends.container.adapters.podman import (
+                PodmanClientAdapter,
+            )
+
+            PodmanClientAdapter()
+    else:
+        host = test_case.config["host"]
+        adapter = _create_adapter(host=host)
+        assert adapter._runtime_type == "podman"
+        assert adapter.client is not None
+        if host:
+            adapter._mock_client_cls.assert_called_once_with(base_url=host)
+        else:
+            adapter._mock_client_cls.assert_called_once_with()
+
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# ping
+# ---------------------------------------------------------------------------
+def test_ping() -> None:
+    """Test ping delegates to client."""
+    print("Executing test: ping")
+    adapter = _create_adapter()
+    adapter.ping()
+    adapter.client.ping.assert_called_once()
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# create_network
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="network already exists",
+            expected_status=SUCCESS,
+            config={"name": "existing-net", "labels": {"app": "test"}},
+            expected_output="existing-net",
+        ),
+        TestCase(
+            name="new network created",
+            expected_status=SUCCESS,
+            config={"name": "new-net", "labels": {"app": "train"}},
+            expected_output="new-net",
+        ),
+    ],
+)
+def test_create_network(test_case: TestCase) -> None:
+    """Test create_network returns name and applies correct params."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+    name = test_case.config["name"]
+    labels = test_case.config["labels"]
+
+    if test_case.name == "network already exists":
+        adapter.client.networks.get.return_value = Mock()
+    else:
+        adapter.client.networks.get.side_effect = Exception("not found")
+
+    result = adapter.create_network(name, labels)
+    assert result == test_case.expected_output
+
+    if test_case.name == "new network created":
+        adapter.client.networks.create.assert_called_once_with(
+            name=name,
+            driver="bridge",
+            dns_enabled=True,
+            labels=labels,
+        )
+    else:
+        adapter.client.networks.create.assert_not_called()
+
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# delete_network
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="delete existing network",
+            expected_status=SUCCESS,
+            config={"network_id": "net-123"},
+        ),
+        TestCase(
+            name="delete missing network silently",
+            expected_status=SUCCESS,
+            config={"network_id": "missing"},
+        ),
+    ],
+)
+def test_delete_network(test_case: TestCase) -> None:
+    """Test delete_network removes or silently ignores errors."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+    net_id = test_case.config["network_id"]
+
+    if test_case.name == "delete missing network silently":
+        adapter.client.networks.get.side_effect = Exception("gone")
+
+    adapter.delete_network(net_id)
+
+    if test_case.name == "delete existing network":
+        mock_net = adapter.client.networks.get.return_value
+        mock_net.remove.assert_called_once()
+
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# create_and_start_container
+# ---------------------------------------------------------------------------
+def test_create_and_start_container() -> None:
+    """Test create_and_start_container delegates to containers.run."""
+    print("Executing test: create_and_start_container")
+    adapter = _create_adapter()
+    mock_container = Mock(id="ctr-abc")
+    adapter.client.containers.run.return_value = mock_container
+
+    cid = adapter.create_and_start_container(
+        image="python:3.10",
+        command=["python", "train.py"],
+        name="worker-0",
+        network_id="net-1",
+        environment={"LR": "0.01"},
+        labels={"job": "train"},
+        volumes={"/data": {"bind": "/mnt/data", "mode": "rw"}},
+        working_dir="/app",
+    )
+    assert cid == "ctr-abc"
+    adapter.client.containers.run.assert_called_once_with(
+        image="python:3.10",
+        command=["python", "train.py"],
+        name="worker-0",
+        network="net-1",
+        working_dir="/app",
+        environment={"LR": "0.01"},
+        labels={"job": "train"},
+        volumes={"/data": {"bind": "/mnt/data", "mode": "rw"}},
+        detach=True,
+        remove=False,
+    )
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# container_logs
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="follow logs streaming",
+            expected_status=SUCCESS,
+            config={"follow": True},
+            expected_output=["hello\n", "world\n"],
+        ),
+        TestCase(
+            name="non-follow logs bytes",
+            expected_status=SUCCESS,
+            config={"follow": False},
+            expected_output=["done\n"],
+        ),
+        TestCase(
+            name="non-follow logs string fallback",
+            expected_status=SUCCESS,
+            config={"follow": False, "logs_type": "str"},
+            expected_output=["done-str"],
+        ),
+    ],
+)
+def test_container_logs(test_case: TestCase) -> None:
+    """Test container_logs yields decoded chunks."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    follow = test_case.config["follow"]
+
+    if follow:
+        mock_container.logs.return_value = iter([b"hello\n", b"world\n"])
+    elif test_case.config.get("logs_type") == "str":
+        mock_container.logs.return_value = "done-str"
+    else:
+        mock_container.logs.return_value = b"done\n"
+
+    result = list(adapter.container_logs("ctr-1", follow=follow))
+    assert result == test_case.expected_output
+    mock_container.logs.assert_called_once_with(stream=bool(follow), follow=bool(follow))
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# stop / remove / pull
+# ---------------------------------------------------------------------------
+def test_stop_container() -> None:
+    """Test stop_container delegates to container.stop."""
+    print("Executing test: stop_container")
+    adapter = _create_adapter()
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    adapter.stop_container("ctr-1", timeout=5)
+    mock_container.stop.assert_called_once_with(timeout=5)
+    print("test execution complete")
+
+
+def test_remove_container() -> None:
+    """Test remove_container delegates to container.remove."""
+    print("Executing test: remove_container")
+    adapter = _create_adapter()
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    adapter.remove_container("ctr-1", force=True)
+    mock_container.remove.assert_called_once_with(force=True)
+    print("test execution complete")
+
+
+def test_pull_image() -> None:
+    """Test pull_image delegates to client.images.pull."""
+    print("Executing test: pull_image")
+    adapter = _create_adapter()
+    adapter.pull_image("python:3.10")
+    adapter.client.images.pull.assert_called_once_with("python:3.10")
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# image_exists
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="image found",
+            expected_status=SUCCESS,
+            config={"image": "python:3.10", "exists": True},
+            expected_output=True,
+        ),
+        TestCase(
+            name="image not found",
+            expected_status=SUCCESS,
+            config={"image": "missing:latest", "exists": False},
+            expected_output=False,
+        ),
+    ],
+)
+def test_image_exists(test_case: TestCase) -> None:
+    """Test image_exists returns bool based on images.get."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+
+    if test_case.config["exists"]:
+        adapter.client.images.get.return_value = Mock()
+    else:
+        adapter.client.images.get.side_effect = Exception("not found")
+
+    result = adapter.image_exists(test_case.config["image"])
+    assert result is test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# run_oneoff_container
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="oneoff returns bytes",
+            expected_status=SUCCESS,
+            config={"logs": b"output\n"},
+            expected_output="output\n",
+        ),
+        TestCase(
+            name="oneoff returns string fallback",
+            expected_status=SUCCESS,
+            config={"logs": "str-output"},
+            expected_output="str-output",
+        ),
+        TestCase(
+            name="oneoff failure",
+            expected_status=FAILED,
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_run_oneoff_container(test_case: TestCase) -> None:
+    """Test run_oneoff_container with create+start+wait+logs pattern."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+
+    expectation = (
+        pytest.raises(RuntimeError, match="One-off container failed")
+        if test_case.expected_error
+        else nullcontext()
+    )
+
+    if test_case.expected_error:
+        adapter.client.containers.create.side_effect = Exception("boom")
+    else:
+        mock_container = Mock()
+        mock_container.logs.return_value = test_case.config["logs"]
+        adapter.client.containers.create.return_value = mock_container
+
+    with expectation:
+        result = adapter.run_oneoff_container("img:1", ["echo", "hi"])
+        assert result == test_case.expected_output
+        mock_container.start.assert_called_once()
+        mock_container.wait.assert_called_once()
+        adapter.client.containers.create.assert_called_once_with(
+            image="img:1",
+            command=["echo", "hi"],
+            detach=False,
+            remove=True,
+        )
+
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# container_status
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="running container",
+            expected_status=SUCCESS,
+            config={"status": "running"},
+            expected_output=("running", None),
+        ),
+        TestCase(
+            name="exited container with code",
+            expected_status=SUCCESS,
+            config={"status": "exited", "exit_code": 1},
+            expected_output=("exited", 1),
+        ),
+        TestCase(
+            name="container not found",
+            expected_status=SUCCESS,
+            config={"missing": True},
+            expected_output=("unknown", None),
+        ),
+    ],
+)
+def test_container_status(test_case: TestCase) -> None:
+    """Test container_status returns (status, exit_code) tuple."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+
+    if test_case.config.get("missing"):
+        adapter.client.containers.get.side_effect = Exception("gone")
+    else:
+        mock_container = Mock()
+        mock_container.status = test_case.config["status"]
+        if test_case.config["status"] == "exited":
+            mock_container.attrs = {"State": {"ExitCode": test_case.config["exit_code"]}}
+        adapter.client.containers.get.return_value = mock_container
+
+    result = adapter.container_status("ctr-1")
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_container_ip
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="ip found by exact network",
+            expected_status=SUCCESS,
+            config={"network_id": "my-net", "ip": "10.0.0.5"},
+            expected_output="10.0.0.5",
+        ),
+        TestCase(
+            name="ip fallback to first network",
+            expected_status=SUCCESS,
+            config={"network_id": "unknown-net", "ip": "10.0.0.9"},
+            expected_output="10.0.0.9",
+        ),
+        TestCase(
+            name="container not found returns None",
+            expected_status=SUCCESS,
+            config={"missing": True},
+            expected_output=None,
+        ),
+    ],
+)
+def test_get_container_ip(test_case: TestCase) -> None:
+    """Test get_container_ip extracts IP from NetworkSettings."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+
+    if test_case.config.get("missing"):
+        adapter.client.containers.get.side_effect = Exception("gone")
+    else:
+        net_id = test_case.config["network_id"]
+        ip = test_case.config["ip"]
+        mock_container = Mock()
+        if test_case.name == "ip fallback to first network":
+            mock_container.attrs = {
+                "NetworkSettings": {
+                    "Networks": {
+                        "other-net": {"IPAddress": ip},
+                    }
+                }
+            }
+        else:
+            mock_container.attrs = {
+                "NetworkSettings": {
+                    "Networks": {
+                        net_id: {"IPAddress": ip},
+                    }
+                }
+            }
+        adapter.client.containers.get.return_value = mock_container
+
+    result = adapter.get_container_ip("ctr-1", test_case.config.get("network_id", "x"))
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# list_containers  (verify filter workaround for single-item lists)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="single-item filter list flattened",
+            expected_status=SUCCESS,
+            config={
+                "filters": {"label": ["app=train"], "name": ["worker"]},
+            },
+        ),
+        TestCase(
+            name="multi-item filter list kept",
+            expected_status=SUCCESS,
+            config={
+                "filters": {"label": ["app=train", "job=1"]},
+            },
+        ),
+        TestCase(
+            name="list_containers exception returns empty",
+            expected_status=SUCCESS,
+            config={"filters": {}, "error": True},
+            expected_output=[],
+        ),
+    ],
+)
+def test_list_containers(test_case: TestCase) -> None:
+    """Test list_containers with podman-py single-item filter workaround."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+    filters = dict(test_case.config["filters"])
+
+    if test_case.config.get("error"):
+        adapter.client.containers.list.side_effect = Exception("fail")
+        result = adapter.list_containers(filters=filters)
+        assert result == []
+    else:
+        mock_ctr = Mock()
+        mock_ctr.id = "ctr-1"
+        mock_ctr.name = "worker-0"
+        mock_ctr.labels = {"app": "train"}
+        mock_ctr.status = "running"
+        mock_ctr.attrs = {"Created": "2025-01-01T00:00:00Z"}
+        adapter.client.containers.list.return_value = [mock_ctr]
+
+        original_filters = dict(filters)
+        result = adapter.list_containers(filters=filters)
+
+        for k, v in original_filters.items():
+            if len(v) == 1:
+                assert filters[k] == v[0]
+            else:
+                assert filters[k] == v
+
+        mock_ctr.reload.assert_called_once()
+        assert len(result) == 1
+        assert result[0]["id"] == "ctr-1"
+        assert result[0]["name"] == "worker-0"
+        assert result[0]["labels"] == {"app": "train"}
+        assert result[0]["status"] == "running"
+
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_network  (verify lowercase "labels")
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="existing network with lowercase labels",
+            expected_status=SUCCESS,
+            config={"network_id": "net-1"},
+            expected_output={
+                "id": "net-id-1",
+                "name": "my-net",
+                "labels": {"managed-by": "kubeflow"},
+            },
+        ),
+        TestCase(
+            name="network not found",
+            expected_status=SUCCESS,
+            config={"network_id": "missing"},
+            expected_output=None,
+        ),
+    ],
+)
+def test_get_network(test_case: TestCase) -> None:
+    """Test get_network uses lowercase 'labels' key from inspect."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+    net_id = test_case.config["network_id"]
+
+    if test_case.expected_output is None:
+        adapter.client.networks.get.side_effect = Exception("missing")
+    else:
+        mock_net = Mock()
+        mock_net.attrs = {
+            "ID": "net-id-1",
+            "Name": "my-net",
+            "labels": {"managed-by": "kubeflow"},
+        }
+        adapter.client.networks.get.return_value = mock_net
+
+    result = adapter.get_network(net_id)
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# wait_for_container
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="wait returns int exit code",
+            expected_status=SUCCESS,
+            config={"wait_result": 0},
+            expected_output=0,
+        ),
+        TestCase(
+            name="wait returns non-zero exit code",
+            expected_status=SUCCESS,
+            config={"wait_result": 137},
+            expected_output=137,
+        ),
+        TestCase(
+            name="wait timeout raises TimeoutError",
+            expected_status=FAILED,
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_wait_for_container(test_case: TestCase) -> None:
+    """Test wait_for_container returns int result directly."""
+    print(f"Executing test: {test_case.name}")
+    adapter = _create_adapter()
+    mock_container = Mock()
+    adapter.client.containers.get.return_value = mock_container
+
+    expectation = (
+        pytest.raises(TimeoutError) if test_case.expected_error is TimeoutError else nullcontext()
+    )
+
+    if test_case.expected_error is TimeoutError:
+        mock_container.wait.side_effect = Exception("timeout waiting for container")
+    else:
+        mock_container.wait.return_value = test_case.config["wait_result"]
+
+    with expectation:
+        result = adapter.wait_for_container("ctr-1", timeout=30)
+        assert result == test_case.expected_output
+        assert isinstance(result, int)
+
+    print("test execution complete")

--- a/kubeflow/trainer/backends/container/adapters/podman_test.py
+++ b/kubeflow/trainer/backends/container/adapters/podman_test.py
@@ -118,13 +118,13 @@ def test_ping() -> None:
         TestCase(
             name="network already exists",
             expected_status=SUCCESS,
-            config={"name": "existing-net", "labels": {"app": "test"}},
+            config={"name": "existing-net", "labels": {"app": "test"}, "existing": True},
             expected_output="existing-net",
         ),
         TestCase(
             name="new network created",
             expected_status=SUCCESS,
-            config={"name": "new-net", "labels": {"app": "train"}},
+            config={"name": "new-net", "labels": {"app": "train"}, "existing": False},
             expected_output="new-net",
         ),
     ],
@@ -136,7 +136,7 @@ def test_create_network(test_case: TestCase) -> None:
     name = test_case.config["name"]
     labels = test_case.config["labels"]
 
-    if test_case.name == "network already exists":
+    if test_case.config["existing"]:
         adapter.client.networks.get.return_value = Mock()
     else:
         adapter.client.networks.get.side_effect = Exception("not found")
@@ -144,7 +144,7 @@ def test_create_network(test_case: TestCase) -> None:
     result = adapter.create_network(name, labels)
     assert result == test_case.expected_output
 
-    if test_case.name == "new network created":
+    if not test_case.config["existing"]:
         adapter.client.networks.create.assert_called_once_with(
             name=name,
             driver="bridge",
@@ -166,12 +166,12 @@ def test_create_network(test_case: TestCase) -> None:
         TestCase(
             name="delete existing network",
             expected_status=SUCCESS,
-            config={"network_id": "net-123"},
+            config={"network_id": "net-123", "missing": False},
         ),
         TestCase(
             name="delete missing network silently",
             expected_status=SUCCESS,
-            config={"network_id": "missing"},
+            config={"network_id": "missing", "missing": True},
         ),
     ],
 )
@@ -181,12 +181,12 @@ def test_delete_network(test_case: TestCase) -> None:
     adapter = _create_adapter()
     net_id = test_case.config["network_id"]
 
-    if test_case.name == "delete missing network silently":
+    if test_case.config["missing"]:
         adapter.client.networks.get.side_effect = Exception("gone")
 
     adapter.delete_network(net_id)
 
-    if test_case.name == "delete existing network":
+    if not test_case.config["missing"]:
         mock_net = adapter.client.networks.get.return_value
         mock_net.remove.assert_called_once()
 
@@ -460,13 +460,13 @@ def test_container_status(test_case: TestCase) -> None:
         TestCase(
             name="ip found by exact network",
             expected_status=SUCCESS,
-            config={"network_id": "my-net", "ip": "10.0.0.5"},
+            config={"network_id": "my-net", "ip": "10.0.0.5", "fallback": False},
             expected_output="10.0.0.5",
         ),
         TestCase(
             name="ip fallback to first network",
             expected_status=SUCCESS,
-            config={"network_id": "unknown-net", "ip": "10.0.0.9"},
+            config={"network_id": "unknown-net", "ip": "10.0.0.9", "fallback": True},
             expected_output="10.0.0.9",
         ),
         TestCase(
@@ -488,7 +488,7 @@ def test_get_container_ip(test_case: TestCase) -> None:
         net_id = test_case.config["network_id"]
         ip = test_case.config["ip"]
         mock_container = Mock()
-        if test_case.name == "ip fallback to first network":
+        if test_case.config["fallback"]:
             mock_container.attrs = {
                 "NetworkSettings": {
                     "Networks": {

--- a/kubeflow/trainer/backends/container/types_test.py
+++ b/kubeflow/trainer/backends/container/types_test.py
@@ -1,0 +1,133 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Container backend Pydantic models."""
+
+from pydantic import ValidationError
+import pytest
+
+from kubeflow.trainer.backends.container.types import (
+    ContainerBackendConfig,
+    TrainingRuntimeSource,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default ContainerBackendConfig values",
+            expected_status=SUCCESS,
+            config={},
+            expected_output={
+                "pull_policy": "IfNotPresent",
+                "auto_remove": True,
+                "container_host": None,
+                "container_runtime": None,
+                "dataset_initializer_image": (
+                    "ghcr.io/kubeflow/trainer/dataset-initializer:latest"
+                ),
+                "model_initializer_image": ("ghcr.io/kubeflow/trainer/model-initializer:latest"),
+                "initializer_timeout": 600,
+            },
+        ),
+        TestCase(
+            name="custom ContainerBackendConfig values",
+            expected_status=SUCCESS,
+            config={
+                "pull_policy": "Always",
+                "auto_remove": False,
+                "container_host": "tcp://192.168.1.100:2375",
+                "container_runtime": "docker",
+                "initializer_timeout": 300,
+            },
+            expected_output={
+                "pull_policy": "Always",
+                "auto_remove": False,
+                "container_host": "tcp://192.168.1.100:2375",
+                "container_runtime": "docker",
+                "initializer_timeout": 300,
+            },
+        ),
+        TestCase(
+            name="ContainerBackendConfig with docker runtime",
+            expected_status=SUCCESS,
+            config={"container_runtime": "docker"},
+            expected_output={"container_runtime": "docker"},
+        ),
+        TestCase(
+            name="ContainerBackendConfig with podman runtime",
+            expected_status=SUCCESS,
+            config={"container_runtime": "podman"},
+            expected_output={"container_runtime": "podman"},
+        ),
+        TestCase(
+            name="invalid container_runtime raises ValidationError",
+            expected_status=FAILED,
+            config={"container_runtime": "containerd"},
+            expected_error=ValidationError,
+        ),
+    ],
+)
+def test_container_backend_config(test_case: TestCase):
+    """Test ContainerBackendConfig model creation and validation."""
+    print(f"Executing test: {test_case.name}")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            ContainerBackendConfig(**test_case.config)
+    else:
+        cfg = ContainerBackendConfig(**test_case.config)
+        for key, expected_val in test_case.expected_output.items():
+            assert getattr(cfg, key) == expected_val, (
+                f"{key}: expected {expected_val}, got {getattr(cfg, key)}"
+            )
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="TrainingRuntimeSource defaults",
+            expected_status=SUCCESS,
+            config={},
+            expected_output=["github://kubeflow/trainer"],
+        ),
+        TestCase(
+            name="TrainingRuntimeSource custom sources",
+            expected_status=SUCCESS,
+            config={
+                "sources": [
+                    "file:///opt/runtimes",
+                    "https://example.com/runtimes",
+                ],
+            },
+            expected_output=[
+                "file:///opt/runtimes",
+                "https://example.com/runtimes",
+            ],
+        ),
+    ],
+)
+def test_training_runtime_source(test_case: TestCase):
+    """Test TrainingRuntimeSource model creation."""
+    print(f"Executing test: {test_case.name}")
+
+    src = TrainingRuntimeSource(**test_case.config)
+    assert src.sources == test_case.expected_output
+
+    print("test execution complete")

--- a/kubeflow/trainer/backends/container/utils_test.py
+++ b/kubeflow/trainer/backends/container/utils_test.py
@@ -1,0 +1,558 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Container backend utility functions."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kubeflow.common.constants import UNKNOWN
+from kubeflow.trainer.backends.container.types import ContainerBackendConfig
+from kubeflow.trainer.backends.container.utils import (
+    aggregate_status_from_containers,
+    build_environment,
+    build_pip_install_cmd,
+    container_status_to_trainjob_status,
+    create_workdir,
+    get_container_status,
+    get_dataset_initializer,
+    get_model_initializer,
+    get_optional_initializer_envs,
+    get_training_script_code,
+    maybe_pull_image,
+)
+from kubeflow.trainer.constants import constants
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types import types
+
+
+# -------------------------------------------------------
+# create_workdir
+# -------------------------------------------------------
+def test_create_workdir(tmp_path):
+    """Test that create_workdir creates the expected directory."""
+    print("Executing test: create_workdir creates directory")
+
+    with patch("kubeflow.trainer.backends.container.utils.Path.home", return_value=tmp_path):
+        result = create_workdir("my-job")
+
+    expected = str((tmp_path / ".kubeflow" / "trainer" / "containers" / "my-job").resolve())
+    assert result == expected
+    assert (tmp_path / ".kubeflow" / "trainer" / "containers" / "my-job").is_dir()
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# get_training_script_code
+# -------------------------------------------------------
+def _sample_train_func():
+    x = 1 + 1
+    return x
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="training script without func_args",
+            expected_status=SUCCESS,
+            config={"func_args": None},
+            expected_output="_sample_train_func()",
+        ),
+        TestCase(
+            name="training script with func_args",
+            expected_status=SUCCESS,
+            config={"func_args": {"lr": 0.01}},
+            expected_output="_sample_train_func(**{'lr': 0.01})",
+        ),
+    ],
+)
+def test_get_training_script_code(test_case: TestCase):
+    """Test training script code generation."""
+    print(f"Executing test: {test_case.name}")
+
+    trainer = types.CustomTrainer(
+        func=_sample_train_func,
+        func_args=test_case.config["func_args"],
+    )
+    code = get_training_script_code(trainer)
+
+    assert "def _sample_train_func():" in code
+    assert test_case.expected_output in code
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# build_environment
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="build environment with env vars",
+            expected_status=SUCCESS,
+            config={"env": {"MY_VAR": "val1", "OTHER": "val2"}},
+            expected_output={"MY_VAR": "val1", "OTHER": "val2"},
+        ),
+        TestCase(
+            name="build environment without env",
+            expected_status=SUCCESS,
+            config={"env": None},
+            expected_output={},
+        ),
+    ],
+)
+def test_build_environment(test_case: TestCase):
+    """Test environment variable construction from trainer config."""
+    print(f"Executing test: {test_case.name}")
+
+    trainer = types.CustomTrainer(
+        func=_sample_train_func,
+        env=test_case.config["env"],
+    )
+    result = build_environment(trainer)
+    assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# build_pip_install_cmd
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="pip install with packages",
+            expected_status=SUCCESS,
+            config={"packages": ["torch", "numpy"]},
+            expected_output=(
+                "PIP_DISABLE_PIP_VERSION_CHECK=1 pip install "
+                "--no-warn-script-location "
+                "--index-url https://pypi.org/simple  "
+                '"torch" "numpy" && '
+            ),
+        ),
+        TestCase(
+            name="pip install without packages",
+            expected_status=SUCCESS,
+            config={"packages": None},
+            expected_output="",
+        ),
+        TestCase(
+            name="pip install with index urls",
+            expected_status=SUCCESS,
+            config={
+                "packages": ["transformers"],
+                "pip_index_urls": [
+                    "https://pypi.org/simple",
+                    "https://download.pytorch.org/whl/cpu",
+                ],
+            },
+            expected_output=(
+                "PIP_DISABLE_PIP_VERSION_CHECK=1 pip install "
+                "--no-warn-script-location "
+                "--index-url https://pypi.org/simple "
+                "--extra-index-url https://download.pytorch.org/whl/cpu "
+                '"transformers" && '
+            ),
+        ),
+    ],
+)
+def test_build_pip_install_cmd(test_case: TestCase):
+    """Test pip install command generation."""
+    print(f"Executing test: {test_case.name}")
+
+    kwargs = {"func": _sample_train_func, "packages_to_install": test_case.config["packages"]}
+    if "pip_index_urls" in test_case.config:
+        kwargs["pip_index_urls"] = test_case.config["pip_index_urls"]
+    trainer = types.CustomTrainer(**kwargs)
+
+    result = build_pip_install_cmd(trainer)
+    assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# container_status_to_trainjob_status
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="running container",
+            expected_status=SUCCESS,
+            config={"status": "running", "exit_code": 0},
+            expected_output=constants.TRAINJOB_RUNNING,
+        ),
+        TestCase(
+            name="created container",
+            expected_status=SUCCESS,
+            config={"status": "created", "exit_code": 0},
+            expected_output=constants.TRAINJOB_CREATED,
+        ),
+        TestCase(
+            name="exited container with exit code 0",
+            expected_status=SUCCESS,
+            config={"status": "exited", "exit_code": 0},
+            expected_output=constants.TRAINJOB_COMPLETE,
+        ),
+        TestCase(
+            name="exited container with exit code 1",
+            expected_status=SUCCESS,
+            config={"status": "exited", "exit_code": 1},
+            expected_output=constants.TRAINJOB_FAILED,
+        ),
+        TestCase(
+            name="unknown container status",
+            expected_status=SUCCESS,
+            config={"status": "paused", "exit_code": 0},
+            expected_output=UNKNOWN,
+        ),
+    ],
+)
+def test_container_status_to_trainjob_status(test_case: TestCase):
+    """Test mapping of container status to TrainJob status."""
+    print(f"Executing test: {test_case.name}")
+
+    result = container_status_to_trainjob_status(
+        test_case.config["status"],
+        test_case.config["exit_code"],
+    )
+    assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# aggregate_status_from_containers
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="failed takes priority",
+            expected_status=SUCCESS,
+            config={
+                "statuses": [
+                    constants.TRAINJOB_RUNNING,
+                    constants.TRAINJOB_FAILED,
+                    constants.TRAINJOB_COMPLETE,
+                ],
+            },
+            expected_output=constants.TRAINJOB_FAILED,
+        ),
+        TestCase(
+            name="running takes priority over complete",
+            expected_status=SUCCESS,
+            config={
+                "statuses": [
+                    constants.TRAINJOB_RUNNING,
+                    constants.TRAINJOB_COMPLETE,
+                ],
+            },
+            expected_output=constants.TRAINJOB_RUNNING,
+        ),
+        TestCase(
+            name="all complete",
+            expected_status=SUCCESS,
+            config={
+                "statuses": [
+                    constants.TRAINJOB_COMPLETE,
+                    constants.TRAINJOB_COMPLETE,
+                ],
+            },
+            expected_output=constants.TRAINJOB_COMPLETE,
+        ),
+        TestCase(
+            name="created present",
+            expected_status=SUCCESS,
+            config={
+                "statuses": [
+                    constants.TRAINJOB_CREATED,
+                    constants.TRAINJOB_COMPLETE,
+                ],
+            },
+            expected_output=constants.TRAINJOB_CREATED,
+        ),
+    ],
+)
+def test_aggregate_status_from_containers(test_case: TestCase):
+    """Test aggregation of multiple container statuses."""
+    print(f"Executing test: {test_case.name}")
+
+    result = aggregate_status_from_containers(test_case.config["statuses"])
+    assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# maybe_pull_image
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="IfNotPresent when image exists",
+            expected_status=SUCCESS,
+            config={
+                "policy": "IfNotPresent",
+                "image_exists": True,
+            },
+            expected_output="no_pull",
+        ),
+        TestCase(
+            name="IfNotPresent when image missing",
+            expected_status=SUCCESS,
+            config={
+                "policy": "IfNotPresent",
+                "image_exists": False,
+            },
+            expected_output="pull",
+        ),
+        TestCase(
+            name="Always pulls regardless",
+            expected_status=SUCCESS,
+            config={
+                "policy": "Always",
+                "image_exists": True,
+            },
+            expected_output="pull",
+        ),
+        TestCase(
+            name="Never when image exists",
+            expected_status=SUCCESS,
+            config={
+                "policy": "Never",
+                "image_exists": True,
+            },
+            expected_output="no_pull",
+        ),
+        TestCase(
+            name="Never when image missing raises",
+            expected_status=FAILED,
+            config={
+                "policy": "Never",
+                "image_exists": False,
+            },
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_maybe_pull_image(test_case: TestCase):
+    """Test image pulling behavior for different pull policies."""
+    print(f"Executing test: {test_case.name}")
+
+    adapter = MagicMock()
+    adapter.image_exists.return_value = test_case.config["image_exists"]
+    image = "test-image:latest"
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            maybe_pull_image(adapter, image, test_case.config["policy"])
+    else:
+        maybe_pull_image(adapter, image, test_case.config["policy"])
+        if test_case.expected_output == "pull":
+            adapter.pull_image.assert_called_once_with(image)
+        else:
+            adapter.pull_image.assert_not_called()
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# get_container_status
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_container_status success",
+            expected_status=SUCCESS,
+            config={"status": "running", "exit_code": 0},
+            expected_output=constants.TRAINJOB_RUNNING,
+        ),
+        TestCase(
+            name="get_container_status error returns UNKNOWN",
+            expected_status=SUCCESS,
+            config={"raise_error": True},
+            expected_output=UNKNOWN,
+        ),
+    ],
+)
+def test_get_container_status(test_case: TestCase):
+    """Test container status retrieval with success and error paths."""
+    print(f"Executing test: {test_case.name}")
+
+    adapter = MagicMock()
+    if test_case.config.get("raise_error"):
+        adapter.container_status.side_effect = Exception("connection lost")
+    else:
+        adapter.container_status.return_value = (
+            test_case.config["status"],
+            test_case.config["exit_code"],
+        )
+
+    result = get_container_status(adapter, "container-abc")
+    assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# get_optional_initializer_envs
+# -------------------------------------------------------
+def test_get_optional_initializer_envs():
+    """Test extraction of optional fields as environment variables."""
+    print("Executing test: get_optional_initializer_envs")
+
+    init = types.HuggingFaceDatasetInitializer(
+        storage_uri="hf://user/dataset",
+        access_token="tok123",
+    )
+    env = get_optional_initializer_envs(init, required_fields={"storage_uri"})
+    assert "ACCESS_TOKEN" in env
+    assert env["ACCESS_TOKEN"] == "tok123"
+    assert "STORAGE_URI" not in env
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# get_dataset_initializer
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dataset initializer with HuggingFace",
+            expected_status=SUCCESS,
+            config={
+                "dataset": types.HuggingFaceDatasetInitializer(
+                    storage_uri="hf://user/my-dataset",
+                ),
+            },
+            expected_output={
+                "name": "dataset-initializer",
+                "env_storage_uri": "hf://user/my-dataset",
+                "env_output_path": constants.DATASET_PATH,
+            },
+        ),
+        TestCase(
+            name="dataset initializer with S3",
+            expected_status=SUCCESS,
+            config={
+                "dataset": types.S3DatasetInitializer(
+                    storage_uri="s3://bucket/data",
+                    endpoint="https://s3.example.com",
+                ),
+            },
+            expected_output={
+                "name": "dataset-initializer",
+                "env_storage_uri": "s3://bucket/data",
+                "env_output_path": constants.DATASET_PATH,
+            },
+        ),
+        TestCase(
+            name="unsupported dataset initializer type",
+            expected_status=FAILED,
+            config={"dataset": "not-an-initializer"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_dataset_initializer(test_case: TestCase):
+    """Test dataset initializer container config generation."""
+    print(f"Executing test: {test_case.name}")
+
+    cfg = ContainerBackendConfig()
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            get_dataset_initializer(test_case.config["dataset"], cfg)
+    else:
+        result = get_dataset_initializer(test_case.config["dataset"], cfg)
+        assert result.name == test_case.expected_output["name"]
+        assert result.env["STORAGE_URI"] == test_case.expected_output["env_storage_uri"]
+        assert result.env["OUTPUT_PATH"] == test_case.expected_output["env_output_path"]
+        assert result.image == cfg.dataset_initializer_image
+
+    print("test execution complete")
+
+
+# -------------------------------------------------------
+# get_model_initializer
+# -------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="model initializer with HuggingFace",
+            expected_status=SUCCESS,
+            config={
+                "model": types.HuggingFaceModelInitializer(
+                    storage_uri="hf://user/my-model",
+                ),
+            },
+            expected_output={
+                "name": "model-initializer",
+                "env_storage_uri": "hf://user/my-model",
+                "env_output_path": constants.MODEL_PATH,
+            },
+        ),
+        TestCase(
+            name="model initializer with S3",
+            expected_status=SUCCESS,
+            config={
+                "model": types.S3ModelInitializer(
+                    storage_uri="s3://bucket/model",
+                    endpoint="https://s3.example.com",
+                ),
+            },
+            expected_output={
+                "name": "model-initializer",
+                "env_storage_uri": "s3://bucket/model",
+                "env_output_path": constants.MODEL_PATH,
+            },
+        ),
+        TestCase(
+            name="unsupported model initializer type",
+            expected_status=FAILED,
+            config={"model": "not-an-initializer"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_model_initializer(test_case: TestCase):
+    """Test model initializer container config generation."""
+    print(f"Executing test: {test_case.name}")
+
+    cfg = ContainerBackendConfig()
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            get_model_initializer(test_case.config["model"], cfg)
+    else:
+        result = get_model_initializer(test_case.config["model"], cfg)
+        assert result.name == test_case.expected_output["name"]
+        assert result.env["STORAGE_URI"] == test_case.expected_output["env_storage_uri"]
+        assert result.env["OUTPUT_PATH"] == test_case.expected_output["env_output_path"]
+        assert result.image == cfg.model_initializer_image
+
+    print("test execution complete")

--- a/kubeflow/trainer/backends/localprocess/job_test.py
+++ b/kubeflow/trainer/backends/localprocess/job_test.py
@@ -1,0 +1,248 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the LocalJob class in the Kubeflow Trainer SDK."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from kubeflow.trainer.backends.localprocess.job import LocalJob
+from kubeflow.trainer.constants import constants
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="init with defaults",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "command": ["echo", "hello"],
+            },
+            expected_output={
+                "status": constants.TRAINJOB_CREATED,
+                "stdout": "",
+                "success": False,
+                "returncode": None,
+                "dependencies": [],
+                "env": {},
+                "creation_time": None,
+                "completion_time": None,
+            },
+        ),
+        TestCase(
+            name="init with custom env and dependencies",
+            expected_status=SUCCESS,
+            config={
+                "name": "custom-job",
+                "command": "run.sh",
+                "env": {"KEY": "VAL"},
+                "dependencies": ["dep1"],
+            },
+            expected_output={
+                "env": {"KEY": "VAL"},
+                "dependencies": ["dep1"],
+            },
+        ),
+    ],
+)
+def test_local_job_init(test_case):
+    """Test LocalJob initialization with various configurations."""
+    print("Executing test:", test_case.name)
+
+    config = test_case.config
+    job = LocalJob(
+        name=config["name"],
+        command=config["command"],
+        env=config.get("env"),
+        dependencies=config.get("dependencies"),
+    )
+
+    expected = test_case.expected_output
+    assert job.status == expected.get("status", constants.TRAINJOB_CREATED)
+    assert job.env == expected["env"]
+    assert job.dependencies == expected["dependencies"]
+
+    if "stdout" in expected:
+        assert job.stdout == expected["stdout"]
+    if "success" in expected:
+        assert job.success == expected["success"]
+    if "returncode" in expected:
+        assert job.returncode == expected["returncode"]
+    if "creation_time" in expected:
+        assert job.creation_time == expected["creation_time"]
+    if "completion_time" in expected:
+        assert job.completion_time == expected["completion_time"]
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="cancel sets the cancel flag",
+            expected_status=SUCCESS,
+            config={"name": "cancel-job", "command": ["sleep", "10"]},
+        ),
+    ],
+)
+def test_local_job_cancel(test_case):
+    """Test that cancel sets the internal cancel-requested event."""
+    print("Executing test:", test_case.name)
+
+    job = LocalJob(name=test_case.config["name"], command=test_case.config["command"])
+    assert not job._cancel_requested.is_set()
+    job.cancel()
+    assert job._cancel_requested.is_set()
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="logs without follow returns splitlines",
+            expected_status=SUCCESS,
+            config={
+                "name": "logs-job",
+                "command": ["echo"],
+                "stdout_content": "line1\nline2\nline3",
+            },
+            expected_output=["line1", "line2", "line3"],
+        ),
+        TestCase(
+            name="logs without follow on empty stdout",
+            expected_status=SUCCESS,
+            config={
+                "name": "empty-logs-job",
+                "command": ["echo"],
+                "stdout_content": "",
+            },
+            expected_output=[],
+        ),
+    ],
+)
+def test_local_job_logs(test_case):
+    """Test logs method returns stdout lines when follow=False."""
+    print("Executing test:", test_case.name)
+
+    job = LocalJob(
+        name=test_case.config["name"],
+        command=test_case.config["command"],
+    )
+    job._stdout = test_case.config["stdout_content"]
+
+    result = job.logs(follow=False)
+    assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dependency failure skips execution",
+            expected_status=FAILED,
+            config={
+                "name": "dep-fail-job",
+                "command": ["echo", "should-not-run"],
+            },
+            expected_output="Dependency failing-dep failed. Skipping",
+        ),
+    ],
+)
+def test_local_job_dependency_failure(test_case):
+    """Test that a failed dependency prevents job execution."""
+    print("Executing test:", test_case.name)
+
+    failing_dep = Mock()
+    failing_dep.name = "failing-dep"
+    failing_dep.success = False
+    failing_dep.join = Mock()
+
+    job = LocalJob(
+        name=test_case.config["name"],
+        command=test_case.config["command"],
+        dependencies=[failing_dep],
+    )
+    job.run()
+
+    assert job.stdout == test_case.expected_output
+    failing_dep.join.assert_called_once()
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="successful subprocess sets Complete status",
+            expected_status=SUCCESS,
+            config={
+                "name": "success-job",
+                "command": ["echo", "hello"],
+                "returncode": 0,
+                "output_lines": ["hello\n", ""],
+            },
+            expected_output={
+                "status": constants.TRAINJOB_COMPLETE,
+                "success": True,
+            },
+        ),
+        TestCase(
+            name="failed subprocess sets Failed status",
+            expected_status=FAILED,
+            config={
+                "name": "fail-job",
+                "command": ["false"],
+                "returncode": 1,
+                "output_lines": ["error\n", ""],
+            },
+            expected_output={
+                "status": constants.TRAINJOB_FAILED,
+                "success": False,
+            },
+        ),
+    ],
+)
+def test_local_job_run_subprocess(test_case):
+    """Test job run with mocked subprocess for success and failure."""
+    print("Executing test:", test_case.name)
+
+    config = test_case.config
+    mock_process = MagicMock()
+    mock_process.stdout.readline.side_effect = config["output_lines"]
+    mock_process.poll.return_value = config["returncode"]
+    mock_process.wait.return_value = config["returncode"]
+    mock_process.returncode = config["returncode"]
+    mock_process.stdout.close = Mock()
+
+    with patch("subprocess.Popen", return_value=mock_process), patch("os.chdir"):
+        job = LocalJob(name=config["name"], command=config["command"])
+        job.run()
+
+    expected = test_case.expected_output
+    assert job.status == expected["status"]
+    assert job.success == expected["success"]
+    assert job.creation_time is not None
+    assert job.completion_time is not None
+
+    print("test execution complete")

--- a/kubeflow/trainer/backends/localprocess/types_test.py
+++ b/kubeflow/trainer/backends/localprocess/types_test.py
@@ -1,0 +1,181 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for LocalProcess backend types."""
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from kubeflow.trainer.backends.localprocess.job import LocalJob
+from kubeflow.trainer.backends.localprocess.types import (
+    LocalBackendJobs,
+    LocalBackendStep,
+    LocalProcessBackendConfig,
+    LocalRuntimeTrainer,
+)
+from kubeflow.trainer.test.common import SUCCESS, TestCase
+from kubeflow.trainer.types import types
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default config has cleanup_venv True",
+            expected_status=SUCCESS,
+            config={},
+            expected_output={"cleanup_venv": True},
+        ),
+        TestCase(
+            name="custom config with cleanup_venv False",
+            expected_status=SUCCESS,
+            config={"cleanup_venv": False},
+            expected_output={"cleanup_venv": False},
+        ),
+    ],
+)
+def test_local_process_backend_config(test_case):
+    """Test LocalProcessBackendConfig default and custom values."""
+    print("Executing test:", test_case.name)
+
+    cfg = LocalProcessBackendConfig(**test_case.config)
+    assert cfg.cleanup_venv == test_case.expected_output["cleanup_venv"]
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default runtime trainer has empty packages",
+            expected_status=SUCCESS,
+            config={
+                "trainer_type": types.TrainerType.CUSTOM_TRAINER,
+                "framework": "torch",
+                "image": "pytorch/pytorch:latest",
+            },
+            expected_output=[],
+        ),
+        TestCase(
+            name="runtime trainer with packages",
+            expected_status=SUCCESS,
+            config={
+                "trainer_type": types.TrainerType.CUSTOM_TRAINER,
+                "framework": "torch",
+                "image": "pytorch/pytorch:latest",
+                "packages": ["numpy", "scipy"],
+            },
+            expected_output=["numpy", "scipy"],
+        ),
+    ],
+)
+def test_local_runtime_trainer(test_case):
+    """Test LocalRuntimeTrainer default and custom packages."""
+    print("Executing test:", test_case.name)
+
+    config = test_case.config
+    trainer = LocalRuntimeTrainer(
+        trainer_type=config["trainer_type"],
+        framework=config["framework"],
+        image=config["image"],
+        packages=config.get("packages", []),
+    )
+    assert trainer.packages == test_case.expected_output
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="backend step with mock job",
+            expected_status=SUCCESS,
+            config={"step_name": "training"},
+            expected_output="training",
+        ),
+    ],
+)
+def test_local_backend_step(test_case):
+    """Test LocalBackendStep creation with a mock LocalJob."""
+    print("Executing test:", test_case.name)
+
+    mock_job = Mock(spec=LocalJob)
+    step = LocalBackendStep.model_construct(
+        step_name=test_case.config["step_name"],
+        job=mock_job,
+    )
+    assert step.step_name == test_case.expected_output
+    assert step.job is mock_job
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="backend jobs with required fields only",
+            expected_status=SUCCESS,
+            config={"name": "train-run-1"},
+            expected_output={
+                "name": "train-run-1",
+                "steps": [],
+                "runtime": None,
+                "created": None,
+                "completed": None,
+            },
+        ),
+        TestCase(
+            name="backend jobs with timestamps",
+            expected_status=SUCCESS,
+            config={
+                "name": "train-run-2",
+                "created": "2025-01-01T00:00:00",
+                "completed": "2025-01-01T01:00:00",
+            },
+            expected_output={
+                "name": "train-run-2",
+                "created": datetime(2025, 1, 1, 0, 0, 0),
+                "completed": datetime(2025, 1, 1, 1, 0, 0),
+            },
+        ),
+    ],
+)
+def test_local_backend_jobs(test_case):
+    """Test LocalBackendJobs creation with various configurations."""
+    print("Executing test:", test_case.name)
+
+    config = test_case.config
+    jobs = LocalBackendJobs(
+        name=config["name"],
+        created=config.get("created"),
+        completed=config.get("completed"),
+    )
+    expected = test_case.expected_output
+    assert jobs.name == expected["name"]
+
+    if "steps" in expected:
+        assert jobs.steps == expected["steps"]
+    if "runtime" in expected:
+        assert jobs.runtime == expected["runtime"]
+    if "created" in expected:
+        assert jobs.created == expected["created"]
+    if "completed" in expected:
+        assert jobs.completed == expected["completed"]
+
+    print("test execution complete")

--- a/kubeflow/trainer/backends/localprocess/utils_test.py
+++ b/kubeflow/trainer/backends/localprocess/utils_test.py
@@ -206,7 +206,6 @@ def test_get_install_packages(test_case: TestCase):
             expected_status=SUCCESS,
             config={
                 "runtime_name": constants.DEFAULT_TRAINING_RUNTIME,
-                "venv_dir": "/tmp/venv",
                 "framework": local_exec_constants.TORCH_FRAMEWORK_TYPE,
             },
         ),
@@ -215,7 +214,6 @@ def test_get_install_packages(test_case: TestCase):
             expected_status=FAILED,
             config={
                 "runtime_name": "nonexistent-runtime",
-                "venv_dir": "/tmp/venv",
                 "framework": "torch",
             },
             expected_error=ValueError,
@@ -225,24 +223,32 @@ def test_get_install_packages(test_case: TestCase):
             expected_status=SUCCESS,
             config={
                 "runtime_name": constants.DEFAULT_TRAINING_RUNTIME,
-                "venv_dir": "/tmp/venv",
                 "framework": local_exec_constants.TORCH_FRAMEWORK_TYPE,
             },
         ),
     ],
 )
-def test_get_local_runtime_trainer(test_case: TestCase):
+def test_get_local_runtime_trainer(test_case: TestCase, tmp_path: Path):
     """Test get_local_runtime_trainer runtime lookup and command setting."""
     print(f"Executing test: {test_case.name}")
+    venv_dir = str(tmp_path / "venv")
     if test_case.expected_status == FAILED:
         with pytest.raises(test_case.expected_error):
-            get_local_runtime_trainer(**test_case.config)
+            get_local_runtime_trainer(
+                runtime_name=test_case.config["runtime_name"],
+                venv_dir=venv_dir,
+                framework=test_case.config["framework"],
+            )
     else:
-        result = get_local_runtime_trainer(**test_case.config)
+        result = get_local_runtime_trainer(
+            runtime_name=test_case.config["runtime_name"],
+            venv_dir=venv_dir,
+            framework=test_case.config["framework"],
+        )
         assert isinstance(result, LocalRuntimeTrainer)
         assert result.image == local_exec_constants.LOCAL_RUNTIME_IMAGE
 
-        venv_bin = str(Path(test_case.config["venv_dir"]) / "bin")
+        venv_bin = str(Path(venv_dir) / "bin")
         if test_case.config["framework"] == local_exec_constants.TORCH_FRAMEWORK_TYPE:
             expected_cmd = str(Path(venv_bin) / local_exec_constants.TORCH_COMMAND)
             assert result.command == (expected_cmd,)
@@ -288,7 +294,11 @@ def test_get_dependencies_command(test_case: TestCase):
     assert "pip install" in result
     assert "--index-url" in result
 
+    for pkg in test_case.config["runtime_packages"]:
+        assert pkg in result, f"Expected package '{pkg}' in command output"
+
     pip_urls = test_case.config["pip_index_urls"]
+    assert pip_urls[0] in result
     if len(pip_urls) > 1:
         assert "--extra-index-url" in result
         assert pip_urls[1] in result
@@ -406,24 +416,27 @@ def test_get_command_using_train_func(test_case: TestCase, tmp_path: Path):
         TestCase(
             name="cleanup_venv true returns script with venv path",
             expected_status=SUCCESS,
-            config={"venv_dir": "/tmp/venv", "cleanup_venv": True},
+            config={"cleanup_venv": True},
         ),
         TestCase(
             name="cleanup_venv false returns newline",
             expected_status=SUCCESS,
-            config={"venv_dir": "/tmp/venv", "cleanup_venv": False},
+            config={"cleanup_venv": False},
             expected_output="\n",
         ),
     ],
 )
-def test_get_cleanup_venv_script(test_case: TestCase):
+def test_get_cleanup_venv_script(test_case: TestCase, tmp_path: Path):
     """Test get_cleanup_venv_script conditional cleanup logic."""
     print(f"Executing test: {test_case.name}")
-    result = get_cleanup_venv_script(**test_case.config)
+    venv_dir = str(tmp_path / "venv")
+    result = get_cleanup_venv_script(
+        venv_dir=venv_dir, cleanup_venv=test_case.config["cleanup_venv"]
+    )
     if not test_case.config["cleanup_venv"]:
         assert result == test_case.expected_output
     else:
-        assert test_case.config["venv_dir"] in result
+        assert venv_dir in result
         assert "rm -rf" in result
     print("test execution complete")
 

--- a/kubeflow/trainer/backends/localprocess/utils_test.py
+++ b/kubeflow/trainer/backends/localprocess/utils_test.py
@@ -1,0 +1,512 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kubeflow.trainer.backends.localprocess import constants as local_exec_constants
+from kubeflow.trainer.backends.localprocess.types import LocalRuntimeTrainer
+from kubeflow.trainer.backends.localprocess.utils import (
+    _canonicalize_name,
+    _extract_name,
+    get_cleanup_venv_script,
+    get_command_using_train_func,
+    get_dependencies_command,
+    get_install_packages,
+    get_local_runtime_trainer,
+    get_local_train_job_script,
+)
+from kubeflow.trainer.constants import constants
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types import types
+
+
+# ---------------------------------------------------------------------------
+# _extract_name
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="simple package name",
+            expected_status=SUCCESS,
+            config={"requirement": "numpy"},
+            expected_output="numpy",
+        ),
+        TestCase(
+            name="package with version specifier",
+            expected_status=SUCCESS,
+            config={"requirement": "numpy==1.21"},
+            expected_output="numpy",
+        ),
+        TestCase(
+            name="package with extras",
+            expected_status=SUCCESS,
+            config={"requirement": "package[extra1,extra2]"},
+            expected_output="package",
+        ),
+        TestCase(
+            name="package with URL",
+            expected_status=SUCCESS,
+            config={"requirement": "package @ https://example.com/pkg.whl"},
+            expected_output="package",
+        ),
+        TestCase(
+            name="None input raises ValueError",
+            expected_status=FAILED,
+            config={"requirement": None},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="empty string raises ValueError",
+            expected_status=FAILED,
+            config={"requirement": ""},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid format raises ValueError",
+            expected_status=FAILED,
+            config={"requirement": "!!!invalid"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_extract_name(test_case: TestCase):
+    """Test _extract_name with various requirement string formats."""
+    print(f"Executing test: {test_case.name}")
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            _extract_name(test_case.config["requirement"])
+    else:
+        result = _extract_name(test_case.config["requirement"])
+        assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# _canonicalize_name
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="lowercase conversion",
+            expected_status=SUCCESS,
+            config={"name": "NumPy"},
+            expected_output="numpy",
+        ),
+        TestCase(
+            name="underscore collapsed to dash",
+            expected_status=SUCCESS,
+            config={"name": "my_package"},
+            expected_output="my-package",
+        ),
+        TestCase(
+            name="dot collapsed to dash",
+            expected_status=SUCCESS,
+            config={"name": "my.package"},
+            expected_output="my-package",
+        ),
+    ],
+)
+def test_canonicalize_name(test_case: TestCase):
+    """Test _canonicalize_name PEP 503 normalization."""
+    print(f"Executing test: {test_case.name}")
+    result = _canonicalize_name(test_case.config["name"])
+    assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_install_packages
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="no trainer packages returns runtime unchanged",
+            expected_status=SUCCESS,
+            config={
+                "runtime_packages": ["numpy==1.21", "pandas"],
+                "trainer_packages": None,
+            },
+            expected_output=["numpy==1.21", "pandas"],
+        ),
+        TestCase(
+            name="trainer overwrites matching runtime package",
+            expected_status=SUCCESS,
+            config={
+                "runtime_packages": ["numpy==1.21", "pandas"],
+                "trainer_packages": ["NumPy==1.25"],
+            },
+            expected_output=["pandas", "NumPy==1.25"],
+        ),
+        TestCase(
+            name="duplicate trainer packages raises ValueError",
+            expected_status=FAILED,
+            config={
+                "runtime_packages": ["numpy"],
+                "trainer_packages": ["torch==2.0", "Torch==2.1"],
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="runtime-only first then trainer ordering preserved",
+            expected_status=SUCCESS,
+            config={
+                "runtime_packages": ["numpy", "scipy", "pandas"],
+                "trainer_packages": ["scipy==1.12"],
+            },
+            expected_output=["numpy", "pandas", "scipy==1.12"],
+        ),
+        TestCase(
+            name="empty runtime with trainer packages",
+            expected_status=SUCCESS,
+            config={
+                "runtime_packages": [],
+                "trainer_packages": ["torch==2.0"],
+            },
+            expected_output=["torch==2.0"],
+        ),
+    ],
+)
+def test_get_install_packages(test_case: TestCase):
+    """Test get_install_packages merge logic."""
+    print(f"Executing test: {test_case.name}")
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            get_install_packages(**test_case.config)
+    else:
+        result = get_install_packages(**test_case.config)
+        assert result == test_case.expected_output
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_local_runtime_trainer
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid default runtime name",
+            expected_status=SUCCESS,
+            config={
+                "runtime_name": constants.DEFAULT_TRAINING_RUNTIME,
+                "venv_dir": "/tmp/venv",
+                "framework": local_exec_constants.TORCH_FRAMEWORK_TYPE,
+            },
+        ),
+        TestCase(
+            name="invalid runtime name raises ValueError",
+            expected_status=FAILED,
+            config={
+                "runtime_name": "nonexistent-runtime",
+                "venv_dir": "/tmp/venv",
+                "framework": "torch",
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="torch framework sets torchrun command",
+            expected_status=SUCCESS,
+            config={
+                "runtime_name": constants.DEFAULT_TRAINING_RUNTIME,
+                "venv_dir": "/tmp/venv",
+                "framework": local_exec_constants.TORCH_FRAMEWORK_TYPE,
+            },
+        ),
+    ],
+)
+def test_get_local_runtime_trainer(test_case: TestCase):
+    """Test get_local_runtime_trainer runtime lookup and command setting."""
+    print(f"Executing test: {test_case.name}")
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            get_local_runtime_trainer(**test_case.config)
+    else:
+        result = get_local_runtime_trainer(**test_case.config)
+        assert isinstance(result, LocalRuntimeTrainer)
+        assert result.image == local_exec_constants.LOCAL_RUNTIME_IMAGE
+
+        venv_bin = str(Path(test_case.config["venv_dir"]) / "bin")
+        if test_case.config["framework"] == local_exec_constants.TORCH_FRAMEWORK_TYPE:
+            expected_cmd = str(Path(venv_bin) / local_exec_constants.TORCH_COMMAND)
+            assert result.command == (expected_cmd,)
+        else:
+            expected_cmd = str(Path(venv_bin) / local_exec_constants.DEFAULT_COMMAND)
+            assert result.command == (expected_cmd,)
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_dependencies_command
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="basic with packages",
+            expected_status=SUCCESS,
+            config={
+                "runtime_packages": ["numpy", "pandas"],
+                "pip_index_urls": ["https://pypi.org/simple"],
+                "trainer_packages": [],
+            },
+        ),
+        TestCase(
+            name="with extra index URLs",
+            expected_status=SUCCESS,
+            config={
+                "runtime_packages": ["torch"],
+                "pip_index_urls": [
+                    "https://pypi.org/simple",
+                    "https://download.pytorch.org/whl/cpu",
+                ],
+                "trainer_packages": [],
+            },
+        ),
+    ],
+)
+def test_get_dependencies_command(test_case: TestCase):
+    """Test get_dependencies_command pip install string construction."""
+    print(f"Executing test: {test_case.name}")
+    result = get_dependencies_command(**test_case.config)
+    assert "pip install" in result
+    assert "--index-url" in result
+
+    pip_urls = test_case.config["pip_index_urls"]
+    if len(pip_urls) > 1:
+        assert "--extra-index-url" in result
+        assert pip_urls[1] in result
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_command_using_train_func
+# ---------------------------------------------------------------------------
+def _sample_train_func(parameters=None):
+    print("training")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="with parameters",
+            expected_status=SUCCESS,
+            config={
+                "train_func_parameters": {"lr": 0.01},
+            },
+        ),
+        TestCase(
+            name="without parameters",
+            expected_status=SUCCESS,
+            config={
+                "train_func_parameters": None,
+            },
+        ),
+        TestCase(
+            name="non-callable raises ValueError",
+            expected_status=FAILED,
+            config={
+                "train_func": "not_a_function",
+                "train_func_parameters": None,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="runtime without trainer raises ValueError",
+            expected_status=FAILED,
+            config={
+                "no_trainer": True,
+                "train_func_parameters": None,
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_command_using_train_func(test_case: TestCase, tmp_path: Path):
+    """Test get_command_using_train_func entrypoint generation."""
+    print(f"Executing test: {test_case.name}")
+
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    venv_dir = str(venv_dir)
+    train_job_name = "test-job"
+
+    if test_case.config.get("no_trainer"):
+        runtime = types.Runtime(name="test", trainer=None)
+        with pytest.raises(test_case.expected_error):
+            get_command_using_train_func(
+                runtime=runtime,
+                train_func=_sample_train_func,
+                train_func_parameters=test_case.config["train_func_parameters"],
+                venv_dir=venv_dir,
+                train_job_name=train_job_name,
+            )
+    elif test_case.expected_status == FAILED:
+        rt = LocalRuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="local",
+        )
+        rt.set_command(("python",))
+        runtime = types.Runtime(name="test", trainer=rt)
+        with pytest.raises(test_case.expected_error):
+            get_command_using_train_func(
+                runtime=runtime,
+                train_func=test_case.config["train_func"],
+                train_func_parameters=test_case.config["train_func_parameters"],
+                venv_dir=venv_dir,
+                train_job_name=train_job_name,
+            )
+    else:
+        rt = LocalRuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="local",
+        )
+        rt.set_command(("python",))
+        runtime = types.Runtime(name="test", trainer=rt)
+        result = get_command_using_train_func(
+            runtime=runtime,
+            train_func=_sample_train_func,
+            train_func_parameters=test_case.config["train_func_parameters"],
+            venv_dir=venv_dir,
+            train_job_name=train_job_name,
+        )
+        assert isinstance(result, str)
+        func_file = (
+            tmp_path / "venv" / local_exec_constants.LOCAL_EXEC_FILENAME.format(train_job_name)
+        )
+        assert func_file.exists()
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_cleanup_venv_script
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="cleanup_venv true returns script with venv path",
+            expected_status=SUCCESS,
+            config={"venv_dir": "/tmp/venv", "cleanup_venv": True},
+        ),
+        TestCase(
+            name="cleanup_venv false returns newline",
+            expected_status=SUCCESS,
+            config={"venv_dir": "/tmp/venv", "cleanup_venv": False},
+            expected_output="\n",
+        ),
+    ],
+)
+def test_get_cleanup_venv_script(test_case: TestCase):
+    """Test get_cleanup_venv_script conditional cleanup logic."""
+    print(f"Executing test: {test_case.name}")
+    result = get_cleanup_venv_script(**test_case.config)
+    if not test_case.config["cleanup_venv"]:
+        assert result == test_case.expected_output
+    else:
+        assert test_case.config["venv_dir"] in result
+        assert "rm -rf" in result
+    print("test execution complete")
+
+
+# ---------------------------------------------------------------------------
+# get_local_train_job_script
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid inputs return 3-tuple",
+            expected_status=SUCCESS,
+            config={},
+        ),
+        TestCase(
+            name="invalid runtime trainer type raises ValueError",
+            expected_status=FAILED,
+            config={"use_base_runtime_trainer": True},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_local_train_job_script(test_case: TestCase, tmp_path: Path):
+    """Test get_local_train_job_script full script generation."""
+    print(f"Executing test: {test_case.name}")
+
+    venv_dir = tmp_path / "venv"
+    venv_dir.mkdir()
+    venv_dir = str(venv_dir)
+    train_job_name = "test-job"
+
+    if test_case.config.get("use_base_runtime_trainer"):
+        base_rt = types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="local",
+        )
+        base_rt.set_command(("python",))
+        runtime = types.Runtime(name="test", trainer=base_rt)
+        trainer = types.CustomTrainer(
+            func=_sample_train_func,
+            packages_to_install=["numpy"],
+        )
+        with (
+            pytest.raises(test_case.expected_error),
+            patch(
+                "kubeflow.trainer.backends.localprocess.utils.shutil.which",
+                return_value="/usr/bin/python",
+            ),
+        ):
+            get_local_train_job_script(
+                train_job_name=train_job_name,
+                venv_dir=venv_dir,
+                trainer=trainer,
+                runtime=runtime,
+            )
+    else:
+        rt = LocalRuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="local",
+            packages=["torch"],
+        )
+        rt.set_command(("python",))
+        runtime = types.Runtime(name="test", trainer=rt)
+        trainer = types.CustomTrainer(
+            func=_sample_train_func,
+            packages_to_install=["numpy"],
+        )
+
+        with patch(
+            "kubeflow.trainer.backends.localprocess.utils.shutil.which",
+            return_value="/usr/bin/python",
+        ):
+            result = get_local_train_job_script(
+                train_job_name=train_job_name,
+                venv_dir=venv_dir,
+                trainer=trainer,
+                runtime=runtime,
+            )
+        assert len(result) == 3
+        assert result[0] == "bash"
+        assert result[1] == "-c"
+        assert isinstance(result[2], str)
+    print("test execution complete")

--- a/kubeflow/trainer/options/localprocess_test.py
+++ b/kubeflow/trainer/options/localprocess_test.py
@@ -1,0 +1,38 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the localprocess options module."""
+
+import pytest
+
+from kubeflow.trainer.test.common import SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="localprocess options module imports without error",
+            expected_status=SUCCESS,
+            config={},
+        ),
+    ],
+)
+def test_localprocess_options_module_imports(test_case):
+    """Verify the localprocess options module can be imported."""
+    print("Executing test:", test_case.name)
+
+    import kubeflow.trainer.options.localprocess  # noqa: F401
+
+    print("test execution complete")


### PR DESCRIPTION
## Summary
- Add 151 unit tests across 10 new test files covering all previously untested trainer source files
- Covers backends (base, container adapters, localprocess), types, utils, and options
- Follows existing repo test patterns (TestCase dataclass, pytest.mark.parametrize, unittest.mock)

Resolves: RHOAIENG-72963

## Test plan
- [x] All 151 new tests pass
- [x] Full trainer suite (606 tests) passes with no regressions
- [x] ruff check passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit coverage for container backends (Docker and Podman), including adapter initialization, networking, container lifecycle, log handling, image operations, status/exit-code mapping, network/IP lookup, and wait/timeout behavior.
  * Added tests for backend configuration and runtime source parsing/validation.
  * Added comprehensive unit tests for local-process job behavior (initialization, cancellation, logs, dependency failure handling, subprocess run outcomes) and local utility/script/command generation.
* **Bug Fixes**
  * Strengthened regression protection for container- and local-runtime workflows by covering additional edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->