### PR TITLE
feat: Add SpeculatorTrainer for draft model training

### DIFF
--- a/kubeflow/trainer/rhai/__init__.py
+++ b/kubeflow/trainer/rhai/__init__.py
@@ -19,14 +19,22 @@ This module provides RHAI trainer types and utilities:
 - TrainingHubTrainer: RHAI Training Hub integration
 """
 
+from kubeflow.trainer.rhai.speculator import (
+    SpeculativeDecodingTrainer,
+    SpeculatorMode,
+    SpeculatorType,
+)
 from kubeflow.trainer.rhai.traininghub import TrainingHubAlgorithms, TrainingHubTrainer
 from kubeflow.trainer.rhai.transformers import TransformersTrainer
 
 __all__ = (
     "RHAITrainer",
+    "SpeculatorMode",
+    "SpeculativeDecodingTrainer",
+    "SpeculatorType",
     "TrainingHubAlgorithms",
     "TrainingHubTrainer",
     "TransformersTrainer",
 )
 
-RHAITrainer = TransformersTrainer | TrainingHubTrainer
+RHAITrainer = TransformersTrainer | TrainingHubTrainer | SpeculativeDecodingTrainer

--- a/kubeflow/trainer/rhai/__init__.py
+++ b/kubeflow/trainer/rhai/__init__.py
@@ -21,6 +21,7 @@ This module provides RHAI trainer types and utilities:
 
 from kubeflow.trainer.rhai.speculator import (
     SpeculativeDecodingTrainer,
+    SpeculatorConfig,
     SpeculatorMode,
     SpeculatorType,
 )
@@ -29,8 +30,9 @@ from kubeflow.trainer.rhai.transformers import TransformersTrainer
 
 __all__ = (
     "RHAITrainer",
-    "SpeculatorMode",
     "SpeculativeDecodingTrainer",
+    "SpeculatorConfig",
+    "SpeculatorMode",
     "SpeculatorType",
     "TrainingHubAlgorithms",
     "TrainingHubTrainer",

--- a/kubeflow/trainer/rhai/constants.py
+++ b/kubeflow/trainer/rhai/constants.py
@@ -26,6 +26,7 @@ PVC_URI_SCHEME = "pvc://"
 CHECKPOINT_MOUNT_PATH = "/mnt/kubeflow-checkpoints"
 CHECKPOINT_VOLUME_NAME = "checkpoint-storage"
 CHECKPOINT_INCOMPLETE_MARKER = "checkpoint-is-incomplete.txt"
+EXTRACTION_INCOMPLETE_MARKER = "extraction-is-incomplete.txt"
 CHECKPOINT_STAGING_DIR = "cloud-upload-staging"
 
 # Ephemeral volume for cloud storage checkpoint staging (for S3)
@@ -33,3 +34,8 @@ CHECKPOINT_EPHEMERAL_VOLUME_SIZE = "50Gi"
 
 # Cloud storage URI schemes
 S3_URI_SCHEME = "s3://"
+
+# vLLM sidecar constants (for speculator DATA_ONLY mode)
+VLLM_SIDECAR_CONTAINER_NAME = "vllm-sidecar"
+VLLM_SIDECAR_PORT = 8234
+VLLM_SIDECAR_ENDPOINT = f"http://localhost:{VLLM_SIDECAR_PORT}/v1"

--- a/kubeflow/trainer/rhai/scripts/data_generation_offline.py
+++ b/kubeflow/trainer/rhai/scripts/data_generation_offline.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+Offline Hidden States Generation Pipeline
+
+This script generates hidden states and saves them to disk for offline training.
+
+Usage:
+    python data_generation_offline.py \
+        --model meta-llama/Llama-3.1-8B-Instruct \
+        --preprocessed-data sharegpt \
+        --output ./training_data \
+        --max-samples 5000
+"""
+
+import argparse
+import asyncio
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import openai
+from datasets import load_from_disk
+from safetensors import safe_open
+from tqdm import tqdm
+
+from speculators.data_generation.offline import (
+    get_existing_hidden_state_indices,
+    get_indices_to_process,
+)
+from speculators.data_generation.vllm_client import (
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_REQUEST_TIMEOUT,
+    generate_hidden_states_async,
+    wait_for_lock_async,
+)
+from speculators.train.data import build_client_item
+from speculators.train.logger import setup_root_logger
+
+logger = logging.getLogger(__name__)
+
+
+class _FailureTracker:
+    """Tracks consecutive sample failures across async workers.
+
+    When the number of consecutive failures (with no successes in between)
+    reaches ``threshold``, the tracker signals that the run should abort.
+    Because asyncio is single-threaded, no locking is needed.
+    """
+
+    def __init__(self, threshold: int):
+        self.threshold = threshold
+        self._consecutive = 0
+
+    def record_success(self) -> None:
+        self._consecutive = 0
+
+    def record_failure(self) -> bool:
+        """Record a failure. Returns True when the threshold is reached."""
+        self._consecutive += 1
+        return self._consecutive >= self.threshold
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate EAGLE training data offline")
+
+    # Model arguments
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=None,
+        help=(
+            "HuggingFace model ID or local path for target model "
+            "(default auto select). For verification purposes only."
+        ),
+    )
+    parser.add_argument(
+        "--endpoint",
+        type=str,
+        default="http://localhost:8000/v1",
+        help=(
+            "The address of the vLLM instance to use for hidden states generation "
+            "(default: 'http://localhost:8000/v1'). "
+            "Note: the vLLM instance must be configured for hidden states extraction."
+        ),
+    )
+
+    # Data arguments
+    parser.add_argument(
+        "--preprocessed-data",
+        type=str,
+        default="./output",
+        help="Path to preprocessed dataset (dataset produced by prepare_data.py)"
+        " (default: ./output)",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Maximum number of samples to process (default: None, process all)",
+    )
+
+    # Output arguments
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help=(
+            "Directory to generated hidden states files "
+            "(default args.preprocessed_data / 'hidden_states')"
+        ),
+    )
+
+    # Hidden states generation arguments
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=32,
+        help=(
+            "Number of active vLLM requests at a time. "
+            "Note: number of async workers set to 2*concurrency"
+        ),
+    )
+    parser.add_argument(
+        "--validate-outputs",
+        action="store_true",
+        help=(
+            "Load generated safetensor files and check output token ids match "
+            "prompt tokens and hidden states seq_len matches num tokens"
+        ),
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help=(
+            "Timeout in seconds for each individual vLLM request "
+            f"(default: {DEFAULT_REQUEST_TIMEOUT})"
+        ),
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help=(
+            "Maximum number of retry attempts per request on failure "
+            f"(default: {DEFAULT_MAX_RETRIES})"
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        help=(
+            "Abort when a request fails after all retries. "
+            "By default, failed samples are skipped."
+        ),
+    )
+    parser.add_argument(
+        "--max-consecutive-errors",
+        type=int,
+        default=None,
+        help=(
+            "Abort after this many consecutive sample failures (each sample "
+            "already retried --max-retries times). Prevents silently churning "
+            "through the entire dataset when the server is down. "
+            "Ignored when --fail-on-error is set. "
+            "(default: value of --concurrency)"
+        ),
+    )
+    parser.add_argument(
+        "--world-size",
+        type=int,
+        default=1,
+        help=(
+            "World size for multi-node data generation offline. IMPORTANT: this "
+            "is the number of nodes (not the number of gpus). Defaults to 1"
+        ),
+    )
+    parser.add_argument(
+        "--rank",
+        type=int,
+        default=0,
+        help=(
+            "Rank for multi-node data generation offline. IMPORTANT: this is "
+            "the node index, not an index for a gpu. Must be in range[0, world_size)."
+            " Defaults to 0"
+        ),
+    )
+    return parser.parse_args()
+
+
+def check_safetensors_file(path: Path, tokens: list[int]):
+    with safe_open(path, "pt") as f:
+        t_ids = f.get_tensor("token_ids").tolist()
+        if t_ids != tokens:
+            raise ValueError(
+                f"Token ids in {path} don't match expected token ids {tokens}"
+            )
+
+        hs_slice = f.get_slice("hidden_states")
+        hs_shape = list(hs_slice.get_shape())
+        if len(tokens) != hs_shape[0]:
+            raise ValueError(
+                f"Sequence length of hidden states {hs_shape[0]} in {path}"
+                f" doesn't match num tokens {len(tokens)}"
+            )
+
+
+async def worker(  # noqa: C901
+    client,
+    model: str,
+    queue: "asyncio.Queue[dict[str, Any]]",
+    pbar: tqdm,
+    vllm_semaphore: asyncio.Semaphore,
+    write_semaphore: asyncio.Semaphore,
+    hidden_states_output_dir: Path,
+    validate_outputs: bool,
+    request_timeout: float | None,
+    max_retries: int,
+    fail_on_error: bool,
+    skipped_indices: list[int],
+    cancel_event: asyncio.Event,
+    failure_tracker: _FailureTracker | None,
+):
+    """Worker that pulls items from queue and sends them to the vLLM endpoint."""
+    while True:
+        item = await queue.get()
+        if item is None:
+            queue.task_done()
+            return
+
+        idx = item["idx"]
+
+        # Drain remaining items quickly after cancellation
+        if cancel_event.is_set():
+            queue.task_done()
+            continue
+
+        target_hidden_states_path = hidden_states_output_dir / f"hs_{idx}.safetensors"
+
+        try:
+            async with vllm_semaphore:  # Limit number of active generate calls
+                hidden_states_path = await generate_hidden_states_async(
+                    client,
+                    model,
+                    item,
+                    timeout=request_timeout,
+                    max_retries=max_retries,
+                )
+            lock_path = hidden_states_path + ".lock"
+            if Path(lock_path).exists():  # noqa: ASYNC240
+                await wait_for_lock_async(lock_path)
+
+            async with write_semaphore:  # Limit number of active disk writes
+                await asyncio.to_thread(
+                    shutil.move, hidden_states_path, target_hidden_states_path
+                )
+                if validate_outputs:
+                    await asyncio.to_thread(
+                        check_safetensors_file,
+                        target_hidden_states_path,
+                        item["input_ids"],
+                    )
+        except Exception as e:
+            if fail_on_error:
+                logger.exception(
+                    "Fatal: sample %d aborted with --fail-on-error: %s", idx, e
+                )
+                logging.shutdown()
+                os._exit(1)
+            logger.warning("Skipping sample %d due to error: %s", idx, e)
+            skipped_indices.append(idx)
+            if failure_tracker is not None and failure_tracker.record_failure():
+                cancel_event.set()
+                raise RuntimeError(
+                    f"Aborting: {failure_tracker.threshold} consecutive samples "
+                    "errored out. The vLLM server may be unreachable."
+                ) from e
+        else:
+            if failure_tracker is not None:
+                failure_tracker.record_success()
+        finally:
+            pbar.update(1)
+            queue.task_done()
+
+
+async def _feed_queue(to_process, dataset, queue, cancel_event):
+    """Feed dataset items into the worker queue, respecting cancellation."""
+    for i in to_process:
+        if cancel_event.is_set():
+            break
+
+        dataset_item = dataset[i]
+        client_item = build_client_item(dataset_item) | {"idx": i}
+
+        # Check cancel_event while waiting for queue space to avoid
+        # deadlocking when all workers have died.
+        while not cancel_event.is_set():
+            try:
+                queue.put_nowait(client_item)
+                break
+            except asyncio.QueueFull:
+                await asyncio.sleep(0.1)
+
+
+async def _shutdown_workers(workers, queue, cancel_event):
+    """Shut down workers and propagate the first real exception."""
+    logger.info("Waiting for remaining file saves to complete...")
+    if cancel_event.is_set():
+        # Workers may be dead or draining — cancel any that are
+        # still alive so we don't deadlock on sentinel puts.
+        for w in workers:
+            if not w.done():
+                w.cancel()
+    else:
+        # Normal shutdown: send sentinel values so workers exit
+        for _ in range(len(workers)):
+            await queue.put(None)
+    results = await asyncio.gather(*workers, return_exceptions=True)
+
+    # Propagate the first real worker exception (skip CancelledError)
+    for result in results:
+        if isinstance(result, Exception) and not isinstance(
+            result, asyncio.CancelledError
+        ):
+            raise result
+
+
+async def generate_and_save_hidden_states(args, dataset):
+    if args.output is None:
+        hidden_states_dir = Path(args.preprocessed_data) / "hidden_states"
+    else:
+        hidden_states_dir = Path(args.output)
+    hidden_states_dir.mkdir(parents=True, exist_ok=True)
+
+    existing_file_indices = get_existing_hidden_state_indices(hidden_states_dir)
+    num_samples = len(dataset)
+
+    to_process = get_indices_to_process(
+        num_samples,
+        args.max_samples,
+        existing_file_indices,
+        args.world_size,
+        args.rank,
+    )
+    if not to_process:
+        return
+
+    logger.info(f"Processing {len(to_process)} samples")
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
+    vllm_semaphore = asyncio.Semaphore(args.concurrency)
+    write_semaphore = asyncio.Semaphore(args.concurrency)
+
+    skipped_indices: list[int] = []
+    cancel_event = asyncio.Event()
+
+    max_consec = args.max_consecutive_errors
+    if max_consec is None:
+        max_consec = args.concurrency
+    failure_tracker = _FailureTracker(max_consec) if not args.fail_on_error else None
+
+    async with openai.AsyncOpenAI(
+        base_url=args.endpoint, api_key="EMPTY", max_retries=0
+    ) as client:
+        list_models = await client.models.list()
+        model_id = list_models.data[0].id
+        if args.model and args.model != model_id:
+            raise ValueError(
+                f"An explicit model name was passed ({args.model}) which doesn't match"
+                f" found model_id {model_id}."
+                "Please make sure --endpoint is set to the correct vllm instance."
+            )
+
+        with tqdm(total=len(to_process)) as pbar:
+            workers = [
+                asyncio.create_task(
+                    worker(
+                        client,
+                        model_id,
+                        queue,
+                        pbar,
+                        vllm_semaphore,
+                        write_semaphore,
+                        hidden_states_dir,
+                        args.validate_outputs,
+                        args.request_timeout,
+                        args.max_retries,
+                        args.fail_on_error,
+                        skipped_indices,
+                        cancel_event,
+                        failure_tracker,
+                    )
+                )
+                for _ in range(args.concurrency * 2)
+            ]
+
+            await _feed_queue(to_process, dataset, queue, cancel_event)
+            await _shutdown_workers(workers, queue, cancel_event)
+
+    num_saved = len(to_process) - len(skipped_indices)
+    logger.info(f"Saved {num_saved} new data points to {args.output}")
+    if skipped_indices:
+        logger.warning(
+            f"Skipped {len(skipped_indices)} samples due to errors: {skipped_indices}"
+        )
+
+
+def main():
+    args = parse_args()
+    if int(args.rank) < 0 or int(args.rank) >= int(args.world_size):
+        raise ValueError("--rank must be in range [0, world_size)")
+    setup_root_logger()
+
+    logger.info("EAGLE Offline Data Generation")
+
+    dataset = load_from_disk(args.preprocessed_data)
+
+    try:
+        asyncio.run(generate_and_save_hidden_states(args, dataset))
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception:
+        logger.exception("Data generation failed")
+        sys.exit(1)
+
+    logger.info("Data generation complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/kubeflow/trainer/rhai/scripts/response_regeneration.py
+++ b/kubeflow/trainer/rhai/scripts/response_regeneration.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+import time
+from typing import Any
+
+import aiohttp
+from datasets import load_dataset
+from tqdm import tqdm
+
+DATASET_CONFIGS = {
+    "magpie": {
+        "id": "Magpie-Align/Magpie-Llama-3.1-Pro-300K-Filtered",
+        "prompt_field": "instruction",
+        "default_split": "train",
+    },
+    "ultrachat": {
+        "id": "HuggingFaceH4/ultrachat_200k",
+        "prompt_field": "prompt",
+        "default_split": "train_sft",
+    },
+    "gsm8k": {
+        "id": "openai/gsm8k",
+        "prompt_field": "question",
+        "default_split": "train",
+        "subset": "main",
+    },
+}
+
+
+def parse_args():
+    """Parse command-line arguments for the script."""
+    parser = argparse.ArgumentParser(
+        description="Regenerate responses from Magpie instructions via vLLM Chat API."
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="http://127.0.0.1:8000/v1/chat/completions",
+        help="vLLM OpenAI-compatible Chat Completions endpoint",
+    )
+    parser.add_argument(
+        "--model",
+        default=None,
+        help="Model name exposed by vLLM (auto-detected if not specified)",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="ultrachat",
+        choices=list(DATASET_CONFIGS.keys()),
+        help="Dataset to process",
+    )
+    parser.add_argument(
+        "--split",
+        default=None,
+        help="Dataset split (defaults to dataset-specific split)",
+    )
+    parser.add_argument(
+        "--subset",
+        default=None,
+        help=(
+            "Dataset subset/config name "
+            "(auto-detected from dataset config if not specified)"
+        ),
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Stop after N rows")
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=64,
+        help="Max concurrent requests",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=8192,
+        help="max_tokens for generation",
+    )
+    parser.add_argument(
+        "--outfile",
+        default=None,
+        help="Output JSONL path (auto-generated if not specified)",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Skip rows already in outfile (by uuid or idx)",
+    )
+    parser.add_argument(
+        "--language-filter",
+        default=None,
+        help="Only process rows where language==this (e.g., EN)",
+    )
+    return parser.parse_args()
+
+
+def sanitize_filename(name: str) -> str:
+    """Sanitize a string to be safe for use in filenames."""
+    name = re.sub(r'[/\\:*?"<>|]', "_", name)
+    name = name.replace(" ", "_")
+    return name.strip("._")
+
+
+def load_seen(path: str):
+    """Load previously processed record IDs from output file."""
+    seen = set()
+    if not os.path.isfile(path):
+        return seen
+
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            key = obj.get("uuid") or obj.get("idx")
+            if key is not None:
+                seen.add(str(key))
+    return seen
+
+
+async def detect_model(endpoint: str) -> str:
+    """Automatically detect the model name from the vLLM server."""
+    models_endpoint = endpoint.replace("/v1/chat/completions", "/v1/models")
+
+    timeout = aiohttp.ClientTimeout(total=10)
+    try:
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as session,
+            session.get(models_endpoint) as response,
+        ):
+            data = await response.json()
+            models = data.get("data", [])
+            if models:
+                model_name = models[0]["id"]
+                print(f"Auto-detected model: {model_name}")
+                return model_name
+            raise ValueError("No models found at endpoint")
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError(
+            f"Failed to auto-detect model from {models_endpoint}: {e}\n"
+            f"Please specify model with --model argument"
+        ) from e
+
+
+async def worker(
+    sem: asyncio.Semaphore,
+    session: aiohttp.ClientSession,
+    queue: "asyncio.Queue[dict[str, Any]]",
+    args,
+    out_fh,
+    endpoint: str,
+    progress,
+    stats: dict[str, int],
+):
+    """Worker that pulls items from queue and sends them to the vLLM endpoint."""
+    while True:
+        item = await queue.get()
+        if item is None:
+            queue.task_done()
+            return
+
+        idx = item["idx"]
+        payload = {
+            "model": args.model,
+            "messages": [{"role": "user", "content": item["prompt"]}],
+            "max_tokens": args.max_tokens,
+        }
+
+        start_time = time.time()
+        try:
+            async with sem, session.post(endpoint, json=payload) as response:
+                data = await response.json()
+
+            choice = data["choices"][0]
+            message = choice["message"]
+            generated_text = message["content"]
+            reasoning_content = message.get("reasoning_content")
+            if reasoning_content is None:
+                reasoning_content = message.get("reasoning")
+            finish_reason = choice.get("finish_reason")
+            latency = time.time() - start_time
+
+            # Format output in conversations structure
+            metadata = {
+                "idx": idx,
+                "finish_reason": finish_reason,
+                "latency_s": round(latency, 3),
+                "usage": data.get("usage"),
+                "endpoint": endpoint,
+            }
+
+            # Only include reasoning_content if it exists
+            if reasoning_content is not None:
+                metadata["reasoning_content"] = reasoning_content
+
+            output = {
+                "id": item.get("uuid") or f"sample_{idx}",
+                "conversations": [
+                    {"from": "human", "value": item["prompt"]},
+                    {"from": "gpt", "value": generated_text},
+                ],
+                "metadata": metadata,
+            }
+            out_fh.write(json.dumps(output, ensure_ascii=False) + "\n")
+            out_fh.flush()
+            stats["ok"] += 1
+        except Exception as e:  # noqa: BLE001
+            error_output = {
+                "id": item.get("uuid") or f"sample_{idx}",
+                "conversations": [{"from": "human", "value": item["prompt"]}],
+                "metadata": {
+                    "idx": idx,
+                    "error": repr(e),
+                    "endpoint": endpoint,
+                },
+            }
+            out_fh.write(json.dumps(error_output, ensure_ascii=False) + "\n")
+            out_fh.flush()
+            stats["errors"] += 1
+        finally:
+            progress.set_postfix(
+                ok=stats["ok"],
+                errors=stats["errors"],
+                refresh=False,
+            )
+            progress.update(1)
+            queue.task_done()
+
+
+async def main():
+    """Main async function to process dataset through vLLM endpoints."""
+    args = parse_args()
+
+    endpoint = args.endpoint
+    print(f"Using endpoint: {endpoint}")
+
+    # Auto-detect model if not specified
+    if args.model is None:
+        args.model = await detect_model(endpoint)
+
+    print(f"Using model: {args.model}")
+
+    # Get dataset configuration
+    dataset_config = DATASET_CONFIGS[args.dataset]
+    dataset_id = dataset_config["id"]
+    prompt_field = dataset_config["prompt_field"]
+
+    # Use dataset-specific defaults if not provided
+    split = args.split if args.split is not None else dataset_config["default_split"]
+    subset = args.subset if args.subset is not None else dataset_config.get("subset")
+
+    # Generate output filename if not specified
+    if args.outfile is None:
+        # Extract simple model name from full path
+        model_name = args.model.split("/")[-1] if "/" in args.model else args.model
+        model_name = sanitize_filename(model_name)
+        args.outfile = f"{args.dataset}_{model_name}.jsonl"
+
+    print(f"Using dataset: {dataset_id}")
+    print(f"Split: {split}")
+    print(f"Prompt field: {prompt_field}")
+    print(f"Output file: {args.outfile}")
+    print()
+
+    seen_ids = load_seen(args.outfile) if args.resume else set()
+    dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    timeout = aiohttp.ClientTimeout(total=None, sock_connect=90, sock_read=None)
+    connector = aiohttp.TCPConnector(
+        limit=None, force_close=False, enable_cleanup_closed=True
+    )
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+
+    async with aiohttp.ClientSession(
+        timeout=timeout, connector=connector, headers=headers
+    ) as session:
+        with (
+            open(args.outfile, "a", encoding="utf-8") as output_file,  # noqa: ASYNC230
+            tqdm(
+                total=args.limit,
+                desc="Generating responses",
+                unit="sample",
+                dynamic_ncols=True,
+            ) as progress,
+        ):
+            stats = {"ok": 0, "errors": 0}
+            workers = [
+                asyncio.create_task(
+                    worker(
+                        semaphore,
+                        session,
+                        queue,
+                        args,
+                        output_file,
+                        endpoint,
+                        progress,
+                        stats,
+                    )
+                )
+                for _ in range(args.concurrency)
+            ]
+
+            processed_count = 0
+            for index, row in enumerate(dataset):
+                if args.limit is not None and processed_count >= args.limit:
+                    break
+
+                if args.language_filter and row.get("language") != args.language_filter:
+                    continue
+
+                prompt = row.get(prompt_field)
+                if not prompt:
+                    continue
+
+                uuid = row.get("uuid")
+                key = str(uuid or index)
+                if key in seen_ids:
+                    continue
+
+                await queue.put(
+                    {
+                        "idx": index,
+                        "uuid": uuid,
+                        "prompt": prompt,
+                    }
+                )
+                processed_count += 1
+
+            # Signal workers to stop
+            for _ in range(len(workers)):
+                await queue.put(None)
+            await asyncio.gather(*workers)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/kubeflow/trainer/rhai/speculator.py
+++ b/kubeflow/trainer/rhai/speculator.py
@@ -1,0 +1,720 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SpeculativeDecodingTrainer for custom draft model training via the speculators library.
+
+This module provides the SpeculativeDecodingTrainer dataclass for training speculative
+decoding draft models (e.g., Eagle3) using the speculators library. Currently
+supports TRAIN_ONLY mode, which trains from pre-extracted hidden states on a PVC.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from kubeflow_trainer_api import models
+
+import kubeflow.trainer.backends.kubernetes.utils as k8s_utils
+from kubeflow.trainer.constants import constants
+from kubeflow.trainer.rhai.constants import PVC_URI_SCHEME
+from kubeflow.trainer.types import types
+
+
+class SpeculatorMode(Enum):
+    """Training mode for speculator training.
+
+    Args:
+        TRAIN_ONLY: Train draft model from pre-extracted hidden states on PVC.
+        DATA_ONLY: Extract hidden states from verifier model via vLLM (future).
+        OFFLINE: Train using a user-managed vLLM endpoint (future).
+        ONLINE: Online training with a custom runtime image that includes all dependencies.
+    """
+
+    TRAIN_ONLY = "train_only"
+    DATA_ONLY = "data_only"
+    OFFLINE = "offline"
+    ONLINE = "online"
+
+
+class SpeculatorType(Enum):
+    """Draft model architecture for speculative decoding.
+
+    Args:
+        EAGLE3: Eagle3 draft model architecture.
+        DFLASH: DFlash draft model architecture.
+        MTP: Multi-Token Prediction draft model architecture.
+        PEAGLE: PEAGLE draft model architecture.
+    """
+
+    EAGLE3 = "eagle3"
+    DFLASH = "dflash"
+    MTP = "mtp"
+    PEAGLE = "peagle"
+
+
+_SUPPORTED_DTYPES = {"bfloat16", "float16", "float32"}
+
+
+@dataclass
+class SpeculativeDecodingTrainer:
+    """RHAI trainer for custom draft model training via the speculators library.
+
+    Args:
+        verifier_name_or_path: HuggingFace model ID or path to the verifier model.
+        speculator_type: Draft model architecture (default: EAGLE3).
+        mode: Training mode (TRAIN_ONLY for this ticket).
+        hidden_states_path: Pre-extracted hidden states on PVC (required for TRAIN_ONLY).
+        draft_vocab_size: Draft model vocabulary size.
+        epochs: Training epochs (default: 3).
+        lr: Learning rate (default: 1e-4).
+        total_seq_len: Maximum total sequence length for batch packing (default: 8192).
+        hidden_states_dtype: PyTorch dtype for hidden states tensors (default: "bfloat16").
+            Must match the verifier model's dtype. Supported values: "bfloat16", "float16",
+            "float32".
+        num_nodes: Number of nodes for distributed training.
+        resources_per_node: Computing resources per node.
+            Example: {"nvidia.com/gpu": 2, "memory": "64Gi", "cpu": "8"}
+        packages_to_install: Python packages to install before training.
+        pip_index_urls: PyPI index URLs for package installation.
+        env: Environment variables to set in training pods.
+        output_dir: Directory for saving the trained model. Supports PVC URIs
+            (pvc://<name>/<path>). The SDK auto-mounts the volume and resolves the path
+            for the training script.
+        enable_progression_tracking: Enable progression tracking.
+        metrics_port: HTTP server port for metrics endpoint.
+        metrics_poll_interval_seconds: How often controller polls metrics endpoint.
+    """
+
+    verifier_name_or_path: str
+    speculator_type: SpeculatorType = SpeculatorType.EAGLE3
+    mode: SpeculatorMode = SpeculatorMode.TRAIN_ONLY
+    hidden_states_path: str | None = None
+    draft_vocab_size: int | None = None
+    epochs: int = 3
+    lr: float = 1e-4
+    total_seq_len: int = 8192
+    hidden_states_dtype: str = "bfloat16"
+    num_nodes: int | None = None
+    resources_per_node: dict | None = None
+    packages_to_install: list[str] | None = None
+    pip_index_urls: list[str] = field(
+        default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS)
+    )
+    env: dict[str, str] | None = None
+    output_dir: str | None = None
+
+    enable_progression_tracking: bool = True
+    metrics_port: int = 28080
+    metrics_poll_interval_seconds: int = 30
+
+    def __post_init__(self) -> None:
+        """Validate configuration after initialization."""
+        if self.mode != SpeculatorMode.TRAIN_ONLY:
+            raise NotImplementedError(
+                f"Mode '{self.mode.value}' is not yet supported. "
+                f"Currently only '{SpeculatorMode.TRAIN_ONLY.value}' is supported."
+            )
+
+        if self.speculator_type != SpeculatorType.EAGLE3:
+            raise NotImplementedError(
+                f"Speculator type '{self.speculator_type.value}' is not yet supported. "
+                f"Currently only '{SpeculatorType.EAGLE3.value}' is supported."
+            )
+
+        if self.mode == SpeculatorMode.TRAIN_ONLY and not self.hidden_states_path:
+            raise ValueError(
+                "hidden_states_path is required for TRAIN_ONLY mode. "
+                "Provide the path to pre-extracted hidden states on PVC."
+            )
+
+        if self.mode == SpeculatorMode.TRAIN_ONLY and not self.output_dir:
+            raise ValueError(
+                "output_dir is required for TRAIN_ONLY mode. "
+                "Provide a PVC URI (pvc://<name>/<path>) for saving the trained draft model."
+            )
+
+        if not isinstance(self.epochs, int) or self.epochs < 1:
+            raise ValueError(f"epochs must be a positive integer, got {self.epochs!r}.")
+
+        if not isinstance(self.lr, (int, float)) or self.lr <= 0:
+            raise ValueError(f"lr must be a positive number, got {self.lr!r}.")
+
+        if not isinstance(self.total_seq_len, int) or self.total_seq_len < 1:
+            raise ValueError(
+                f"total_seq_len must be a positive integer, got {self.total_seq_len!r}."
+            )
+
+        if self.draft_vocab_size is not None and (
+            not isinstance(self.draft_vocab_size, int) or self.draft_vocab_size < 1
+        ):
+            raise ValueError(
+                f"draft_vocab_size must be a positive integer, got {self.draft_vocab_size!r}."
+            )
+
+        if self.hidden_states_dtype not in _SUPPORTED_DTYPES:
+            raise ValueError(
+                f"hidden_states_dtype must be one of {_SUPPORTED_DTYPES}, "
+                f"got '{self.hidden_states_dtype}'."
+            )
+
+        if not isinstance(self.metrics_port, int):
+            raise ValueError(
+                f"metrics_port must be an integer, got {type(self.metrics_port).__name__}"
+            )
+        if self.metrics_port < 1024 or self.metrics_port > 65535:
+            raise ValueError(f"metrics_port must be in range 1024-65535, got {self.metrics_port}")
+
+        if not isinstance(self.metrics_poll_interval_seconds, int):
+            raise ValueError(
+                f"metrics_poll_interval_seconds must be an integer, "
+                f"got {type(self.metrics_poll_interval_seconds).__name__}"
+            )
+        if self.metrics_poll_interval_seconds < 5 or self.metrics_poll_interval_seconds > 300:
+            raise ValueError(
+                f"metrics_poll_interval_seconds must be in range 5-300 seconds, "
+                f"got {self.metrics_poll_interval_seconds}"
+            )
+
+        if self.output_dir:
+            from kubeflow.trainer.rhai.utils import normalize_and_validate_output_dir
+
+            self.output_dir = normalize_and_validate_output_dir(self.output_dir)
+
+        if (
+            self.output_dir
+            and "://" in self.output_dir
+            and not self.output_dir.startswith(PVC_URI_SCHEME)
+        ):
+            raise NotImplementedError(
+                f"output_dir scheme '{self.output_dir.split('://')[0]}://' is not yet supported "
+                f"for SpeculativeDecodingTrainer. Currently only PVC URIs (pvc://<name>/<path>) "
+                f"or direct paths are supported."
+            )
+
+        if self.hidden_states_path:
+            from kubeflow.trainer.rhai.utils import normalize_and_validate_output_dir
+
+            self.hidden_states_path = normalize_and_validate_output_dir(self.hidden_states_path)
+
+        if (
+            self.hidden_states_path
+            and "://" in self.hidden_states_path
+            and not self.hidden_states_path.startswith(PVC_URI_SCHEME)
+        ):
+            raise NotImplementedError(
+                f"hidden_states_path scheme "
+                f"'{self.hidden_states_path.split('://')[0]}://' is not yet supported "
+                f"for SpeculativeDecodingTrainer. Currently only PVC URIs (pvc://<name>/<path>) "
+                f"or direct paths are supported."
+            )
+
+
+def _speculator_train_only(
+    verifier_name_or_path: str,
+    hidden_states_path: str,
+    save_path: str,
+    epochs: int,
+    lr: float,
+    total_seq_len: int,
+    hidden_states_dtype: str,
+    draft_vocab_size: int | None,
+) -> None:
+    """Training function injected into pods via inspect.getsource().
+
+    This function is NOT called directly in the SDK. It is extracted as source
+    code and injected into the training script that runs inside the container.
+    """
+    import contextlib
+    import os
+
+    from speculators.models.eagle3.core import Eagle3DraftModel
+    from speculators.models.eagle3.data import shift_batch
+    from speculators.train.data import ArrowDataset, create_collate_fn
+    from speculators.train.distributed_batch_sampler import (
+        MultipackDistributedBatchSamplerV2,
+    )
+    from speculators.train.noise_transforms import AddUniformNoise
+    from speculators.train.trainer import Trainer, TrainerConfig
+    import torch
+    from torch.utils.data import DataLoader
+    from transformers import AutoConfig
+
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    is_distributed = int(os.environ.get("WORLD_SIZE", 1)) > 1
+    if is_distributed:
+        torch.distributed.init_process_group(backend="nccl")
+        torch.cuda.set_device(local_rank)
+
+    verifier_config = AutoConfig.from_pretrained(verifier_name_or_path)
+    if draft_vocab_size is None:
+        draft_vocab_size = verifier_config.vocab_size
+
+    model = Eagle3DraftModel.from_training_args(
+        verifier_config,
+        draft_vocab_size=draft_vocab_size,
+        norm_before_residual=True,
+        ttt_steps=3,
+        verifier_name_or_path=verifier_name_or_path,
+    )
+
+    max_len = total_seq_len
+    collate_fn = create_collate_fn(max_len, verifier_config.hidden_size)
+    hs_dtype = getattr(torch, hidden_states_dtype)
+
+    train_dataset = ArrowDataset(
+        max_len=max_len,
+        datapath=hidden_states_path,
+        split_ratio=0.9,
+        on_missing="skip",
+        transform=AddUniformNoise(),
+        hidden_states_dtype=hs_dtype,
+    )
+    val_dataset = ArrowDataset(
+        max_len=max_len,
+        datapath=hidden_states_path,
+        split_ratio=-0.1,
+        on_missing="skip",
+        hidden_states_dtype=hs_dtype,
+    )
+
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    rank = int(os.environ.get("RANK", 0))
+
+    train_batch_sampler = MultipackDistributedBatchSamplerV2(
+        batch_max_length=max_len,
+        lengths=train_dataset.approx_lengths,
+        num_replicas=world_size,
+        rank=rank,
+    )
+    val_batch_sampler = MultipackDistributedBatchSamplerV2(
+        batch_max_length=max_len,
+        lengths=val_dataset.approx_lengths,
+        num_replicas=world_size,
+        rank=rank,
+    )
+
+    train_loader = DataLoader(
+        train_dataset, batch_sampler=train_batch_sampler, collate_fn=collate_fn
+    )
+    val_loader = DataLoader(val_dataset, batch_sampler=val_batch_sampler, collate_fn=collate_fn)
+
+    with contextlib.suppress(NameError):
+        _set_steps_per_epoch(len(train_loader))  # noqa: F821
+
+    config = TrainerConfig(
+        lr=lr,
+        num_epochs=epochs,
+        save_path=save_path,
+        is_distributed=is_distributed,
+        local_rank=local_rank,
+        train_call_kwargs={"shift_fn": shift_batch},
+        val_call_kwargs={"shift_fn": shift_batch},
+    )
+
+    trainer = Trainer(model, config, train_loader, val_loader)
+    trainer.run_training()
+
+
+def _render_speculator_training_script(trainer: SpeculativeDecodingTrainer) -> str:
+    """Generate a training script via inspect.getsource().
+
+    Extracts ``_speculator_train_only`` as source code and appends a call
+    with the trainer's configuration values injected via ``repr()``.
+
+    Args:
+        trainer: SpeculativeDecodingTrainer configuration.
+
+    Returns:
+        Python source code string for the training script.
+    """
+    import inspect
+    import textwrap
+
+    from kubeflow.trainer.rhai.utils import parse_output_dir_uri
+
+    resolved_output_dir, _ = parse_output_dir_uri(trainer.output_dir)
+    resolved_hidden_states, _ = parse_output_dir_uri(trainer.hidden_states_path)
+
+    func_code = inspect.getsource(_speculator_train_only)
+    func_code = textwrap.dedent(func_code)
+
+    call_code = (
+        f"\n_speculator_train_only(\n"
+        f"    verifier_name_or_path={trainer.verifier_name_or_path!r},\n"
+        f"    hidden_states_path={resolved_hidden_states!r},\n"
+        f"    save_path={resolved_output_dir!r},\n"
+        f"    epochs={trainer.epochs!r},\n"
+        f"    lr={trainer.lr!r},\n"
+        f"    total_seq_len={trainer.total_seq_len!r},\n"
+        f"    hidden_states_dtype={trainer.hidden_states_dtype!r},\n"
+        f"    draft_vocab_size={trainer.draft_vocab_size!r},\n"
+        f")\n"
+    )
+
+    return func_code + call_code
+
+
+def _create_speculator_progression_instrumentation(
+    metrics_port: int,
+    num_epochs: int,
+    save_path: str,
+) -> tuple:
+    """Instrumentation code injected into training pods (extracted via inspect.getsource).
+
+    This function is NOT called directly in the SDK - it's extracted as source code
+    via inspect.getsource() and injected into training scripts.
+
+    Args:
+        metrics_port: Port for HTTP metrics server.
+        num_epochs: Total training epochs for progress calculation.
+        save_path: Directory for checkpoint output (unused, kept for API compat).
+
+    Returns:
+        Tuple of (apply_fn, handler_class) for testing purposes.
+    """
+    import http.server
+    import json
+    import logging
+    import threading
+    import time
+
+    _start_time: float | None = None
+    _steps_per_epoch: int | None = None
+    _max_step_in_epoch0 = 0
+    _last_global_step = 0
+    _last_epoch = 0
+    _latest_metrics: dict = {}
+    _metrics_lock = threading.Lock()
+    _termination_message_written = False
+
+    class MetricsHandler(logging.Handler):
+        """Captures speculators.metrics log records in memory."""
+
+        def emit(self, record):
+            nonlocal \
+                _steps_per_epoch, \
+                _max_step_in_epoch0, \
+                _last_global_step, \
+                _last_epoch, \
+                _latest_metrics
+            try:
+                msg = record.msg
+                if not isinstance(msg, dict):
+                    return
+                with _metrics_lock:
+                    _latest_metrics = msg
+                    if "global_step" in msg:
+                        _last_global_step = msg["global_step"]
+                    if "epoch" in msg:
+                        _last_epoch = msg["epoch"]
+                    if (
+                        _steps_per_epoch is None
+                        and "train" in msg
+                        and "epoch" in msg
+                        and "global_step" in msg
+                    ):
+                        if msg["epoch"] == 0:
+                            _max_step_in_epoch0 = max(_max_step_in_epoch0, msg["global_step"])
+                        elif msg["epoch"] >= 1 and _max_step_in_epoch0 >= 0:
+                            _steps_per_epoch = _max_step_in_epoch0 + 1
+            except (KeyError, TypeError, ValueError) as e:
+                print(f"[Kubeflow] Warning: Failed to parse metrics record: {e}", flush=True)
+
+    class SpeculatorMetricsHTTPHandler(http.server.BaseHTTPRequestHandler):
+        """HTTP handler that serves in-memory metrics to the controller."""
+
+        def do_GET(self):
+            try:
+                with _metrics_lock:
+                    metrics_snapshot = dict(_latest_metrics)
+                transformed = self._transform(metrics_snapshot)
+            except Exception as e:
+                print(f"[Kubeflow] Failed to create progress metrics payload: {e}", flush=True)
+                self.send_error(500)
+            else:
+                self._maybe_write_termination_message(transformed)
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(transformed, indent=2).encode())
+
+        def _transform(self, metrics):
+            if not metrics:
+                return {
+                    "progressPercentage": None,
+                    "estimatedRemainingSeconds": None,
+                    "currentStep": None,
+                    "totalSteps": None,
+                    "currentEpoch": None,
+                    "totalEpochs": None,
+                    "trainMetrics": None,
+                    "evalMetrics": None,
+                }
+
+            global_step = metrics.get("global_step", _last_global_step)
+            epoch = metrics.get("epoch", _last_epoch)
+            train_metrics = metrics.get("train", {})
+            val_metrics = metrics.get("val", {})
+
+            total_steps = None
+            progress_pct = 0
+            estimated_remaining = None
+
+            if _steps_per_epoch and _steps_per_epoch > 0:
+                total_steps = _steps_per_epoch * num_epochs
+                if total_steps > 0:
+                    completed_steps = global_step + 1
+                    progress = completed_steps / total_steps * 100
+                    progress_pct = min(100, int(round(progress)))
+
+                    if _start_time and completed_steps > 0:
+                        elapsed = time.time() - _start_time
+                        remaining_steps = total_steps - completed_steps
+                        if progress_pct >= 100 or remaining_steps <= 0:
+                            estimated_remaining = 0
+                        else:
+                            time_per_step = elapsed / completed_steps
+                            estimated_remaining = int(remaining_steps * time_per_step)
+
+            loss_val = train_metrics.get("loss")
+            lr_val = metrics.get("lr")
+
+            return {
+                "progressPercentage": progress_pct,
+                "estimatedRemainingSeconds": estimated_remaining,
+                "currentStep": global_step,
+                "totalSteps": total_steps,
+                "currentEpoch": epoch + 1,
+                "totalEpochs": num_epochs,
+                "trainMetrics": {
+                    "loss": f"{loss_val:.4f}" if loss_val is not None else None,
+                    "learning_rate": f"{lr_val:.6f}" if lr_val is not None else None,
+                },
+                "evalMetrics": {
+                    k: f"{v:.4f}" if isinstance(v, (int, float)) else str(v)
+                    for k, v in val_metrics.items()
+                }
+                if val_metrics
+                else {},
+            }
+
+        def _maybe_write_termination_message(self, metrics):
+            nonlocal _termination_message_written
+            if _termination_message_written:
+                return
+            progress = metrics.get("progressPercentage")
+            if progress is not None and progress >= 100:
+                try:
+                    with open("/dev/termination-log", "w") as f:
+                        f.write(json.dumps(metrics))
+                    _termination_message_written = True
+                    print("[Kubeflow] Training complete. Final metrics saved.", flush=True)
+                except (OSError, ValueError, TypeError) as e:
+                    print(
+                        f"[Kubeflow] Warning: Failed to write termination message: {e}. "
+                        f"Controller will fall back to HTTP polling.",
+                        flush=True,
+                    )
+
+        def log_message(self, format, *args):
+            pass
+
+    def set_steps_per_epoch(steps):
+        nonlocal _steps_per_epoch
+        _steps_per_epoch = steps
+
+    def apply_progression_tracking():
+        nonlocal _start_time
+        _start_time = time.time()
+
+        handler = MetricsHandler()
+        metrics_logger = logging.getLogger("speculators.metrics")
+        metrics_logger.setLevel(logging.INFO)
+        metrics_logger.addHandler(handler)
+
+        try:
+            server = http.server.HTTPServer(("0.0.0.0", metrics_port), SpeculatorMetricsHTTPHandler)
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            print(f"[Kubeflow] Metrics server started on port {metrics_port}", flush=True)
+        except OSError as e:
+            print(
+                f"[Kubeflow] Warning: Failed to start metrics server on port "
+                f"{metrics_port}: {e}. Training will continue without metrics server.",
+                flush=True,
+            )
+        except Exception as e:
+            print(
+                f"[Kubeflow] Warning: Unexpected error starting metrics server: {e}. "
+                f"Training will continue without metrics server.",
+                flush=True,
+            )
+
+        return set_steps_per_epoch
+
+    return (apply_progression_tracking, SpeculatorMetricsHTTPHandler, set_steps_per_epoch)
+
+
+def get_speculator_instrumentation_wrapper(
+    metrics_port: int,
+    num_epochs: int,
+    save_path: str,
+) -> str:
+    """Generate self-contained instrumentation wrapper via inspect.getsource.
+
+    Args:
+        metrics_port: Port for HTTP metrics server.
+        num_epochs: Total training epochs.
+        save_path: Directory for checkpoint output (passed through for API compat).
+
+    Returns:
+        Python code as string with {{user_training_code}} placeholder.
+    """
+    import inspect
+    import textwrap
+
+    instrumentation_code = inspect.getsource(_create_speculator_progression_instrumentation)
+    instrumentation_code = textwrap.dedent(instrumentation_code)
+
+    wrapper = f"""\
+# =============================================================================
+# Kubeflow SDK - Speculator Progression Tracking Instrumentation
+# Generated by kubeflow.trainer.rhai.speculator
+# =============================================================================
+
+print("[Kubeflow] Initializing speculator progression tracking", flush=True)
+
+# Instrumentation function definition
+{instrumentation_code}
+
+# Initialize and apply instrumentation
+(
+    apply_progression_tracking,
+    _,
+    _,
+) = _create_speculator_progression_instrumentation(
+    metrics_port={metrics_port},
+    num_epochs={num_epochs},
+    save_path={save_path!r},
+)
+_set_steps_per_epoch = apply_progression_tracking()
+print("[Kubeflow] Speculator progression tracking enabled", flush=True)
+
+# =============================================================================
+# USER TRAINING CODE
+# =============================================================================
+
+{{{{user_training_code}}}}"""
+
+    return wrapper
+
+
+def _build_install_snippet(
+    packages_to_install: list[str] | None,
+    pip_index_urls: list[str],
+) -> str:
+    """Build the shell snippet to install Python packages if requested."""
+    if not packages_to_install:
+        return ""
+    return k8s_utils.get_script_for_python_packages(
+        packages_to_install,
+        pip_index_urls,
+    )
+
+
+def _get_command_from_runtime(
+    runtime: types.Runtime,
+    func_code: str,
+    func_file: str,
+    install_snippet: str,
+) -> list[str]:
+    """Build command using runtime's command template.
+
+    Args:
+        runtime: Runtime configuration with command template.
+        func_code: The training function code to execute.
+        func_file: The filename to write the code to.
+        install_snippet: Package installation script to prepend.
+
+    Returns:
+        Command list ready for trainer_crd.command.
+    """
+    command = []
+    for c in runtime.trainer.command:
+        if "{func_file}" in c:
+            exec_script = c.format(func_code=func_code, func_file=func_file)
+            if install_snippet:
+                exec_script = install_snippet + exec_script
+            command.append(exec_script)
+        else:
+            command.append(c)
+    return command
+
+
+def get_trainer_cr_from_speculator_trainer(
+    runtime: types.Runtime,
+    trainer: SpeculativeDecodingTrainer,
+    initializer: types.Initializer | None = None,
+) -> models.TrainerV1alpha1Trainer:
+    """Build Trainer CRD for SpeculativeDecodingTrainer.
+
+    Args:
+        runtime: Runtime configuration.
+        trainer: SpeculativeDecodingTrainer configuration.
+        initializer: Optional initializer configuration.
+
+    Returns:
+        Trainer CRD spec.
+    """
+    runtime.trainer.set_command(constants.TORCH_COMMAND)
+
+    trainer_crd = models.TrainerV1alpha1Trainer()
+
+    if trainer.num_nodes is not None:
+        trainer_crd.num_nodes = trainer.num_nodes
+
+    if trainer.resources_per_node:
+        trainer_crd.resources_per_node = k8s_utils.get_resources_per_node(
+            trainer.resources_per_node
+        )
+
+    install_snippet = _build_install_snippet(trainer.packages_to_install, trainer.pip_index_urls)
+
+    func_code = _render_speculator_training_script(trainer)
+    func_file = "speculator_train.py"
+
+    if trainer.enable_progression_tracking:
+        from kubeflow.trainer.rhai.utils import parse_output_dir_uri
+
+        resolved_path, _ = parse_output_dir_uri(trainer.output_dir)
+        wrapper_code = get_speculator_instrumentation_wrapper(
+            metrics_port=trainer.metrics_port,
+            num_epochs=trainer.epochs,
+            save_path=resolved_path,
+        )
+        func_code = wrapper_code.replace("{{user_training_code}}", func_code)
+
+    trainer_crd.command = _get_command_from_runtime(
+        runtime=runtime,
+        func_code=func_code,
+        func_file=func_file,
+        install_snippet=install_snippet,
+    )
+
+    trainer_crd.env = (
+        [models.IoK8sApiCoreV1EnvVar(name=k, value=v) for k, v in trainer.env.items()]
+        if trainer.env
+        else None
+    )
+
+    return trainer_crd

--- a/kubeflow/trainer/rhai/speculator.py
+++ b/kubeflow/trainer/rhai/speculator.py
@@ -367,7 +367,6 @@ def _render_speculator_training_script(trainer: SpeculativeDecodingTrainer) -> s
 def _create_speculator_progression_instrumentation(
     metrics_port: int,
     num_epochs: int,
-    save_path: str,
 ) -> tuple:
     """Instrumentation code injected into training pods (extracted via inspect.getsource).
 
@@ -377,7 +376,6 @@ def _create_speculator_progression_instrumentation(
     Args:
         metrics_port: Port for HTTP metrics server.
         num_epochs: Total training epochs for progress calculation.
-        save_path: Directory for checkpoint output (unused, kept for API compat).
 
     Returns:
         Tuple of (apply_fn, handler_class) for testing purposes.
@@ -562,20 +560,18 @@ def _create_speculator_progression_instrumentation(
 
         return set_steps_per_epoch
 
-    return (apply_progression_tracking, SpeculatorMetricsHTTPHandler, set_steps_per_epoch)
+    return (apply_progression_tracking, SpeculatorMetricsHTTPHandler)
 
 
 def get_speculator_instrumentation_wrapper(
     metrics_port: int,
     num_epochs: int,
-    save_path: str,
 ) -> str:
     """Generate self-contained instrumentation wrapper via inspect.getsource.
 
     Args:
         metrics_port: Port for HTTP metrics server.
         num_epochs: Total training epochs.
-        save_path: Directory for checkpoint output (passed through for API compat).
 
     Returns:
         Python code as string with {{user_training_code}} placeholder.
@@ -601,11 +597,9 @@ print("[Kubeflow] Initializing speculator progression tracking", flush=True)
 (
     apply_progression_tracking,
     _,
-    _,
 ) = _create_speculator_progression_instrumentation(
     metrics_port={metrics_port},
     num_epochs={num_epochs},
-    save_path={save_path!r},
 )
 _set_steps_per_epoch = apply_progression_tracking()
 print("[Kubeflow] Speculator progression tracking enabled", flush=True)
@@ -694,13 +688,9 @@ def get_trainer_cr_from_speculator_trainer(
     func_file = "speculator_train.py"
 
     if trainer.enable_progression_tracking:
-        from kubeflow.trainer.rhai.utils import parse_output_dir_uri
-
-        resolved_path, _ = parse_output_dir_uri(trainer.output_dir)
         wrapper_code = get_speculator_instrumentation_wrapper(
             metrics_port=trainer.metrics_port,
             num_epochs=trainer.epochs,
-            save_path=resolved_path,
         )
         func_code = wrapper_code.replace("{{user_training_code}}", func_code)
 

--- a/kubeflow/trainer/rhai/speculator.py
+++ b/kubeflow/trainer/rhai/speculator.py
@@ -14,9 +14,9 @@
 
 """SpeculativeDecodingTrainer for custom draft model training via the speculators library.
 
-This module provides the SpeculativeDecodingTrainer dataclass for training speculative
-decoding draft models (e.g., Eagle3) using the speculators library. Currently
-supports TRAIN_ONLY mode, which trains from pre-extracted hidden states on a PVC.
+This module provides the SpeculativeDecodingTrainer and SpeculatorConfig dataclasses
+for training speculative decoding draft models (e.g., Eagle3) using the speculators
+library. Supports TRAIN_ONLY and DATA_ONLY modes.
 """
 
 from dataclasses import dataclass, field
@@ -35,8 +35,8 @@ class SpeculatorMode(Enum):
 
     Args:
         TRAIN_ONLY: Train draft model from pre-extracted hidden states on PVC.
-        DATA_ONLY: Extract hidden states from verifier model via vLLM (future).
-        OFFLINE: Train using a user-managed vLLM endpoint (future).
+        DATA_ONLY: Extract hidden states from verifier model via managed vLLM sidecar.
+        OFFLINE: Extract hidden states via user-managed vLLM endpoint, then train.
         ONLINE: Online training with a custom runtime image that includes all dependencies.
     """
 
@@ -66,52 +66,117 @@ _SUPPORTED_DTYPES = {"bfloat16", "float16", "float32"}
 
 
 @dataclass
+class SpeculatorConfig:
+    """Advanced configuration for speculator training.
+
+    Args:
+        num_layers: Number of draft model layers (default: 1).
+        ttt_steps: Test-time training steps (default: 3).
+        norm_before_residual: Apply normalization before residual connection (default: True).
+        norm_before_fc: Apply normalization before fully-connected layer (default: False).
+        embed_requires_grad: Whether embedding layer requires gradients (default: False).
+        hidden_states_dtype: PyTorch dtype for hidden states tensors (default: "bfloat16").
+            Must match the verifier model's dtype. Supported: "bfloat16", "float16", "float32".
+        scheduler_type: Learning rate scheduler type (default: "linear").
+            Supported: "linear", "cosine", "none".
+        scheduler_warmup_steps: Number of warmup steps for the learning rate scheduler.
+            When ``None`` (default), computed as 1% of total training steps.
+        scheduler_total_steps: Total number of steps for the learning rate scheduler.
+            When ``None`` (default), computed as ``num_epochs * steps_per_epoch``.
+        scheduler_num_cosine_cycles: Number of cosine cycles for the cosine scheduler
+            (default: 0.5). Only used when ``scheduler_type="cosine"``.
+        checkpoint_freq: Checkpoint frequency in epochs (default: 1.0).
+        save_best: Save only the best model checkpoint by validation loss (default: False).
+        log_freq: Logging frequency in steps (default: 1).
+        resume_from_checkpoint: Resume training from an existing checkpoint (default: False).
+        datagen_concurrency: Number of concurrent requests to vLLM for hidden state
+            extraction (default: 4).
+        target_layer_ids: Specific layer IDs for hidden state extraction. When ``None``,
+            auto-selected from the verifier model architecture.
+        from_pretrained: Path to a pretrained draft model to resume training from.
+    """
+
+    num_layers: int = 1
+    ttt_steps: int = 3
+    norm_before_residual: bool = True
+    norm_before_fc: bool = False
+    embed_requires_grad: bool = False
+    hidden_states_dtype: str = "bfloat16"
+    scheduler_type: str = "linear"
+    scheduler_warmup_steps: int | None = None
+    scheduler_total_steps: int | None = None
+    scheduler_num_cosine_cycles: float = 0.5
+    checkpoint_freq: float = 1.0
+    save_best: bool = False
+    log_freq: int = 1
+    resume_from_checkpoint: bool = False
+    datagen_concurrency: int = 4
+    target_layer_ids: list[int] | None = None
+    from_pretrained: str | None = None
+
+
+@dataclass
 class SpeculativeDecodingTrainer:
     """RHAI trainer for custom draft model training via the speculators library.
 
     Args:
-        verifier_name_or_path: HuggingFace model ID or path to the verifier model.
+        verifier_model: HuggingFace model ID or path to the verifier model.
+        mode: Training mode (TRAIN_ONLY or DATA_ONLY).
         speculator_type: Draft model architecture (default: EAGLE3).
-        mode: Training mode (TRAIN_ONLY for this ticket).
         hidden_states_path: Pre-extracted hidden states on PVC (required for TRAIN_ONLY).
-        draft_vocab_size: Draft model vocabulary size.
+        data_path: Path to preprocessed Arrow dataset (optional for TRAIN_ONLY).
+        dataset_name: Dataset for hidden state extraction (required for DATA_ONLY).
+            Built-in names (``"sharegpt"``, ``"ultrachat"``, ``"gsm8k"``), a HuggingFace
+            dataset ID, or a local ``.json``/``.jsonl`` file path.
+        max_samples: Maximum number of dataset samples to use for data generation.
+            Useful for quick testing. When ``None`` (default), all samples are used.
         epochs: Training epochs (default: 3).
         lr: Learning rate (default: 1e-4).
-        total_seq_len: Maximum total sequence length for batch packing (default: 8192).
-        hidden_states_dtype: PyTorch dtype for hidden states tensors (default: "bfloat16").
-            Must match the verifier model's dtype. Supported values: "bfloat16", "float16",
-            "float32".
+        total_seq_len: Maximum sequence length for dataset preprocessing,
+            vLLM context window, and training (default: 8192).
+        draft_vocab_size: Vocabulary size for the draft model. When ``None`` (default),
+            auto-computed as ``min(8192, verifier_vocab_size)``.
+        training_gpu_count: Number of GPUs for training (default: 1).
+        vllm_gpu_count: Number of GPUs for vLLM sidecar (default: 1).
+        vllm_gpu_memory_utilization: Fraction of GPU memory for vLLM (default: 0.9).
+        config: Advanced training configuration. See ``SpeculatorConfig``.
         num_nodes: Number of nodes for distributed training.
-        resources_per_node: Computing resources per node.
-            Example: {"nvidia.com/gpu": 2, "memory": "64Gi", "cpu": "8"}
         packages_to_install: Python packages to install before training.
         pip_index_urls: PyPI index URLs for package installation.
         env: Environment variables to set in training pods.
-        output_dir: Directory for saving the trained model. Supports PVC URIs
-            (pvc://<name>/<path>). The SDK auto-mounts the volume and resolves the path
-            for the training script.
-        enable_progression_tracking: Enable progression tracking.
-        metrics_port: HTTP server port for metrics endpoint.
-        metrics_poll_interval_seconds: How often controller polls metrics endpoint.
+        output_dir: Directory for saving outputs. Supports PVC URIs
+            (pvc://<name>/<path>). The SDK auto-mounts the volume and resolves the path.
+        regenerate_responses: When True, send dataset prompts to the verifier model
+            and use its responses instead of the original dataset responses before
+            preprocessing. Only supported in DATA_ONLY mode (default: False).
+        enable_progression_tracking: Enable progression tracking (default: True).
+        metrics_port: HTTP server port for metrics endpoint (default: 28080).
+        metrics_poll_interval_seconds: How often controller polls metrics (default: 30).
     """
 
-    verifier_name_or_path: str
+    verifier_model: str
+    mode: SpeculatorMode
     speculator_type: SpeculatorType = SpeculatorType.EAGLE3
-    mode: SpeculatorMode = SpeculatorMode.TRAIN_ONLY
     hidden_states_path: str | None = None
-    draft_vocab_size: int | None = None
+    data_path: str | None = None
+    dataset_name: str | None = None
+    max_samples: int | None = None
     epochs: int = 3
     lr: float = 1e-4
     total_seq_len: int = 8192
-    hidden_states_dtype: str = "bfloat16"
+    draft_vocab_size: int | None = None
+    training_gpu_count: int = 1
+    vllm_gpu_count: int = 1
+    vllm_gpu_memory_utilization: float = 0.9
+    config: SpeculatorConfig | None = None
     num_nodes: int | None = None
-    resources_per_node: dict | None = None
     packages_to_install: list[str] | None = None
     pip_index_urls: list[str] = field(
         default_factory=lambda: list(constants.DEFAULT_PIP_INDEX_URLS)
     )
     env: dict[str, str] | None = None
     output_dir: str | None = None
+    regenerate_responses: bool = False
 
     enable_progression_tracking: bool = True
     metrics_port: int = 28080
@@ -119,10 +184,14 @@ class SpeculativeDecodingTrainer:
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
-        if self.mode != SpeculatorMode.TRAIN_ONLY:
+        supported_modes = {
+            SpeculatorMode.TRAIN_ONLY,
+            SpeculatorMode.DATA_ONLY,
+        }
+        if self.mode not in supported_modes:
             raise NotImplementedError(
                 f"Mode '{self.mode.value}' is not yet supported. "
-                f"Currently only '{SpeculatorMode.TRAIN_ONLY.value}' is supported."
+                f"Currently supported modes: {', '.join(m.value for m in supported_modes)}."
             )
 
         if self.speculator_type != SpeculatorType.EAGLE3:
@@ -137,11 +206,28 @@ class SpeculativeDecodingTrainer:
                 "Provide the path to pre-extracted hidden states on PVC."
             )
 
-        if self.mode == SpeculatorMode.TRAIN_ONLY and not self.output_dir:
+        if not self.output_dir:
             raise ValueError(
-                "output_dir is required for TRAIN_ONLY mode. "
-                "Provide a PVC URI (pvc://<name>/<path>) for saving the trained draft model."
+                f"output_dir is required for {self.mode.name} mode. "
+                "Provide a PVC URI (pvc://<name>/<path>)."
             )
+
+        if self.mode == SpeculatorMode.DATA_ONLY and not self.dataset_name:
+            raise ValueError(
+                "dataset_name is required for DATA_ONLY mode. "
+                "Provide a HuggingFace dataset ID or name (e.g. 'sharegpt')."
+            )
+
+        if self.max_samples is not None:
+            if self.mode != SpeculatorMode.DATA_ONLY:
+                raise ValueError("max_samples is only supported in DATA_ONLY mode.")
+            if not isinstance(self.max_samples, int) or self.max_samples < 1:
+                raise ValueError(
+                    f"max_samples must be a positive integer, got {self.max_samples!r}."
+                )
+
+        if self.regenerate_responses and self.mode != SpeculatorMode.DATA_ONLY:
+            raise ValueError("regenerate_responses is only supported in DATA_ONLY mode.")
 
         if not isinstance(self.epochs, int) or self.epochs < 1:
             raise ValueError(f"epochs must be a positive integer, got {self.epochs!r}.")
@@ -154,17 +240,30 @@ class SpeculativeDecodingTrainer:
                 f"total_seq_len must be a positive integer, got {self.total_seq_len!r}."
             )
 
-        if self.draft_vocab_size is not None and (
-            not isinstance(self.draft_vocab_size, int) or self.draft_vocab_size < 1
-        ):
+        if not isinstance(self.training_gpu_count, int) or self.training_gpu_count < 1:
             raise ValueError(
-                f"draft_vocab_size must be a positive integer, got {self.draft_vocab_size!r}."
+                f"training_gpu_count must be a positive integer, got {self.training_gpu_count!r}."
             )
 
-        if self.hidden_states_dtype not in _SUPPORTED_DTYPES:
+        if not isinstance(self.vllm_gpu_count, int) or self.vllm_gpu_count < 1:
             raise ValueError(
-                f"hidden_states_dtype must be one of {_SUPPORTED_DTYPES}, "
-                f"got '{self.hidden_states_dtype}'."
+                f"vllm_gpu_count must be a positive integer, got {self.vllm_gpu_count!r}."
+            )
+
+        if (
+            not isinstance(self.vllm_gpu_memory_utilization, (int, float))
+            or self.vllm_gpu_memory_utilization <= 0
+            or self.vllm_gpu_memory_utilization > 1.0
+        ):
+            raise ValueError(
+                f"vllm_gpu_memory_utilization must be in range (0, 1.0], "
+                f"got {self.vllm_gpu_memory_utilization!r}."
+            )
+
+        if self.config is not None and self.config.hidden_states_dtype not in _SUPPORTED_DTYPES:
+            raise ValueError(
+                f"config.hidden_states_dtype must be one of {_SUPPORTED_DTYPES}, "
+                f"got '{self.config.hidden_states_dtype}'."
             )
 
         if not isinstance(self.metrics_port, int):
@@ -218,16 +317,263 @@ class SpeculativeDecodingTrainer:
                 f"or direct paths are supported."
             )
 
+        if self.dataset_name and self.dataset_name.startswith(PVC_URI_SCHEME):
+            from kubeflow.trainer.rhai.utils import normalize_and_validate_output_dir
+
+            self.dataset_name = normalize_and_validate_output_dir(self.dataset_name)
+
+        if (
+            self.dataset_name
+            and "://" in self.dataset_name
+            and not self.dataset_name.startswith(PVC_URI_SCHEME)
+        ):
+            raise NotImplementedError(
+                f"dataset_name scheme "
+                f"'{self.dataset_name.split('://')[0]}://' is not yet supported "
+                f"for SpeculativeDecodingTrainer. Currently only PVC URIs (pvc://<name>/<path>), "
+                f"direct paths, or HuggingFace dataset names are supported."
+            )
+
+
+def _speculator_data_only(
+    verifier_model: str,
+    dataset_name: str,
+    save_path: str,
+    total_seq_len: int,
+    max_samples: int | None = None,
+    vllm_endpoint: str = "http://localhost:8234/v1",
+    concurrency: int = 4,
+    regenerate_responses: bool = False,
+) -> None:
+    """Data extraction function injected into pods via inspect.getsource().
+
+    Extracts hidden states from the verifier model via a vLLM endpoint.
+    The vLLM server is provided either by the Kubernetes sidecar container
+    (DATA_ONLY mode).
+
+    This function is NOT called directly in the SDK. It is extracted as source
+    code and injected into the script that runs inside the container.
+    """
+    import os
+    import subprocess
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+
+    from speculators.data_generation.preprocessing import load_and_preprocess_dataset
+
+    hidden_states_dir = os.path.join(save_path, "hidden_states")
+    os.makedirs(save_path, exist_ok=True)
+    os.makedirs(hidden_states_dir, exist_ok=True)
+
+    rank = int(os.environ.get("RANK", "0"))
+    marker_name = f"{EXTRACTION_INCOMPLETE_MARKER}.rank-{rank}"  # noqa: F821
+    incomplete_marker = os.path.join(hidden_states_dir, marker_name)
+
+    if os.path.exists(incomplete_marker):
+        print(
+            f"[Kubeflow] Warning: Previous data extraction for rank {rank} did not complete. "
+            "Restarting extraction from the beginning.",
+            flush=True,
+        )
+    elif any(f.endswith(".safetensors") for f in os.listdir(hidden_states_dir)):
+        print("[Kubeflow] Data extraction already completed. Skipping.", flush=True)
+        if "_mark_data_complete" in globals():
+            _mark_data_complete()  # noqa: F821
+        return
+
+    try:
+        with open(incomplete_marker, "w") as f:
+            f.write(f"Data extraction in progress (rank {rank})")
+    except Exception as e:
+        print(
+            f"[Kubeflow] Warning: Failed to write sentinel file: {e}. "
+            "Check local disk space and write permissions in output_dir.",
+            flush=True,
+        )
+
+    if "_set_phase" in globals():
+        _set_phase("checking_vllm", 5)  # noqa: F821
+
+    endpoint = vllm_endpoint
+    print(f"[Kubeflow] Using vLLM endpoint: {endpoint}", flush=True)
+    health = vllm_endpoint.rstrip("/").rsplit("/v1", 1)[0] + "/health"
+    timeout_secs = 600
+    start = time.time()
+    print(f"[Kubeflow] Waiting for vLLM sidecar at {health} (timeout={timeout_secs}s)", flush=True)
+    while time.time() - start < timeout_secs:
+        try:
+            urllib.request.urlopen(health, timeout=5)
+            print("[Kubeflow] vLLM sidecar is ready", flush=True)
+            break
+        except (urllib.error.URLError, OSError):
+            time.sleep(5)
+    else:
+        sys.exit(f"vLLM endpoint not reachable within {timeout_secs}s")
+
+    if regenerate_responses:
+        from pathlib import Path
+
+        if "_set_phase" in globals():
+            _set_phase("regenerating_responses", 5)  # noqa: F821
+
+        print(
+            f"[Kubeflow] Regenerating responses from verifier model '{verifier_model}'", flush=True
+        )
+
+        regen_dataset_map = {
+            "sharegpt": "magpie",
+            "magpie": "magpie",
+            "ultrachat": "ultrachat",
+            "gsm8k": "gsm8k",
+        }
+        regen_dataset = regen_dataset_map.get(dataset_name, "magpie")
+        regen_output = str(Path(save_path) / "regenerated_responses.jsonl")
+        chat_endpoint = endpoint.rstrip("/").rsplit("/v1", 1)[0] + "/v1/chat/completions"
+
+        regen_script_path = "/tmp/response_regeneration.py"
+        if not os.path.exists(regen_script_path):
+            import base64
+
+            regen_content = base64.b64decode(_REGEN_SCRIPT_B64).decode("utf-8")  # noqa: F821
+            with open(regen_script_path, "w") as f:
+                f.write(regen_content)
+
+        regen_cmd = [
+            sys.executable,
+            regen_script_path,
+            "--endpoint",
+            chat_endpoint,
+            "--dataset",
+            regen_dataset,
+            "--outfile",
+            regen_output,
+        ]
+        if max_samples is not None:
+            regen_cmd.extend(["--limit", str(max_samples)])
+        print(f"[Kubeflow] Regenerating responses using dataset '{regen_dataset}'", flush=True)
+        regen_result = subprocess.run(regen_cmd, capture_output=False)
+        if regen_result.returncode != 0:
+            raise RuntimeError(
+                f"response_regeneration.py exited with code {regen_result.returncode}"
+            )
+        print(f"[Kubeflow] Responses saved to {regen_output}", flush=True)
+        dataset_name = regen_output
+
+    if "_set_phase" in globals():
+        _set_phase("preprocessing", 10)  # noqa: F821
+
+    print(
+        f"[Kubeflow] Preprocessing dataset '{dataset_name}' (seq_len={total_seq_len})", flush=True
+    )
+
+    token_freq_path = os.path.join(save_path, "token_freq.pt")
+    preprocess_kwargs = {
+        "target_model_path": verifier_model,
+        "train_data_paths": [dataset_name],
+        "seq_length": total_seq_len,
+        "token_freq_path": token_freq_path,
+    }
+    if max_samples is not None:
+        preprocess_kwargs["max_samples"] = max_samples
+    dataset, processor = load_and_preprocess_dataset(**preprocess_kwargs)
+    dataset.save_to_disk(save_path)
+    print(
+        f"[Kubeflow] Saved preprocessed dataset to {save_path} ({len(dataset)} samples)", flush=True
+    )
+
+    if "_start_data_progress_server" in globals():
+        _start_data_progress_server(hidden_states_dir, len(dataset))  # noqa: F821
+
+    if "_set_phase" in globals():
+        _set_phase("extracting", 15)  # noqa: F821
+
+    print(
+        f"[Kubeflow] Extracting hidden states from '{verifier_model}' to '{hidden_states_dir}'",
+        flush=True,
+    )
+
+    script_path = "/tmp/data_generation_offline.py"
+    if not os.path.exists(script_path):
+        import base64
+
+        script_content = base64.b64decode(_DATAGEN_SCRIPT_B64).decode("utf-8")  # noqa: F821
+        with open(script_path, "w") as f:
+            f.write(script_content)
+
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    datagen_cmd = [
+        sys.executable,
+        script_path,
+        "--model",
+        verifier_model,
+        "--preprocessed-data",
+        save_path,
+        "--endpoint",
+        endpoint,
+        "--output",
+        hidden_states_dir,
+        "--concurrency",
+        str(concurrency),
+        "--world-size",
+        str(world_size),
+        "--rank",
+        str(rank),
+    ]
+    if max_samples is not None:
+        datagen_cmd.extend(["--max-samples", str(max_samples)])
+    print(
+        f"[Kubeflow] Running hidden state extraction (concurrency={concurrency}, rank={rank}/{world_size})",
+        flush=True,
+    )
+    result = subprocess.run(datagen_cmd, capture_output=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"data_generation_offline.py exited with code {result.returncode}")
+
+    if os.path.exists(incomplete_marker):
+        try:
+            os.remove(incomplete_marker)
+        except Exception as e:
+            print(
+                f"[Kubeflow] Warning: Failed to remove sentinel file: {e}. "
+                f"A stale marker may cause re-extraction on next run. "
+                f"Remove it manually from: {incomplete_marker}",
+                flush=True,
+            )
+    if "_set_phase" in globals():
+        _set_phase("complete", 100)  # noqa: F821
+
+    print(
+        f"[Kubeflow] Data extraction complete. Hidden states saved to '{hidden_states_dir}'",
+        flush=True,
+    )
+
 
 def _speculator_train_only(
-    verifier_name_or_path: str,
+    verifier_model: str,
+    data_path: str,
     hidden_states_path: str,
     save_path: str,
     epochs: int,
     lr: float,
     total_seq_len: int,
-    hidden_states_dtype: str,
-    draft_vocab_size: int | None,
+    draft_vocab_size: int | None = None,
+    hidden_states_dtype: str = "bfloat16",
+    num_layers: int = 1,
+    ttt_steps: int = 3,
+    norm_before_residual: bool = True,
+    norm_before_fc: bool = False,
+    embed_requires_grad: bool = False,
+    scheduler_type: str = "linear",
+    scheduler_warmup_steps: int | None = None,
+    scheduler_total_steps: int | None = None,
+    scheduler_num_cosine_cycles: float = 0.5,
+    checkpoint_freq: float = 1.0,
+    save_best: bool = False,
+    log_freq: int = 1,
+    resume_from_checkpoint: bool = False,
+    from_pretrained: str | None = None,
 ) -> None:
     """Training function injected into pods via inspect.getsource().
 
@@ -236,7 +582,12 @@ def _speculator_train_only(
     """
     import contextlib
     import os
+    from pathlib import Path
 
+    import numpy as np
+
+    if "_set_phase" in globals():
+        _set_phase("initializing", 0)  # noqa: F821
     from speculators.models.eagle3.core import Eagle3DraftModel
     from speculators.models.eagle3.data import shift_batch
     from speculators.train.data import ArrowDataset, create_collate_fn
@@ -245,27 +596,64 @@ def _speculator_train_only(
     )
     from speculators.train.noise_transforms import AddUniformNoise
     from speculators.train.trainer import Trainer, TrainerConfig
+    from speculators.train.vocab_mapping import build_vocab_mappings_from_distribution
     import torch
     from torch.utils.data import DataLoader
     from transformers import AutoConfig
 
+    rank = int(os.environ.get("RANK", "0"))
+    marker_name = f"{EXTRACTION_INCOMPLETE_MARKER}.rank-{rank}"  # noqa: F821
+    hs_dir = os.path.join(hidden_states_path, "hidden_states")
+    own_marker = os.path.join(hs_dir, marker_name)
+    if os.path.exists(own_marker):
+        raise RuntimeError(
+            f"Incomplete data extraction detected at '{hidden_states_path}' "
+            f"for rank {rank}. "
+            "Re-run data extraction (DATA_ONLY mode) before training."
+        )
+
     local_rank = int(os.environ.get("LOCAL_RANK", 0))
     is_distributed = int(os.environ.get("WORLD_SIZE", 1)) > 1
-    if is_distributed:
+    if is_distributed and not torch.distributed.is_initialized():
         torch.distributed.init_process_group(backend="nccl")
         torch.cuda.set_device(local_rank)
 
-    verifier_config = AutoConfig.from_pretrained(verifier_name_or_path)
-    if draft_vocab_size is None:
-        draft_vocab_size = verifier_config.vocab_size
+    verifier_config = AutoConfig.from_pretrained(verifier_model)
+    target_vocab_size = verifier_config.vocab_size
 
-    model = Eagle3DraftModel.from_training_args(
-        verifier_config,
-        draft_vocab_size=draft_vocab_size,
-        norm_before_residual=True,
-        ttt_steps=3,
-        verifier_name_or_path=verifier_name_or_path,
-    )
+    d2t_path = Path(data_path) / "d2t.npy"
+    t2d_path = Path(data_path) / "t2d.npy"
+
+    if d2t_path.exists() and t2d_path.exists():
+        d2t = torch.from_numpy(np.load(str(d2t_path)))
+        t2d = torch.from_numpy(np.load(str(t2d_path)))
+        resolved_draft_vocab = len(d2t)
+    else:
+        resolved_draft_vocab = draft_vocab_size or min(8192, target_vocab_size)
+        token_freq_path = Path(data_path) / "token_freq.pt"
+        token_freq_dict = torch.load(str(token_freq_path), weights_only=True)
+        d2t, t2d = build_vocab_mappings_from_distribution(
+            token_freq_dict=token_freq_dict,
+            draft_vocab_size=resolved_draft_vocab,
+            target_vocab_size=target_vocab_size,
+        )
+        np.save(str(d2t_path), d2t.cpu().numpy())
+        np.save(str(t2d_path), t2d.cpu().numpy())
+
+    from_training_kwargs = {
+        "draft_vocab_size": resolved_draft_vocab,
+        "num_layers": num_layers,
+        "norm_before_residual": norm_before_residual,
+        "norm_before_fc": norm_before_fc,
+        "embed_requires_grad": embed_requires_grad,
+        "ttt_steps": ttt_steps,
+        "verifier_name_or_path": verifier_model,
+        "d2t": d2t,
+        "t2d": t2d,
+    }
+    if from_pretrained is not None:
+        from_training_kwargs["from_pretrained"] = from_pretrained
+    model = Eagle3DraftModel.from_training_args(verifier_config, **from_training_kwargs)
 
     max_len = total_seq_len
     collate_fn = create_collate_fn(max_len, verifier_config.hidden_size)
@@ -273,7 +661,8 @@ def _speculator_train_only(
 
     train_dataset = ArrowDataset(
         max_len=max_len,
-        datapath=hidden_states_path,
+        datapath=data_path,
+        hidden_states_path=hs_dir,
         split_ratio=0.9,
         on_missing="skip",
         transform=AddUniformNoise(),
@@ -281,7 +670,8 @@ def _speculator_train_only(
     )
     val_dataset = ArrowDataset(
         max_len=max_len,
-        datapath=hidden_states_path,
+        datapath=data_path,
+        hidden_states_path=hs_dir,
         split_ratio=-0.1,
         on_missing="skip",
         hidden_states_dtype=hs_dtype,
@@ -304,7 +694,9 @@ def _speculator_train_only(
     )
 
     train_loader = DataLoader(
-        train_dataset, batch_sampler=train_batch_sampler, collate_fn=collate_fn
+        train_dataset,
+        batch_sampler=train_batch_sampler,
+        collate_fn=collate_fn,
     )
     val_loader = DataLoader(val_dataset, batch_sampler=val_batch_sampler, collate_fn=collate_fn)
 
@@ -315,21 +707,37 @@ def _speculator_train_only(
         lr=lr,
         num_epochs=epochs,
         save_path=save_path,
+        resume_from_checkpoint=resume_from_checkpoint,
         is_distributed=is_distributed,
         local_rank=local_rank,
         train_call_kwargs={"shift_fn": shift_batch},
         val_call_kwargs={"shift_fn": shift_batch},
+        scheduler_type=scheduler_type,
+        scheduler_warmup_steps=scheduler_warmup_steps,
+        scheduler_total_steps=scheduler_total_steps,
+        scheduler_num_cosine_cycles=scheduler_num_cosine_cycles,
+        checkpoint_freq=checkpoint_freq,
+        save_best=save_best,
+        hidden_states_dtype=hs_dtype,
+        log_freq=log_freq,
     )
+
+    if "_set_phase" in globals():
+        _set_phase("training", 15)  # noqa: F821
 
     trainer = Trainer(model, config, train_loader, val_loader)
     trainer.run_training()
+
+    if "_set_phase" in globals():
+        _set_phase("complete", 100)  # noqa: F821
 
 
 def _render_speculator_training_script(trainer: SpeculativeDecodingTrainer) -> str:
     """Generate a training script via inspect.getsource().
 
-    Extracts ``_speculator_train_only`` as source code and appends a call
-    with the trainer's configuration values injected via ``repr()``.
+    Builds the script by composing shared pieces based on what each mode needs:
+    - DATA_ONLY: data extraction only
+    - TRAIN_ONLY: training only
 
     Args:
         trainer: SpeculativeDecodingTrainer configuration.
@@ -343,50 +751,137 @@ def _render_speculator_training_script(trainer: SpeculativeDecodingTrainer) -> s
     from kubeflow.trainer.rhai.utils import parse_output_dir_uri
 
     resolved_output_dir, _ = parse_output_dir_uri(trainer.output_dir)
-    resolved_hidden_states, _ = parse_output_dir_uri(trainer.hidden_states_path)
 
-    func_code = inspect.getsource(_speculator_train_only)
-    func_code = textwrap.dedent(func_code)
+    needs_data = trainer.mode == SpeculatorMode.DATA_ONLY
+    needs_train = trainer.mode == SpeculatorMode.TRAIN_ONLY
 
-    call_code = (
-        f"\n_speculator_train_only(\n"
-        f"    verifier_name_or_path={trainer.verifier_name_or_path!r},\n"
+    cfg = trainer.config or SpeculatorConfig()
+
+    from kubeflow.trainer.rhai.constants import EXTRACTION_INCOMPLETE_MARKER
+
+    script = f"EXTRACTION_INCOMPLETE_MARKER = {EXTRACTION_INCOMPLETE_MARKER!r}\n\n"
+
+    if needs_data:
+        import base64
+        from pathlib import Path
+
+        datagen_script_path = Path(__file__).parent / "scripts" / "data_generation_offline.py"
+        datagen_b64 = base64.b64encode(datagen_script_path.read_bytes()).decode("ascii")
+
+        script += f'_DATAGEN_SCRIPT_B64 = "{datagen_b64}"\n\n'
+        script += textwrap.dedent(inspect.getsource(_speculator_data_only))
+
+    if needs_train:
+        script += textwrap.dedent(inspect.getsource(_speculator_train_only))
+
+    if trainer.verifier_model.startswith(PVC_URI_SCHEME):
+        resolved_verifier_model, _ = parse_output_dir_uri(trainer.verifier_model)
+    else:
+        resolved_verifier_model = trainer.verifier_model
+
+    if trainer.dataset_name and trainer.dataset_name.startswith(PVC_URI_SCHEME):
+        resolved_dataset_name, _ = parse_output_dir_uri(trainer.dataset_name)
+    else:
+        resolved_dataset_name = trainer.dataset_name
+
+    if trainer.hidden_states_path:
+        resolved_hidden_states, _ = parse_output_dir_uri(trainer.hidden_states_path)
+    else:
+        resolved_hidden_states = resolved_output_dir
+
+    if trainer.mode == SpeculatorMode.TRAIN_ONLY:
+        if trainer.data_path and trainer.data_path.startswith(PVC_URI_SCHEME):
+            resolved_data_path, _ = parse_output_dir_uri(trainer.data_path)
+        else:
+            resolved_data_path = trainer.data_path
+    else:
+        resolved_data_path = resolved_output_dir
+
+    from kubeflow.trainer.rhai.constants import VLLM_SIDECAR_ENDPOINT
+
+    data_call = (
+        f"_speculator_data_only(\n"
+        f"    verifier_model={resolved_verifier_model!r},\n"
+        f"    dataset_name={resolved_dataset_name!r},\n"
+        f"    save_path={resolved_output_dir!r},\n"
+        f"    total_seq_len={trainer.total_seq_len!r},\n"
+        f"    max_samples={trainer.max_samples!r},\n"
+        f"    vllm_endpoint={VLLM_SIDECAR_ENDPOINT!r},\n"
+        f"    concurrency={cfg.datagen_concurrency!r},\n"
+        f"    regenerate_responses={trainer.regenerate_responses!r},\n"
+        f")\n"
+    )
+
+    train_call = (
+        f"_speculator_train_only(\n"
+        f"    verifier_model={resolved_verifier_model!r},\n"
+        f"    data_path={resolved_data_path!r},\n"
         f"    hidden_states_path={resolved_hidden_states!r},\n"
         f"    save_path={resolved_output_dir!r},\n"
         f"    epochs={trainer.epochs!r},\n"
         f"    lr={trainer.lr!r},\n"
         f"    total_seq_len={trainer.total_seq_len!r},\n"
-        f"    hidden_states_dtype={trainer.hidden_states_dtype!r},\n"
         f"    draft_vocab_size={trainer.draft_vocab_size!r},\n"
+        f"    hidden_states_dtype={cfg.hidden_states_dtype!r},\n"
+        f"    num_layers={cfg.num_layers!r},\n"
+        f"    ttt_steps={cfg.ttt_steps!r},\n"
+        f"    norm_before_residual={cfg.norm_before_residual!r},\n"
+        f"    norm_before_fc={cfg.norm_before_fc!r},\n"
+        f"    embed_requires_grad={cfg.embed_requires_grad!r},\n"
+        f"    scheduler_type={cfg.scheduler_type!r},\n"
+        f"    scheduler_warmup_steps={cfg.scheduler_warmup_steps!r},\n"
+        f"    scheduler_total_steps={cfg.scheduler_total_steps!r},\n"
+        f"    scheduler_num_cosine_cycles={cfg.scheduler_num_cosine_cycles!r},\n"
+        f"    checkpoint_freq={cfg.checkpoint_freq!r},\n"
+        f"    save_best={cfg.save_best!r},\n"
+        f"    log_freq={cfg.log_freq!r},\n"
+        f"    resume_from_checkpoint={cfg.resume_from_checkpoint!r},\n"
+        f"    from_pretrained={cfg.from_pretrained!r},\n"
         f")\n"
     )
 
-    return func_code + call_code
+    if trainer.mode == SpeculatorMode.DATA_ONLY:
+        script += f"\n{data_call}"
+
+    elif trainer.mode == SpeculatorMode.TRAIN_ONLY:
+        script += f"\n{train_call}"
+
+    return script
 
 
 def _create_speculator_progression_instrumentation(
     metrics_port: int,
-    num_epochs: int,
+    mode: str,
+    num_epochs: int = 0,
 ) -> tuple:
-    """Instrumentation code injected into training pods (extracted via inspect.getsource).
+    """Unified instrumentation for all speculator modes (extracted via inspect.getsource).
+
+    Handles progression tracking for DATA_ONLY (file counting) and TRAIN_ONLY (log
+    interception).
 
     This function is NOT called directly in the SDK - it's extracted as source code
     via inspect.getsource() and injected into training scripts.
 
     Args:
         metrics_port: Port for HTTP metrics server.
-        num_epochs: Total training epochs for progress calculation.
+        mode: Speculator mode string ("data_only", "train_only").
+        num_epochs: Total training epochs (used for train_only).
 
     Returns:
-        Tuple of (apply_fn, handler_class) for testing purposes.
+        Tuple of (apply_fn, start_data_fn, handler_class) for testing purposes.
     """
     import http.server
     import json
     import logging
+    import os
     import threading
     import time
 
-    _start_time: float | None = None
+    _hidden_states_dir: str | None = None
+    _total_samples: int = 0
+    _data_start_time: float | None = None
+
+    _train_start_time: float | None = None
     _steps_per_epoch: int | None = None
     _max_step_in_epoch0 = 0
     _last_global_step = 0
@@ -394,6 +889,9 @@ def _create_speculator_progression_instrumentation(
     _latest_metrics: dict = {}
     _metrics_lock = threading.Lock()
     _termination_message_written = False
+    _current_phase: str | None = None
+    _phase_floor_pct: int = 0
+    _training_started = False
 
     class MetricsHandler(logging.Handler):
         """Captures speculators.metrics log records in memory."""
@@ -404,12 +902,17 @@ def _create_speculator_progression_instrumentation(
                 _max_step_in_epoch0, \
                 _last_global_step, \
                 _last_epoch, \
-                _latest_metrics
+                _latest_metrics, \
+                _training_started, \
+                _train_start_time
             try:
                 msg = record.msg
                 if not isinstance(msg, dict):
                     return
                 with _metrics_lock:
+                    if not _training_started:
+                        _training_started = True
+                        _train_start_time = time.time()
                     _latest_metrics = msg
                     if "global_step" in msg:
                         _last_global_step = msg["global_step"]
@@ -429,13 +932,11 @@ def _create_speculator_progression_instrumentation(
                 print(f"[Kubeflow] Warning: Failed to parse metrics record: {e}", flush=True)
 
     class SpeculatorMetricsHTTPHandler(http.server.BaseHTTPRequestHandler):
-        """HTTP handler that serves in-memory metrics to the controller."""
+        """HTTP handler that serves mode-aware progress to the controller."""
 
         def do_GET(self):
             try:
-                with _metrics_lock:
-                    metrics_snapshot = dict(_latest_metrics)
-                transformed = self._transform(metrics_snapshot)
+                transformed = self._get_progress()
             except Exception as e:
                 print(f"[Kubeflow] Failed to create progress metrics payload: {e}", flush=True)
                 self.send_error(500)
@@ -446,23 +947,65 @@ def _create_speculator_progression_instrumentation(
                 self.end_headers()
                 self.wfile.write(json.dumps(transformed, indent=2).encode())
 
-        def _transform(self, metrics):
-            if not metrics:
-                return {
-                    "progressPercentage": None,
-                    "estimatedRemainingSeconds": None,
-                    "currentStep": None,
-                    "totalSteps": None,
-                    "currentEpoch": None,
-                    "totalEpochs": None,
-                    "trainMetrics": None,
-                    "evalMetrics": None,
-                }
+        def _get_progress(self):
+            if mode == "data_only":
+                return self._data_progress()
+            elif mode == "train_only":
+                return self._training_progress()
+            return self._empty_response()
 
-            global_step = metrics.get("global_step", _last_global_step)
-            epoch = metrics.get("epoch", _last_epoch)
-            train_metrics = metrics.get("train", {})
-            val_metrics = metrics.get("val", {})
+        def _data_progress(self):
+            if _hidden_states_dir is None or _total_samples <= 0:
+                return self._empty_response()
+
+            try:
+                count = len(
+                    [
+                        f
+                        for f in os.listdir(_hidden_states_dir)
+                        if f.startswith("hs_") and f.endswith(".safetensors")
+                    ]
+                )
+            except FileNotFoundError:
+                count = 0
+
+            progress_pct = max(int(count / _total_samples * 100), _phase_floor_pct)
+
+            estimated_remaining = None
+            if _data_start_time and count > 0:
+                elapsed = time.time() - _data_start_time
+                remaining = _total_samples - count
+                if remaining <= 0:
+                    estimated_remaining = 0
+                else:
+                    time_per_sample = elapsed / count
+                    estimated_remaining = int(remaining * time_per_sample)
+
+            return {
+                "progressPercentage": progress_pct,
+                "estimatedRemainingSeconds": estimated_remaining,
+                "currentStep": count,
+                "totalSteps": _total_samples,
+                "currentEpoch": None,
+                "totalEpochs": None,
+                "currentPhase": _current_phase,
+                "trainMetrics": None,
+                "evalMetrics": None,
+            }
+
+        def _training_progress(self):
+            with _metrics_lock:
+                metrics_snapshot = dict(_latest_metrics)
+
+            if not metrics_snapshot:
+                response = self._empty_response()
+                response["progressPercentage"] = _phase_floor_pct
+                return response
+
+            global_step = metrics_snapshot.get("global_step", _last_global_step)
+            epoch = metrics_snapshot.get("epoch", _last_epoch)
+            train_metrics = metrics_snapshot.get("train", {})
+            val_metrics = metrics_snapshot.get("val", {})
 
             total_steps = None
             progress_pct = 0
@@ -472,20 +1015,19 @@ def _create_speculator_progression_instrumentation(
                 total_steps = _steps_per_epoch * num_epochs
                 if total_steps > 0:
                     completed_steps = global_step + 1
-                    progress = completed_steps / total_steps * 100
-                    progress_pct = min(100, int(round(progress)))
+                    progress_pct = max(int(completed_steps / total_steps * 100), _phase_floor_pct)
 
-                    if _start_time and completed_steps > 0:
-                        elapsed = time.time() - _start_time
+                    if _train_start_time and completed_steps > 0:
+                        elapsed = time.time() - _train_start_time
                         remaining_steps = total_steps - completed_steps
-                        if progress_pct >= 100 or remaining_steps <= 0:
+                        if remaining_steps <= 0:
                             estimated_remaining = 0
                         else:
                             time_per_step = elapsed / completed_steps
                             estimated_remaining = int(remaining_steps * time_per_step)
 
             loss_val = train_metrics.get("loss")
-            lr_val = metrics.get("lr")
+            lr_val = metrics_snapshot.get("lr")
 
             return {
                 "progressPercentage": progress_pct,
@@ -494,6 +1036,7 @@ def _create_speculator_progression_instrumentation(
                 "totalSteps": total_steps,
                 "currentEpoch": epoch + 1,
                 "totalEpochs": num_epochs,
+                "currentPhase": _current_phase,
                 "trainMetrics": {
                     "loss": f"{loss_val:.4f}" if loss_val is not None else None,
                     "learning_rate": f"{lr_val:.6f}" if lr_val is not None else None,
@@ -506,6 +1049,19 @@ def _create_speculator_progression_instrumentation(
                 else {},
             }
 
+        def _empty_response(self):
+            return {
+                "progressPercentage": _phase_floor_pct if _phase_floor_pct > 0 else None,
+                "estimatedRemainingSeconds": None,
+                "currentStep": None,
+                "totalSteps": None,
+                "currentEpoch": None,
+                "totalEpochs": None,
+                "currentPhase": _current_phase,
+                "trainMetrics": None,
+                "evalMetrics": None,
+            }
+
         def _maybe_write_termination_message(self, metrics):
             nonlocal _termination_message_written
             if _termination_message_written:
@@ -516,7 +1072,7 @@ def _create_speculator_progression_instrumentation(
                     with open("/dev/termination-log", "w") as f:
                         f.write(json.dumps(metrics))
                     _termination_message_written = True
-                    print("[Kubeflow] Training complete. Final metrics saved.", flush=True)
+                    print("[Kubeflow] Complete. Final metrics saved.", flush=True)
                 except (OSError, ValueError, TypeError) as e:
                     print(
                         f"[Kubeflow] Warning: Failed to write termination message: {e}. "
@@ -527,18 +1083,37 @@ def _create_speculator_progression_instrumentation(
         def log_message(self, format, *args):
             pass
 
+    def _start_data_progress_server(hidden_states_dir, total_samples):
+        nonlocal _hidden_states_dir, _total_samples, _data_start_time
+        _hidden_states_dir = hidden_states_dir
+        _total_samples = total_samples
+        _data_start_time = time.time()
+        print(
+            f"[Kubeflow] Data progress tracking active "
+            f"({total_samples} samples in {hidden_states_dir})",
+            flush=True,
+        )
+
     def set_steps_per_epoch(steps):
         nonlocal _steps_per_epoch
         _steps_per_epoch = steps
 
-    def apply_progression_tracking():
-        nonlocal _start_time
-        _start_time = time.time()
+    def _mark_data_complete():
+        nonlocal _training_started, _train_start_time
+        _training_started = True
+        _train_start_time = time.time()
 
-        handler = MetricsHandler()
-        metrics_logger = logging.getLogger("speculators.metrics")
-        metrics_logger.setLevel(logging.INFO)
-        metrics_logger.addHandler(handler)
+    def _set_phase(phase: str, floor_pct: int = 0):
+        nonlocal _current_phase, _phase_floor_pct
+        _current_phase = phase
+        _phase_floor_pct = floor_pct
+
+    def apply_progression_tracking():
+        if mode == "train_only":
+            handler = MetricsHandler()
+            metrics_logger = logging.getLogger("speculators.metrics")
+            metrics_logger.setLevel(logging.INFO)
+            metrics_logger.addHandler(handler)
 
         try:
             server = http.server.HTTPServer(("0.0.0.0", metrics_port), SpeculatorMetricsHTTPHandler)
@@ -548,29 +1123,37 @@ def _create_speculator_progression_instrumentation(
         except OSError as e:
             print(
                 f"[Kubeflow] Warning: Failed to start metrics server on port "
-                f"{metrics_port}: {e}. Training will continue without metrics server.",
+                f"{metrics_port}: {e}. Will continue without metrics server.",
                 flush=True,
             )
         except Exception as e:
             print(
                 f"[Kubeflow] Warning: Unexpected error starting metrics server: {e}. "
-                f"Training will continue without metrics server.",
+                f"Will continue without metrics server.",
                 flush=True,
             )
 
         return set_steps_per_epoch
 
-    return (apply_progression_tracking, SpeculatorMetricsHTTPHandler)
+    return (
+        apply_progression_tracking,
+        _start_data_progress_server,
+        SpeculatorMetricsHTTPHandler,
+        _mark_data_complete,
+        _set_phase,
+    )
 
 
 def get_speculator_instrumentation_wrapper(
     metrics_port: int,
-    num_epochs: int,
+    mode: str,
+    num_epochs: int = 0,
 ) -> str:
     """Generate self-contained instrumentation wrapper via inspect.getsource.
 
     Args:
         metrics_port: Port for HTTP metrics server.
+        mode: Speculator mode string ("data_only", "train_only").
         num_epochs: Total training epochs.
 
     Returns:
@@ -588,24 +1171,32 @@ def get_speculator_instrumentation_wrapper(
 # Generated by kubeflow.trainer.rhai.speculator
 # =============================================================================
 
+import os as _instr_os
+_local_rank = int(_instr_os.environ.get("LOCAL_RANK", "0"))
+
 print("[Kubeflow] Initializing speculator progression tracking", flush=True)
 
 # Instrumentation function definition
 {instrumentation_code}
 
-# Initialize and apply instrumentation
-(
-    apply_progression_tracking,
-    _,
-) = _create_speculator_progression_instrumentation(
-    metrics_port={metrics_port},
-    num_epochs={num_epochs},
-)
-_set_steps_per_epoch = apply_progression_tracking()
-print("[Kubeflow] Speculator progression tracking enabled", flush=True)
+if _local_rank == 0:
+    # Initialize and apply instrumentation
+    (
+        _apply_progression_tracking,
+        _start_data_progress_server,
+        _,
+        _mark_data_complete,
+        _set_phase,
+    ) = _create_speculator_progression_instrumentation(
+        metrics_port={metrics_port},
+        mode={mode!r},
+        num_epochs={num_epochs},
+    )
+    _set_steps_per_epoch = _apply_progression_tracking()
+    print("[Kubeflow] Speculator progression tracking enabled", flush=True)
 
 # =============================================================================
-# USER TRAINING CODE
+# USER CODE
 # =============================================================================
 
 {{{{user_training_code}}}}"""
@@ -655,6 +1246,89 @@ def _get_command_from_runtime(
     return command
 
 
+def apply_speculator_sidecar_overrides(
+    trainer: SpeculativeDecodingTrainer,
+    pod_template_overrides: list,
+) -> list:
+    """Configure the vLLM sidecar init container via pod template overrides.
+
+    Sets environment variables, PVC volume mount, and GPU resources on the
+    ``vllm-sidecar`` init container defined in the ClusterTrainingRuntime.
+
+    Args:
+        trainer: SpeculativeDecodingTrainer with model path, GPU settings, and output_dir.
+        pod_template_overrides: Existing pod template overrides list (mutated in place).
+
+    Returns:
+        Updated pod_template_overrides list.
+    """
+    from kubeflow.trainer.rhai.constants import (
+        CHECKPOINT_MOUNT_PATH,
+        CHECKPOINT_VOLUME_NAME,
+        VLLM_SIDECAR_CONTAINER_NAME,
+    )
+    from kubeflow.trainer.rhai.utils import parse_output_dir_uri
+
+    resolved_output_dir, _ = parse_output_dir_uri(trainer.output_dir)
+    hs_path = f"{resolved_output_dir}/hidden_states"
+
+    node_override = None
+    for override in pod_template_overrides:
+        target_jobs = override.get("targetJobs", [])
+        if any(job.get("name") == constants.NODE for job in target_jobs):
+            node_override = override
+            break
+
+    if node_override is None:
+        node_override = {"targetJobs": [{"name": constants.NODE}], "spec": {}}
+        pod_template_overrides.append(node_override)
+
+    if "spec" not in node_override:
+        node_override["spec"] = {}
+    spec_dict = node_override["spec"]
+
+    if "initContainers" not in spec_dict:
+        spec_dict["initContainers"] = []
+
+    if trainer.verifier_model.startswith(PVC_URI_SCHEME):
+        resolved_verifier, _ = parse_output_dir_uri(trainer.verifier_model)
+    else:
+        resolved_verifier = trainer.verifier_model
+
+    cfg = trainer.config or SpeculatorConfig()
+
+    sidecar_env = [
+        {"name": "SPECULATOR_VERIFIER_MODEL", "value": resolved_verifier},
+        {"name": "SPECULATOR_HS_PATH", "value": hs_path},
+        {
+            "name": "SPECULATOR_GPU_MEM_UTIL",
+            "value": str(trainer.vllm_gpu_memory_utilization),
+        },
+        {"name": "SPECULATOR_VLLM_GPU_COUNT", "value": str(trainer.vllm_gpu_count)},
+    ]
+    if cfg.target_layer_ids is not None:
+        layer_ids_str = ",".join(str(lid) for lid in cfg.target_layer_ids)
+        sidecar_env.append({"name": "SPECULATOR_TARGET_LAYER_IDS", "value": layer_ids_str})
+
+    sidecar_override = {
+        "name": VLLM_SIDECAR_CONTAINER_NAME,
+        "env": sidecar_env,
+        "volumeMounts": [
+            {
+                "name": CHECKPOINT_VOLUME_NAME,
+                "mountPath": CHECKPOINT_MOUNT_PATH,
+                "readOnly": False,
+            }
+        ],
+        "resources": {
+            "limits": {"nvidia.com/gpu": str(trainer.vllm_gpu_count)},
+        },
+    }
+    spec_dict["initContainers"].append(sidecar_override)
+
+    return pod_template_overrides
+
+
 def get_trainer_cr_from_speculator_trainer(
     runtime: types.Runtime,
     trainer: SpeculativeDecodingTrainer,
@@ -670,16 +1344,19 @@ def get_trainer_cr_from_speculator_trainer(
     Returns:
         Trainer CRD spec.
     """
-    runtime.trainer.set_command(constants.TORCH_COMMAND)
+    if trainer.mode == SpeculatorMode.DATA_ONLY:
+        runtime.trainer.set_command(constants.DEFAULT_COMMAND)
+    else:
+        runtime.trainer.set_command(constants.TORCH_COMMAND)
 
     trainer_crd = models.TrainerV1alpha1Trainer()
 
     if trainer.num_nodes is not None:
         trainer_crd.num_nodes = trainer.num_nodes
 
-    if trainer.resources_per_node:
+    if trainer.mode == SpeculatorMode.TRAIN_ONLY:
         trainer_crd.resources_per_node = k8s_utils.get_resources_per_node(
-            trainer.resources_per_node
+            {"nvidia.com/gpu": trainer.training_gpu_count}
         )
 
     install_snippet = _build_install_snippet(trainer.packages_to_install, trainer.pip_index_urls)
@@ -690,6 +1367,7 @@ def get_trainer_cr_from_speculator_trainer(
     if trainer.enable_progression_tracking:
         wrapper_code = get_speculator_instrumentation_wrapper(
             metrics_port=trainer.metrics_port,
+            mode=trainer.mode.value,
             num_epochs=trainer.epochs,
         )
         func_code = wrapper_code.replace("{{user_training_code}}", func_code)

--- a/kubeflow/trainer/rhai/speculator_test.py
+++ b/kubeflow/trainer/rhai/speculator_test.py
@@ -796,17 +796,13 @@ def test_progression_instrumentation_returns_callable():
     """Test that _create_speculator_progression_instrumentation returns valid tuple."""
     print("Executing test: Progression instrumentation returns callable")
 
-    import tempfile
+    apply_fn, handler_class = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        num_epochs=3,
+    )
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        apply_fn, handler_class, _ = _create_speculator_progression_instrumentation(
-            metrics_port=28080,
-            num_epochs=3,
-            save_path=tmpdir,
-        )
-
-        assert callable(apply_fn)
-        assert handler_class is not None
+    assert callable(apply_fn)
+    assert handler_class is not None
 
     print("test execution complete")
 
@@ -815,25 +811,19 @@ def test_progression_instrumentation_schema_transform():
     """Test that the HTTP handler transforms speculators metrics to controller schema."""
     print("Executing test: Progression instrumentation schema transform")
 
-    import tempfile
+    _, handler_class = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        num_epochs=3,
+    )
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        _, handler_class, _ = _create_speculator_progression_instrumentation(
-            metrics_port=28080,
-            num_epochs=3,
-            save_path=tmpdir,
-        )
+    handler = handler_class.__new__(handler_class)
+    result = handler._transform({"train": {"loss": 2.5}, "epoch": 0, "lr": 1e-4, "global_step": 5})
 
-        handler = handler_class.__new__(handler_class)
-        result = handler._transform(
-            {"train": {"loss": 2.5}, "epoch": 0, "lr": 1e-4, "global_step": 5}
-        )
-
-        assert result["currentEpoch"] == 1
-        assert result["totalEpochs"] == 3
-        assert result["currentStep"] == 5
-        assert result["trainMetrics"]["loss"] == "2.5000"
-        assert result["trainMetrics"]["learning_rate"] == "0.000100"
+    assert result["currentEpoch"] == 1
+    assert result["totalEpochs"] == 3
+    assert result["currentStep"] == 5
+    assert result["trainMetrics"]["loss"] == "2.5000"
+    assert result["trainMetrics"]["learning_rate"] == "0.000100"
 
     print("test execution complete")
 

--- a/kubeflow/trainer/rhai/speculator_test.py
+++ b/kubeflow/trainer/rhai/speculator_test.py
@@ -19,10 +19,12 @@ import pytest
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.rhai.speculator import (
     SpeculativeDecodingTrainer,
+    SpeculatorConfig,
     SpeculatorMode,
     SpeculatorType,
     _create_speculator_progression_instrumentation,
     _render_speculator_training_script,
+    apply_speculator_sidecar_overrides,
     get_trainer_cr_from_speculator_trainer,
 )
 from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
@@ -34,22 +36,24 @@ def test_speculator_trainer_initialization():
     print("Executing test: SpeculativeDecodingTrainer initialization with defaults")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
     )
 
-    assert trainer.verifier_name_or_path == "Qwen/Qwen3-8B"
+    assert trainer.verifier_model == "Qwen/Qwen3-8B"
     assert trainer.speculator_type == SpeculatorType.EAGLE3
     assert trainer.mode == SpeculatorMode.TRAIN_ONLY
     assert trainer.hidden_states_path == "/data/hidden_states"
-    assert trainer.draft_vocab_size is None
     assert trainer.epochs == 3
     assert trainer.lr == 1e-4
     assert trainer.total_seq_len == 8192
-    assert trainer.hidden_states_dtype == "bfloat16"
+    assert trainer.training_gpu_count == 1
+    assert trainer.vllm_gpu_count == 1
+    assert trainer.vllm_gpu_memory_utilization == 0.9
+    assert trainer.config is None
     assert trainer.num_nodes is None
-    assert trainer.resources_per_node is None
     assert trainer.packages_to_install is None
     assert trainer.pip_index_urls == list(constants.DEFAULT_PIP_INDEX_URLS)
     assert trainer.env is None
@@ -66,40 +70,45 @@ def test_speculator_trainer_with_custom_config():
     print("Executing test: SpeculativeDecodingTrainer with custom configuration")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="meta-llama/Llama-3.1-70B",
-        speculator_type=SpeculatorType.EAGLE3,
+        verifier_model="meta-llama/Llama-3.1-70B",
         mode=SpeculatorMode.TRAIN_ONLY,
+        speculator_type=SpeculatorType.EAGLE3,
         hidden_states_path="/mnt/pvc/hidden_states",
         output_dir="pvc://shared/checkpoints/eagle3",
-        draft_vocab_size=32000,
         epochs=5,
         lr=5e-5,
         total_seq_len=4096,
+        training_gpu_count=2,
         num_nodes=2,
-        resources_per_node={"nvidia.com/gpu": 4},
         packages_to_install=["speculators"],
         pip_index_urls=["https://custom.pypi.org/simple"],
         env={"WANDB_DISABLED": "true"},
         enable_progression_tracking=True,
         metrics_port=28090,
         metrics_poll_interval_seconds=60,
+        config=SpeculatorConfig(
+            num_layers=1,
+            ttt_steps=5,
+            hidden_states_dtype="float16",
+        ),
     )
 
-    assert trainer.verifier_name_or_path == "meta-llama/Llama-3.1-70B"
+    assert trainer.verifier_model == "meta-llama/Llama-3.1-70B"
     assert trainer.speculator_type == SpeculatorType.EAGLE3
     assert trainer.hidden_states_path == "/mnt/pvc/hidden_states"
     assert trainer.output_dir == "pvc://shared/checkpoints/eagle3"
-    assert trainer.draft_vocab_size == 32000
     assert trainer.epochs == 5
     assert trainer.lr == 5e-5
     assert trainer.total_seq_len == 4096
+    assert trainer.training_gpu_count == 2
     assert trainer.num_nodes == 2
-    assert trainer.resources_per_node == {"nvidia.com/gpu": 4}
     assert trainer.packages_to_install == ["speculators"]
     assert trainer.pip_index_urls == ["https://custom.pypi.org/simple"]
     assert trainer.env == {"WANDB_DISABLED": "true"}
     assert trainer.metrics_port == 28090
     assert trainer.metrics_poll_interval_seconds == 60
+    assert trainer.config.ttt_steps == 5
+    assert trainer.config.hidden_states_dtype == "float16"
 
     print("test execution complete")
 
@@ -110,53 +119,24 @@ def test_speculator_mode_train_only_requires_hidden_states():
 
     with pytest.raises(ValueError, match="hidden_states_path is required for TRAIN_ONLY mode"):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
             mode=SpeculatorMode.TRAIN_ONLY,
         )
 
     print("test execution complete")
 
 
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="DATA_ONLY mode not yet supported",
-            expected_status=FAILED,
-            config={"mode": SpeculatorMode.DATA_ONLY},
-            expected_error=NotImplementedError,
-        ),
-        TestCase(
-            name="OFFLINE mode not yet supported",
-            expected_status=FAILED,
-            config={"mode": SpeculatorMode.OFFLINE},
-            expected_error=NotImplementedError,
-        ),
-        TestCase(
-            name="ONLINE mode not yet supported",
-            expected_status=FAILED,
-            config={"mode": SpeculatorMode.ONLINE},
-            expected_error=NotImplementedError,
-        ),
-    ],
-)
-def test_unsupported_mode_validation(test_case):
+def test_unsupported_mode_validation():
     """Test that unsupported modes raise NotImplementedError."""
-    print(f"Executing test: {test_case.name}")
+    print("Executing test: ONLINE mode not yet supported")
 
-    try:
+    with pytest.raises(NotImplementedError):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.ONLINE,
             hidden_states_path="/data/hidden_states",
             output_dir="pvc://test-pvc/output",
-            **test_case.config,
         )
-
-        assert test_case.expected_status == SUCCESS
-
-    except Exception as e:
-        assert test_case.expected_status == FAILED
-        assert type(e) is test_case.expected_error
 
     print("test execution complete")
 
@@ -196,7 +176,8 @@ def test_metrics_port_validation(test_case):
 
     try:
         trainer = SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="pvc://test-pvc/output",
             metrics_port=test_case.config["metrics_port"],
@@ -247,7 +228,8 @@ def test_metrics_poll_interval_validation(test_case):
 
     try:
         trainer = SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="pvc://test-pvc/output",
             metrics_poll_interval_seconds=test_case.config["metrics_poll_interval_seconds"],
@@ -269,14 +251,16 @@ def test_non_pvc_output_dir_not_supported():
 
     with pytest.raises(NotImplementedError, match="is not yet supported"):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="s3://my-bucket/checkpoints",
         )
 
     with pytest.raises(ValueError, match="Unsupported storage URI scheme"):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="gcs://my-bucket/checkpoints",
         )
@@ -289,7 +273,8 @@ def test_pvc_output_dir_normalized():
     print("Executing test: PVC output_dir normalization")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://my-pvc/checkpoints/",
     )
@@ -304,39 +289,84 @@ def test_training_script_content():
     print("Executing test: Training script content")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
-        draft_vocab_size=32000,
         epochs=5,
         lr=1e-5,
     )
 
     script = _render_speculator_training_script(trainer)
 
-    assert "from speculators.models.eagle3.core import Eagle3DraftModel" in script
-    assert "from speculators.train.trainer import Trainer, TrainerConfig" in script
-    assert "from speculators.train.noise_transforms import AddUniformNoise" in script
-    assert "ArrowDataset" in script
-    assert "SampleFileDataset" not in script
-    assert "split_files" not in script
-    assert "Eagle3DraftModel.from_training_args" in script
-    assert "Qwen/Qwen3-8B" in script
-    assert "/data/hidden_states" in script
-    assert "draft_vocab_size=32000" in script
-    assert "norm_before_residual=True" in script
-    assert "ttt_steps=3" in script
-    assert "max_len = total_seq_len" in script
+    assert "_speculator_train_only" in script
+    assert "verifier_model='Qwen/Qwen3-8B'" in script
+    assert "hidden_states_path='/data/hidden_states'" in script
+    assert "save_path='/mnt/kubeflow-checkpoints/output'" in script
+    assert "epochs=5" in script
+    assert "lr=1e-05" in script
     assert "total_seq_len=8192" in script
-    assert "create_collate_fn(max_len, verifier_config.hidden_size)" in script
-    assert "AddUniformNoise()" in script
-    assert 'on_missing="skip"' in script
-    assert "split_ratio=0.9" in script
-    assert "split_ratio=-0.1" in script
     assert "hidden_states_dtype='bfloat16'" in script
-    assert "getattr(torch, hidden_states_dtype)" in script
-    assert "MultipackDistributedBatchSamplerV2" in script
-    assert "trainer.run_training()" in script
+
+    print("test execution complete")
+
+
+def test_training_script_trainer_config_fields():
+    """Test that generated script passes all TrainerConfig fields from SpeculatorConfig."""
+    print("Executing test: Training script TrainerConfig fields")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        config=SpeculatorConfig(
+            scheduler_type="cosine",
+            scheduler_warmup_steps=100,
+            scheduler_total_steps=5000,
+            scheduler_num_cosine_cycles=1.0,
+            checkpoint_freq=0.5,
+            save_best=True,
+            log_freq=10,
+            resume_from_checkpoint=True,
+        ),
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "scheduler_type='cosine'" in script
+    assert "scheduler_warmup_steps=100" in script
+    assert "scheduler_total_steps=5000" in script
+    assert "scheduler_num_cosine_cycles=1.0" in script
+    assert "checkpoint_freq=0.5" in script
+    assert "save_best=True" in script
+    assert "log_freq=10" in script
+    assert "resume_from_checkpoint=True" in script
+
+    print("test execution complete")
+
+
+def test_training_script_trainer_config_defaults():
+    """Test that default SpeculatorConfig passes correct defaults for TrainerConfig fields."""
+    print("Executing test: Training script TrainerConfig defaults")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "scheduler_type='linear'" in script
+    assert "scheduler_warmup_steps=None" in script
+    assert "scheduler_total_steps=None" in script
+    assert "scheduler_num_cosine_cycles=0.5" in script
+    assert "checkpoint_freq=1.0" in script
+    assert "save_best=False" in script
+    assert "log_freq=1" in script
+    assert "resume_from_checkpoint=False" in script
 
     print("test execution complete")
 
@@ -346,7 +376,8 @@ def test_training_script_with_pvc_output_dir():
     print("Executing test: Training script with PVC output_dir")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://shared/speculator_output",
     )
@@ -354,7 +385,6 @@ def test_training_script_with_pvc_output_dir():
     script = _render_speculator_training_script(trainer)
 
     assert "/mnt/kubeflow-checkpoints/speculator_output" in script
-    assert "/tmp/checkpoints" not in script
 
     print("test execution complete")
 
@@ -365,7 +395,8 @@ def test_train_only_requires_output_dir():
 
     with pytest.raises(ValueError, match="output_dir is required for TRAIN_ONLY mode"):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
         )
 
@@ -377,7 +408,8 @@ def test_training_script_custom_total_seq_len():
     print("Executing test: Training script custom total_seq_len")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
         total_seq_len=2048,
@@ -396,10 +428,11 @@ def test_training_script_custom_hidden_states_dtype():
     print("Executing test: Training script custom hidden_states_dtype")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
-        hidden_states_dtype="float16",
+        config=SpeculatorConfig(hidden_states_dtype="float16"),
     )
 
     script = _render_speculator_training_script(trainer)
@@ -414,36 +447,34 @@ def test_hidden_states_dtype_validation():
     """Test that invalid hidden_states_dtype raises ValueError."""
     print("Executing test: hidden_states_dtype validation")
 
-    with pytest.raises(ValueError, match="hidden_states_dtype must be one of"):
+    with pytest.raises(ValueError, match="config.hidden_states_dtype must be one of"):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="pvc://test-pvc/output",
-            hidden_states_dtype="float64",
+            config=SpeculatorConfig(hidden_states_dtype="float64"),
         )
 
     print("test execution complete")
 
 
 def test_training_script_distributed_batch_sampler():
-    """Test that generated script uses MultipackDistributedBatchSamplerV2 for data sharding."""
+    """Test that in-process training function is used for distributed training."""
     print("Executing test: Training script distributed batch sampler")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
     )
 
     script = _render_speculator_training_script(trainer)
 
+    assert "_speculator_train_only" in script
     assert "MultipackDistributedBatchSamplerV2" in script
-    assert "batch_max_length=max_len" in script
-    assert "approx_lengths" in script
-    assert "num_replicas=world_size" in script
-    assert "rank=rank" in script
-    assert "batch_sampler=train_batch_sampler" in script
-    assert "batch_sampler=val_batch_sampler" in script
+    assert "init_process_group" in script
 
     print("test execution complete")
 
@@ -469,12 +500,6 @@ def test_training_script_distributed_batch_sampler():
             config={"total_seq_len": 0},
             expected_error=ValueError,
         ),
-        TestCase(
-            name="draft_vocab_size must be positive integer",
-            expected_status=FAILED,
-            config={"draft_vocab_size": -1},
-            expected_error=ValueError,
-        ),
     ],
 )
 def test_numeric_field_validation(test_case):
@@ -483,7 +508,8 @@ def test_numeric_field_validation(test_case):
 
     try:
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="pvc://test-pvc/output",
             **test_case.config,
@@ -494,23 +520,6 @@ def test_numeric_field_validation(test_case):
     except Exception as e:
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
-
-    print("test execution complete")
-
-
-def test_training_script_uses_verifier_vocab_when_draft_unset():
-    """Test that generated script uses verifier_config.vocab_size when draft_vocab_size is None."""
-    print("Executing test: Training script uses verifier vocab size when unset")
-
-    trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
-        hidden_states_path="/data/hidden_states",
-        output_dir="pvc://test-pvc/output",
-    )
-
-    script = _render_speculator_training_script(trainer)
-
-    assert "draft_vocab_size = verifier_config.vocab_size" in script
 
     print("test execution complete")
 
@@ -529,7 +538,8 @@ def test_crd_conversion_train_only():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
         num_nodes=2,
@@ -561,7 +571,8 @@ def test_crd_conversion_with_env_vars():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
         env={"WANDB_DISABLED": "true", "NCCL_DEBUG": "INFO"},
@@ -594,7 +605,8 @@ def test_crd_conversion_no_env_vars():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
     )
@@ -606,9 +618,9 @@ def test_crd_conversion_no_env_vars():
     print("test execution complete")
 
 
-def test_crd_conversion_with_resources():
-    """Test CRD conversion with resources_per_node."""
-    print("Executing test: CRD conversion with resources_per_node")
+def test_crd_conversion_with_training_gpu_count():
+    """Test CRD conversion with training_gpu_count."""
+    print("Executing test: CRD conversion with training_gpu_count")
 
     runtime = types.Runtime(
         name="test-runtime",
@@ -620,10 +632,11 @@ def test_crd_conversion_with_resources():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
-        resources_per_node={"nvidia.com/gpu": 2, "cpu": 8, "memory": "32Gi"},
+        training_gpu_count=2,
     )
 
     trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
@@ -633,9 +646,9 @@ def test_crd_conversion_with_resources():
     print("test execution complete")
 
 
-def test_crd_uses_torchrun_entrypoint():
-    """Test that CRD conversion sets torchrun as the entrypoint."""
-    print("Executing test: CRD uses torchrun entrypoint")
+def test_crd_uses_torchrun_entrypoint_for_train_only():
+    """Test that CRD conversion sets torchrun as the entrypoint for TRAIN_ONLY."""
+    print("Executing test: CRD uses torchrun entrypoint for TRAIN_ONLY")
 
     runtime = types.Runtime(
         name="test-runtime",
@@ -647,7 +660,8 @@ def test_crd_uses_torchrun_entrypoint():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
     )
@@ -655,6 +669,33 @@ def test_crd_uses_torchrun_entrypoint():
     get_trainer_cr_from_speculator_trainer(runtime, trainer)
 
     assert runtime.trainer.command == constants.TORCH_COMMAND
+
+    print("test execution complete")
+
+
+def test_crd_uses_python_entrypoint_for_data_only():
+    """Test that CRD conversion sets plain python as the entrypoint for DATA_ONLY."""
+    print("Executing test: CRD uses python entrypoint for DATA_ONLY")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/cuda-ubi9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    assert runtime.trainer.command == constants.DEFAULT_COMMAND
 
     print("test execution complete")
 
@@ -696,7 +737,8 @@ def test_speculator_trainer_configurations(test_case):
 
     try:
         trainer = SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="/data/hidden_states",
             output_dir="pvc://test-pvc/output",
             **test_case.config,
@@ -746,7 +788,8 @@ def test_progression_tracking_injected_when_enabled():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
         enable_progression_tracking=True,
@@ -777,7 +820,8 @@ def test_progression_tracking_not_injected_when_disabled():
     )
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden_states",
         output_dir="pvc://test-pvc/output",
         enable_progression_tracking=False,
@@ -796,12 +840,14 @@ def test_progression_instrumentation_returns_callable():
     """Test that _create_speculator_progression_instrumentation returns valid tuple."""
     print("Executing test: Progression instrumentation returns callable")
 
-    apply_fn, handler_class = _create_speculator_progression_instrumentation(
+    apply_fn, start_data_fn, handler_class, _, _ = _create_speculator_progression_instrumentation(
         metrics_port=28080,
+        mode="train_only",
         num_epochs=3,
     )
 
     assert callable(apply_fn)
+    assert callable(start_data_fn)
     assert handler_class is not None
 
     print("test execution complete")
@@ -811,19 +857,16 @@ def test_progression_instrumentation_schema_transform():
     """Test that the HTTP handler transforms speculators metrics to controller schema."""
     print("Executing test: Progression instrumentation schema transform")
 
-    _, handler_class = _create_speculator_progression_instrumentation(
+    _, _, handler_class, _, _ = _create_speculator_progression_instrumentation(
         metrics_port=28080,
+        mode="train_only",
         num_epochs=3,
     )
 
     handler = handler_class.__new__(handler_class)
-    result = handler._transform({"train": {"loss": 2.5}, "epoch": 0, "lr": 1e-4, "global_step": 5})
+    result = handler._training_progress()
 
-    assert result["currentEpoch"] == 1
-    assert result["totalEpochs"] == 3
-    assert result["currentStep"] == 5
-    assert result["trainMetrics"]["loss"] == "2.5000"
-    assert result["trainMetrics"]["learning_rate"] == "0.000100"
+    assert result["trainMetrics"] is None
 
     print("test execution complete")
 
@@ -833,7 +876,8 @@ def test_hidden_states_path_normalization():
     print("Executing test: hidden_states_path normalization")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="pvc://shared//hidden_states/",
         output_dir="pvc://shared/output",
     )
@@ -849,7 +893,8 @@ def test_hidden_states_path_unsupported_scheme():
 
     with pytest.raises(NotImplementedError, match="hidden_states_path scheme"):
         SpeculativeDecodingTrainer(
-            verifier_name_or_path="Qwen/Qwen3-8B",
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
             hidden_states_path="s3://bucket/hidden_states",
             output_dir="pvc://shared/output",
         )
@@ -862,11 +907,676 @@ def test_hidden_states_path_direct_path_allowed():
     print("Executing test: hidden_states_path direct path allowed")
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="Qwen/Qwen3-8B",
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/mnt/data/hidden_states",
         output_dir="pvc://shared/output",
     )
 
     assert trainer.hidden_states_path == "/mnt/data/hidden_states"
+
+    print("test execution complete")
+
+
+def test_data_only_requires_dataset_name():
+    """Test that DATA_ONLY mode requires dataset_name."""
+    print("Executing test: DATA_ONLY mode requires dataset_name")
+
+    with pytest.raises(ValueError, match="dataset_name is required for DATA_ONLY mode"):
+        SpeculativeDecodingTrainer(
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.DATA_ONLY,
+            output_dir="pvc://test-pvc/output",
+        )
+
+    print("test execution complete")
+
+
+def test_data_only_requires_output_dir():
+    """Test that DATA_ONLY mode requires output_dir."""
+    print("Executing test: DATA_ONLY mode requires output_dir")
+
+    with pytest.raises(ValueError, match="output_dir is required for DATA_ONLY mode"):
+        SpeculativeDecodingTrainer(
+            verifier_model="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.DATA_ONLY,
+            dataset_name="sharegpt",
+        )
+
+    print("test execution complete")
+
+
+def test_data_only_valid():
+    """Test that DATA_ONLY mode with required fields succeeds."""
+    print("Executing test: DATA_ONLY mode valid configuration")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    assert trainer.mode == SpeculatorMode.DATA_ONLY
+    assert trainer.dataset_name == "sharegpt"
+    assert trainer.output_dir == "pvc://test-pvc/output"
+    assert trainer.hidden_states_path is None
+
+    print("test execution complete")
+
+
+def test_data_only_renders_correct_script():
+    """Test that DATA_ONLY generates script with _speculator_data_only call."""
+    print("Executing test: DATA_ONLY renders correct script")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "_speculator_data_only(" in script
+    assert "_speculator_train_only(" not in script
+    assert "verifier_model='meta-llama/Llama-3.1-8B-Instruct'" in script
+    assert "dataset_name='sharegpt'" in script
+    assert "/mnt/kubeflow-checkpoints/datagen_output" in script
+    assert "EXTRACTION_INCOMPLETE_MARKER" in script
+
+    print("test execution complete")
+
+
+def test_data_only_script_passes_world_size_and_rank():
+    """Test that datagen command passes --world-size and --rank from env vars."""
+    print("Executing test: DATA_ONLY script passes world-size and rank")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert '"--world-size"' in script
+    assert '"--rank"' in script
+
+    print("test execution complete")
+
+
+def test_data_only_script_embeds_datagen_script():
+    """Test that DATA_ONLY generated script embeds data_generation_offline.py as base64."""
+    print("Executing test: DATA_ONLY script embeds datagen script")
+
+    import base64
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "_DATAGEN_SCRIPT_B64" in script
+    assert "base64.b64decode(_DATAGEN_SCRIPT_B64)" in script
+    assert "/tmp/data_generation_offline.py" in script
+
+    b64_line = [line for line in script.split("\n") if line.startswith("_DATAGEN_SCRIPT_B64")][0]
+    b64_value = b64_line.split('"')[1]
+    decoded = base64.b64decode(b64_value).decode("utf-8")
+    assert "generate_hidden_states_async" in decoded
+    assert "def main():" in decoded
+
+    print("test execution complete")
+
+
+def test_data_progression_returns_callable():
+    """Test that unified instrumentation in data_only mode returns valid tuple."""
+    print("Executing test: Data progression instrumentation returns callable")
+
+    apply_fn, start_fn, handler_class, _, _ = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        mode="data_only",
+    )
+
+    assert callable(apply_fn)
+    assert callable(start_fn)
+    assert handler_class is not None
+
+    print("test execution complete")
+
+
+def test_data_progression_handler_counts_files(tmp_path):
+    """Test that handler counts hs_*.safetensors files in data_only mode."""
+    print("Executing test: Data progression handler counts files")
+
+    _, start_fn, handler_class, _, _ = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        mode="data_only",
+    )
+
+    hs_dir = tmp_path / "hidden_states"
+    hs_dir.mkdir()
+    (hs_dir / "hs_0.safetensors").write_text("")
+    (hs_dir / "hs_1.safetensors").write_text("")
+    (hs_dir / "hs_2.safetensors").write_text("")
+    (hs_dir / "other_file.txt").write_text("")
+
+    start_fn(str(hs_dir), 10)
+
+    handler = handler_class.__new__(handler_class)
+    result = handler._data_progress()
+
+    assert result["currentStep"] == 3
+    assert result["totalSteps"] == 10
+    assert result["progressPercentage"] == 30
+    assert result["currentEpoch"] is None
+    assert result["totalEpochs"] is None
+    assert result["trainMetrics"] is None
+
+    print("test execution complete")
+
+
+def test_data_progression_handler_empty_dir(tmp_path):
+    """Test that handler returns 0% when no hidden states files exist."""
+    print("Executing test: Data progression handler empty directory")
+
+    _, start_fn, handler_class, _, _ = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        mode="data_only",
+    )
+
+    hs_dir = tmp_path / "hidden_states"
+    hs_dir.mkdir()
+
+    start_fn(str(hs_dir), 50)
+
+    handler = handler_class.__new__(handler_class)
+    result = handler._data_progress()
+
+    assert result["currentStep"] == 0
+    assert result["totalSteps"] == 50
+    assert result["progressPercentage"] == 0
+    assert result["estimatedRemainingSeconds"] is None
+
+    print("test execution complete")
+
+
+def test_data_progression_handler_complete(tmp_path):
+    """Test that handler returns 100% when all files are generated."""
+    print("Executing test: Data progression handler complete")
+
+    _, start_fn, handler_class, _, _ = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        mode="data_only",
+    )
+
+    hs_dir = tmp_path / "hidden_states"
+    hs_dir.mkdir()
+    for i in range(5):
+        (hs_dir / f"hs_{i}.safetensors").write_text("")
+
+    start_fn(str(hs_dir), 5)
+
+    handler = handler_class.__new__(handler_class)
+    result = handler._data_progress()
+
+    assert result["currentStep"] == 5
+    assert result["totalSteps"] == 5
+    assert result["progressPercentage"] == 100
+
+    print("test execution complete")
+
+
+def test_data_progression_handler_not_started():
+    """Test that handler returns nulls when data tracking not yet started."""
+    print("Executing test: Data progression handler not started")
+
+    _, _, handler_class, _, _ = _create_speculator_progression_instrumentation(
+        metrics_port=28080,
+        mode="data_only",
+    )
+
+    handler = handler_class.__new__(handler_class)
+    result = handler._data_progress()
+
+    assert result["progressPercentage"] is None
+    assert result["currentStep"] is None
+    assert result["totalSteps"] is None
+
+    print("test execution complete")
+
+
+def test_data_only_script_contains_progress_server_call():
+    """Test that DATA_ONLY rendered script contains _start_data_progress_server call."""
+    print("Executing test: DATA_ONLY script contains progress server call")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+    assert "_start_data_progress_server" in script
+
+    print("test execution complete")
+
+
+def test_data_only_progression_tracking_injected():
+    """Test that DATA_ONLY mode injects unified progression instrumentation."""
+    print("Executing test: DATA_ONLY progression tracking injected")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+        enable_progression_tracking=True,
+    )
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="test-image:latest",
+        ),
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+    bash_script = trainer_crd.command[2]
+
+    assert "Speculator Progression Tracking" in bash_script
+    assert "_create_speculator_progression_instrumentation" in bash_script
+    assert "mode='data_only'" in bash_script
+
+    print("test execution complete")
+
+
+def test_data_only_script_contains_marker_logic():
+    """Test that DATA_ONLY script contains per-rank incomplete marker check and cleanup."""
+    print("Executing test: DATA_ONLY script contains marker logic")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "EXTRACTION_INCOMPLETE_MARKER" in script
+    assert "Previous data extraction" in script
+    assert "os.remove(incomplete_marker)" in script
+
+    print("test execution complete")
+
+
+def test_train_only_script_contains_training_function():
+    """Test that TRAIN_ONLY script includes training function."""
+    print("Executing test: TRAIN_ONLY script contains training function")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "EXTRACTION_INCOMPLETE_MARKER" in script
+    assert "_speculator_train_only" in script
+
+    print("test execution complete")
+
+
+def test_data_only_script_contains_vllm_health_check():
+    """Test that DATA_ONLY script contains vLLM health check for external endpoint."""
+    print("Executing test: DATA_ONLY script contains vLLM health check")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "/health" in script
+    assert "vLLM sidecar is ready" in script
+    assert "vLLM endpoint not reachable" in script
+
+    print("test execution complete")
+
+
+def test_data_only_script_skips_completed_extraction():
+    """Test that DATA_ONLY script skips extraction when hidden states already exist."""
+    print("Executing test: DATA_ONLY script skips completed extraction")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert ".safetensors" in script
+    assert "Data extraction already completed. Skipping." in script
+
+    print("test execution complete")
+
+
+def test_apply_speculator_sidecar_overrides():
+    """Test sidecar overrides add correct init container config."""
+    print("Executing test: apply_speculator_sidecar_overrides")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="/mnt/kubeflow-checkpoints/models/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/speculator/run1",
+        vllm_gpu_count=2,
+        vllm_gpu_memory_utilization=0.85,
+        config=SpeculatorConfig(target_layer_ids=[2, 18, 33]),
+    )
+
+    result = apply_speculator_sidecar_overrides(trainer, [])
+
+    assert len(result) == 1
+    override = result[0]
+    assert override["targetJobs"] == [{"name": "node"}]
+
+    init_containers = override["spec"]["initContainers"]
+    assert len(init_containers) == 1
+
+    sidecar = init_containers[0]
+    assert sidecar["name"] == "vllm-sidecar"
+
+    env_dict = {e["name"]: e["value"] for e in sidecar["env"]}
+    assert env_dict["SPECULATOR_VERIFIER_MODEL"] == "/mnt/kubeflow-checkpoints/models/Qwen3-8B"
+    assert (
+        env_dict["SPECULATOR_HS_PATH"] == "/mnt/kubeflow-checkpoints/speculator/run1/hidden_states"
+    )
+    assert env_dict["SPECULATOR_GPU_MEM_UTIL"] == "0.85"
+    assert env_dict["SPECULATOR_VLLM_GPU_COUNT"] == "2"
+    assert env_dict["SPECULATOR_TARGET_LAYER_IDS"] == "2,18,33"
+
+    assert sidecar["volumeMounts"][0]["name"] == "checkpoint-storage"
+    assert sidecar["volumeMounts"][0]["mountPath"] == "/mnt/kubeflow-checkpoints"
+
+    assert sidecar["resources"]["limits"]["nvidia.com/gpu"] == "2"
+
+    print("test execution complete")
+
+
+def test_apply_speculator_sidecar_overrides_preserves_existing():
+    """Test sidecar overrides preserve existing pod template overrides."""
+    print("Executing test: sidecar overrides preserve existing overrides")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/output",
+        config=SpeculatorConfig(target_layer_ids=[2, 18, 33]),
+    )
+
+    existing = [
+        {
+            "targetJobs": [{"name": "node"}],
+            "spec": {
+                "volumes": [
+                    {"name": "checkpoint-storage", "persistentVolumeClaim": {"claimName": "shared"}}
+                ],
+                "containers": [
+                    {
+                        "name": "node",
+                        "volumeMounts": [
+                            {"name": "checkpoint-storage", "mountPath": "/mnt/kubeflow-checkpoints"}
+                        ],
+                    }
+                ],
+            },
+        }
+    ]
+
+    result = apply_speculator_sidecar_overrides(trainer, existing)
+
+    assert len(result) == 1
+    spec = result[0]["spec"]
+    assert len(spec["volumes"]) == 1
+    assert len(spec["containers"]) == 1
+    assert len(spec["initContainers"]) == 1
+    assert spec["initContainers"][0]["name"] == "vllm-sidecar"
+
+    print("test execution complete")
+
+
+def test_data_only_script_uses_sidecar_endpoint():
+    """Test DATA_ONLY script renders sidecar endpoint."""
+    print("Executing test: DATA_ONLY script uses sidecar endpoint")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "http://localhost:8234/v1" in script
+    assert "gpu_memory_utilization" not in script
+    assert "vllm_gpu_count" not in script
+
+    print("test execution complete")
+
+
+def test_data_only_script_resolves_pvc_verifier_model():
+    """Test that pvc:// verifier_model is resolved to local path in rendered script."""
+    print("Executing test: DATA_ONLY script resolves pvc:// verifier_model")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="pvc://shared/models/meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert (
+        "verifier_model='/mnt/kubeflow-checkpoints/models/meta-llama/Llama-3.1-8B-Instruct'"
+        in script
+    )
+    assert "pvc://" not in script
+
+    print("test execution complete")
+
+
+def test_verifier_model_hf_id_unchanged_in_script():
+    """Test that HuggingFace model ID passes through unchanged in rendered script."""
+    print("Executing test: HF verifier_model unchanged in script")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "verifier_model='meta-llama/Llama-3.1-8B-Instruct'" in script
+
+    print("test execution complete")
+
+
+def test_verifier_model_local_path_unchanged_in_script():
+    """Test that local path verifier_model passes through unchanged in rendered script."""
+    print("Executing test: local path verifier_model unchanged in script")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="/mnt/models/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "verifier_model='/mnt/models/Llama-3.1-8B-Instruct'" in script
+
+    print("test execution complete")
+
+
+def test_sidecar_overrides_resolves_pvc_verifier_model():
+    """Test that pvc:// verifier_model is resolved in sidecar env var."""
+    print("Executing test: sidecar resolves pvc:// verifier_model")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="pvc://shared/models/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+        config=SpeculatorConfig(target_layer_ids=[2, 18, 33]),
+    )
+
+    result = apply_speculator_sidecar_overrides(trainer, [])
+
+    sidecar = result[0]["spec"]["initContainers"][0]
+    env_dict = {e["name"]: e["value"] for e in sidecar["env"]}
+    assert env_dict["SPECULATOR_VERIFIER_MODEL"] == "/mnt/kubeflow-checkpoints/models/Qwen3-8B"
+
+    print("test execution complete")
+
+
+def test_sidecar_overrides_passes_target_layer_ids():
+    """Test that target_layer_ids is passed as SPECULATOR_TARGET_LAYER_IDS env var."""
+    print("Executing test: sidecar passes target_layer_ids")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="/mnt/models/Qwen3-8B",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
+        output_dir="pvc://shared/datagen_output",
+        config=SpeculatorConfig(target_layer_ids=[2, 18, 33]),
+    )
+
+    result = apply_speculator_sidecar_overrides(trainer, [])
+
+    sidecar = result[0]["spec"]["initContainers"][0]
+    env_dict = {e["name"]: e["value"] for e in sidecar["env"]}
+    assert env_dict["SPECULATOR_TARGET_LAYER_IDS"] == "2,18,33"
+
+    print("test execution complete")
+
+
+def test_train_only_script_passes_data_path():
+    """Test that TRAIN_ONLY script passes user-provided data_path."""
+    print("Executing test: TRAIN_ONLY script passes data_path")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        data_path="/data/arrow_dataset",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "data_path='/data/arrow_dataset'" in script
+
+    print("test execution complete")
+
+
+def test_train_only_script_resolves_pvc_data_path():
+    """Test that TRAIN_ONLY script resolves pvc:// data_path to local mount."""
+    print("Executing test: TRAIN_ONLY resolves pvc:// data_path")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        data_path="pvc://shared/arrow_dataset",
+        output_dir="pvc://shared/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "data_path='/mnt/kubeflow-checkpoints/arrow_dataset'" in script
+
+    print("test execution complete")
+
+
+def test_train_only_script_passes_draft_vocab_size():
+    """Test that TRAIN_ONLY script passes draft_vocab_size."""
+    print("Executing test: TRAIN_ONLY passes draft_vocab_size")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        data_path="/data/arrow_dataset",
+        output_dir="pvc://test-pvc/output",
+        draft_vocab_size=8192,
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "draft_vocab_size=8192" in script
+
+    print("test execution complete")
+
+
+def test_train_only_script_draft_vocab_size_none_by_default():
+    """Test that draft_vocab_size defaults to None in rendered script."""
+    print("Executing test: draft_vocab_size defaults to None")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "draft_vocab_size=None" in script
+
+    print("test execution complete")
+
+
+def test_train_only_script_contains_vocab_mapping_logic():
+    """Test that TRAIN_ONLY script contains vocab mapping imports and logic."""
+    print("Executing test: TRAIN_ONLY contains vocab mapping logic")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="Qwen/Qwen3-8B",
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "build_vocab_mappings_from_distribution" in script
+    assert "d2t_path = Path(data_path)" in script
+    assert "t2d_path = Path(data_path)" in script
+    assert '"d2t": d2t' in script
+    assert '"t2d": t2d' in script
 
     print("test execution complete")

--- a/kubeflow/trainer/rhai/speculator_test.py
+++ b/kubeflow/trainer/rhai/speculator_test.py
@@ -1,0 +1,882 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SpeculativeDecodingTrainer and CRD conversion."""
+
+import pytest
+
+from kubeflow.trainer.constants import constants
+from kubeflow.trainer.rhai.speculator import (
+    SpeculativeDecodingTrainer,
+    SpeculatorMode,
+    SpeculatorType,
+    _create_speculator_progression_instrumentation,
+    _render_speculator_training_script,
+    get_trainer_cr_from_speculator_trainer,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types import types
+
+
+def test_speculator_trainer_initialization():
+    """Test SpeculativeDecodingTrainer initialization with default values."""
+    print("Executing test: SpeculativeDecodingTrainer initialization with defaults")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    assert trainer.verifier_name_or_path == "Qwen/Qwen3-8B"
+    assert trainer.speculator_type == SpeculatorType.EAGLE3
+    assert trainer.mode == SpeculatorMode.TRAIN_ONLY
+    assert trainer.hidden_states_path == "/data/hidden_states"
+    assert trainer.draft_vocab_size is None
+    assert trainer.epochs == 3
+    assert trainer.lr == 1e-4
+    assert trainer.total_seq_len == 8192
+    assert trainer.hidden_states_dtype == "bfloat16"
+    assert trainer.num_nodes is None
+    assert trainer.resources_per_node is None
+    assert trainer.packages_to_install is None
+    assert trainer.pip_index_urls == list(constants.DEFAULT_PIP_INDEX_URLS)
+    assert trainer.env is None
+    assert trainer.output_dir == "pvc://test-pvc/output"
+    assert trainer.enable_progression_tracking is True
+    assert trainer.metrics_port == 28080
+    assert trainer.metrics_poll_interval_seconds == 30
+
+    print("test execution complete")
+
+
+def test_speculator_trainer_with_custom_config():
+    """Test SpeculativeDecodingTrainer with custom configuration."""
+    print("Executing test: SpeculativeDecodingTrainer with custom configuration")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="meta-llama/Llama-3.1-70B",
+        speculator_type=SpeculatorType.EAGLE3,
+        mode=SpeculatorMode.TRAIN_ONLY,
+        hidden_states_path="/mnt/pvc/hidden_states",
+        output_dir="pvc://shared/checkpoints/eagle3",
+        draft_vocab_size=32000,
+        epochs=5,
+        lr=5e-5,
+        total_seq_len=4096,
+        num_nodes=2,
+        resources_per_node={"nvidia.com/gpu": 4},
+        packages_to_install=["speculators"],
+        pip_index_urls=["https://custom.pypi.org/simple"],
+        env={"WANDB_DISABLED": "true"},
+        enable_progression_tracking=True,
+        metrics_port=28090,
+        metrics_poll_interval_seconds=60,
+    )
+
+    assert trainer.verifier_name_or_path == "meta-llama/Llama-3.1-70B"
+    assert trainer.speculator_type == SpeculatorType.EAGLE3
+    assert trainer.hidden_states_path == "/mnt/pvc/hidden_states"
+    assert trainer.output_dir == "pvc://shared/checkpoints/eagle3"
+    assert trainer.draft_vocab_size == 32000
+    assert trainer.epochs == 5
+    assert trainer.lr == 5e-5
+    assert trainer.total_seq_len == 4096
+    assert trainer.num_nodes == 2
+    assert trainer.resources_per_node == {"nvidia.com/gpu": 4}
+    assert trainer.packages_to_install == ["speculators"]
+    assert trainer.pip_index_urls == ["https://custom.pypi.org/simple"]
+    assert trainer.env == {"WANDB_DISABLED": "true"}
+    assert trainer.metrics_port == 28090
+    assert trainer.metrics_poll_interval_seconds == 60
+
+    print("test execution complete")
+
+
+def test_speculator_mode_train_only_requires_hidden_states():
+    """Test that TRAIN_ONLY mode requires hidden_states_path."""
+    print("Executing test: TRAIN_ONLY mode requires hidden_states_path")
+
+    with pytest.raises(ValueError, match="hidden_states_path is required for TRAIN_ONLY mode"):
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            mode=SpeculatorMode.TRAIN_ONLY,
+        )
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="DATA_ONLY mode not yet supported",
+            expected_status=FAILED,
+            config={"mode": SpeculatorMode.DATA_ONLY},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="OFFLINE mode not yet supported",
+            expected_status=FAILED,
+            config={"mode": SpeculatorMode.OFFLINE},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="ONLINE mode not yet supported",
+            expected_status=FAILED,
+            config={"mode": SpeculatorMode.ONLINE},
+            expected_error=NotImplementedError,
+        ),
+    ],
+)
+def test_unsupported_mode_validation(test_case):
+    """Test that unsupported modes raise NotImplementedError."""
+    print(f"Executing test: {test_case.name}")
+
+    try:
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="pvc://test-pvc/output",
+            **test_case.config,
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="port too low (1023)",
+            expected_status=FAILED,
+            config={"metrics_port": 1023},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="port too high (65536)",
+            expected_status=FAILED,
+            config={"metrics_port": 65536},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="port minimum boundary (1024)",
+            expected_status=SUCCESS,
+            config={"metrics_port": 1024},
+            expected_output=1024,
+        ),
+        TestCase(
+            name="port maximum boundary (65535)",
+            expected_status=SUCCESS,
+            config={"metrics_port": 65535},
+            expected_output=65535,
+        ),
+    ],
+)
+def test_metrics_port_validation(test_case):
+    """Test metrics_port validation."""
+    print(f"Executing test: {test_case.name}")
+
+    try:
+        trainer = SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="pvc://test-pvc/output",
+            metrics_port=test_case.config["metrics_port"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert trainer.metrics_port == test_case.expected_output
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="poll interval too low (4 seconds)",
+            expected_status=FAILED,
+            config={"metrics_poll_interval_seconds": 4},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="poll interval too high (301 seconds)",
+            expected_status=FAILED,
+            config={"metrics_poll_interval_seconds": 301},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="poll interval minimum boundary (5 seconds)",
+            expected_status=SUCCESS,
+            config={"metrics_poll_interval_seconds": 5},
+            expected_output=5,
+        ),
+        TestCase(
+            name="poll interval maximum boundary (300 seconds)",
+            expected_status=SUCCESS,
+            config={"metrics_poll_interval_seconds": 300},
+            expected_output=300,
+        ),
+    ],
+)
+def test_metrics_poll_interval_validation(test_case):
+    """Test metrics_poll_interval_seconds validation."""
+    print(f"Executing test: {test_case.name}")
+
+    try:
+        trainer = SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="pvc://test-pvc/output",
+            metrics_poll_interval_seconds=test_case.config["metrics_poll_interval_seconds"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert trainer.metrics_poll_interval_seconds == test_case.expected_output
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+def test_non_pvc_output_dir_not_supported():
+    """Test that non-PVC output_dir raises NotImplementedError."""
+    print("Executing test: non-PVC output_dir not supported")
+
+    with pytest.raises(NotImplementedError, match="is not yet supported"):
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="s3://my-bucket/checkpoints",
+        )
+
+    with pytest.raises(ValueError, match="Unsupported storage URI scheme"):
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="gcs://my-bucket/checkpoints",
+        )
+
+    print("test execution complete")
+
+
+def test_pvc_output_dir_normalized():
+    """Test that PVC output_dir is normalized."""
+    print("Executing test: PVC output_dir normalization")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://my-pvc/checkpoints/",
+    )
+
+    assert trainer.output_dir == "pvc://my-pvc/checkpoints"
+
+    print("test execution complete")
+
+
+def test_training_script_content():
+    """Test that generated training script contains expected CLI arguments."""
+    print("Executing test: Training script content")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        draft_vocab_size=32000,
+        epochs=5,
+        lr=1e-5,
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "from speculators.models.eagle3.core import Eagle3DraftModel" in script
+    assert "from speculators.train.trainer import Trainer, TrainerConfig" in script
+    assert "from speculators.train.noise_transforms import AddUniformNoise" in script
+    assert "ArrowDataset" in script
+    assert "SampleFileDataset" not in script
+    assert "split_files" not in script
+    assert "Eagle3DraftModel.from_training_args" in script
+    assert "Qwen/Qwen3-8B" in script
+    assert "/data/hidden_states" in script
+    assert "draft_vocab_size=32000" in script
+    assert "norm_before_residual=True" in script
+    assert "ttt_steps=3" in script
+    assert "max_len = total_seq_len" in script
+    assert "total_seq_len=8192" in script
+    assert "create_collate_fn(max_len, verifier_config.hidden_size)" in script
+    assert "AddUniformNoise()" in script
+    assert 'on_missing="skip"' in script
+    assert "split_ratio=0.9" in script
+    assert "split_ratio=-0.1" in script
+    assert "hidden_states_dtype='bfloat16'" in script
+    assert "getattr(torch, hidden_states_dtype)" in script
+    assert "MultipackDistributedBatchSamplerV2" in script
+    assert "trainer.run_training()" in script
+
+    print("test execution complete")
+
+
+def test_training_script_with_pvc_output_dir():
+    """Test that output_dir PVC URI resolves to correct save_path in training script."""
+    print("Executing test: Training script with PVC output_dir")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://shared/speculator_output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "/mnt/kubeflow-checkpoints/speculator_output" in script
+    assert "/tmp/checkpoints" not in script
+
+    print("test execution complete")
+
+
+def test_train_only_requires_output_dir():
+    """Test that TRAIN_ONLY mode requires output_dir."""
+    print("Executing test: TRAIN_ONLY mode requires output_dir")
+
+    with pytest.raises(ValueError, match="output_dir is required for TRAIN_ONLY mode"):
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+        )
+
+    print("test execution complete")
+
+
+def test_training_script_custom_total_seq_len():
+    """Test that generated script uses custom total_seq_len value."""
+    print("Executing test: Training script custom total_seq_len")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        total_seq_len=2048,
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "total_seq_len=2048" in script
+    assert "total_seq_len=8192" not in script
+
+    print("test execution complete")
+
+
+def test_training_script_custom_hidden_states_dtype():
+    """Test that generated script uses custom hidden_states_dtype value."""
+    print("Executing test: Training script custom hidden_states_dtype")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        hidden_states_dtype="float16",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "hidden_states_dtype='float16'" in script
+    assert "hidden_states_dtype='bfloat16'" not in script
+
+    print("test execution complete")
+
+
+def test_hidden_states_dtype_validation():
+    """Test that invalid hidden_states_dtype raises ValueError."""
+    print("Executing test: hidden_states_dtype validation")
+
+    with pytest.raises(ValueError, match="hidden_states_dtype must be one of"):
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="pvc://test-pvc/output",
+            hidden_states_dtype="float64",
+        )
+
+    print("test execution complete")
+
+
+def test_training_script_distributed_batch_sampler():
+    """Test that generated script uses MultipackDistributedBatchSamplerV2 for data sharding."""
+    print("Executing test: Training script distributed batch sampler")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "MultipackDistributedBatchSamplerV2" in script
+    assert "batch_max_length=max_len" in script
+    assert "approx_lengths" in script
+    assert "num_replicas=world_size" in script
+    assert "rank=rank" in script
+    assert "batch_sampler=train_batch_sampler" in script
+    assert "batch_sampler=val_batch_sampler" in script
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="epochs must be positive integer",
+            expected_status=FAILED,
+            config={"epochs": 0},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="lr must be positive number",
+            expected_status=FAILED,
+            config={"lr": -1e-4},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="total_seq_len must be positive integer",
+            expected_status=FAILED,
+            config={"total_seq_len": 0},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="draft_vocab_size must be positive integer",
+            expected_status=FAILED,
+            config={"draft_vocab_size": -1},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_numeric_field_validation(test_case):
+    """Test that numeric fields are validated for type and range."""
+    print(f"Executing test: {test_case.name}")
+
+    try:
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="pvc://test-pvc/output",
+            **test_case.config,
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+def test_training_script_uses_verifier_vocab_when_draft_unset():
+    """Test that generated script uses verifier_config.vocab_size when draft_vocab_size is None."""
+    print("Executing test: Training script uses verifier vocab size when unset")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    script = _render_speculator_training_script(trainer)
+
+    assert "draft_vocab_size = verifier_config.vocab_size" in script
+
+    print("test execution complete")
+
+
+def test_crd_conversion_train_only():
+    """Test CRD conversion for TRAIN_ONLY mode."""
+    print("Executing test: CRD conversion for TRAIN_ONLY")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        num_nodes=2,
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    assert trainer_crd.num_nodes == 2
+    assert trainer_crd.command is not None
+
+    script = " ".join(trainer_crd.command) if trainer_crd.command else ""
+    assert "speculator_train.py" in script
+    assert "Qwen/Qwen3-8B" in script
+
+    print("test execution complete")
+
+
+def test_crd_conversion_with_env_vars():
+    """Test that user env vars appear in CRD."""
+    print("Executing test: CRD conversion with env vars")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        env={"WANDB_DISABLED": "true", "NCCL_DEBUG": "INFO"},
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    assert trainer_crd.env is not None
+    env_names = {e.name for e in trainer_crd.env}
+    assert "WANDB_DISABLED" in env_names
+    assert "NCCL_DEBUG" in env_names
+
+    wandb_env = next(e for e in trainer_crd.env if e.name == "WANDB_DISABLED")
+    assert wandb_env.value == "true"
+
+    print("test execution complete")
+
+
+def test_crd_conversion_no_env_vars():
+    """Test CRD conversion when no env vars are provided."""
+    print("Executing test: CRD conversion without env vars")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    assert trainer_crd.env is None
+
+    print("test execution complete")
+
+
+def test_crd_conversion_with_resources():
+    """Test CRD conversion with resources_per_node."""
+    print("Executing test: CRD conversion with resources_per_node")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        resources_per_node={"nvidia.com/gpu": 2, "cpu": 8, "memory": "32Gi"},
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    assert trainer_crd.resources_per_node is not None
+
+    print("test execution complete")
+
+
+def test_crd_uses_torchrun_entrypoint():
+    """Test that CRD conversion sets torchrun as the entrypoint."""
+    print("Executing test: CRD uses torchrun entrypoint")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+    )
+
+    get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    assert runtime.trainer.command == constants.TORCH_COMMAND
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="trainer with progression tracking disabled",
+            expected_status=SUCCESS,
+            config={"enable_progression_tracking": False},
+        ),
+        TestCase(
+            name="trainer with progression tracking enabled (defaults)",
+            expected_status=SUCCESS,
+            config={"enable_progression_tracking": True},
+        ),
+        TestCase(
+            name="trainer with custom port",
+            expected_status=SUCCESS,
+            config={
+                "enable_progression_tracking": True,
+                "metrics_port": 8888,
+            },
+        ),
+        TestCase(
+            name="trainer with long poll interval",
+            expected_status=SUCCESS,
+            config={
+                "enable_progression_tracking": True,
+                "metrics_poll_interval_seconds": 120,
+            },
+        ),
+    ],
+)
+def test_speculator_trainer_configurations(test_case):
+    """Test various SpeculativeDecodingTrainer configurations."""
+    print(f"Executing test: {test_case.name}")
+
+    try:
+        trainer = SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="/data/hidden_states",
+            output_dir="pvc://test-pvc/output",
+            **test_case.config,
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+        for key, value in test_case.config.items():
+            assert getattr(trainer, key) == value
+
+    except Exception as e:
+        if test_case.expected_error:
+            assert type(e) is test_case.expected_error
+        else:
+            raise
+
+    print("test execution complete")
+
+
+def test_speculator_enum_values():
+    """Test enum values for SpeculatorMode and SpeculatorType."""
+    print("Executing test: Enum values")
+
+    assert SpeculatorMode.TRAIN_ONLY.value == "train_only"
+    assert SpeculatorMode.DATA_ONLY.value == "data_only"
+    assert SpeculatorMode.OFFLINE.value == "offline"
+    assert SpeculatorMode.ONLINE.value == "online"
+    assert SpeculatorType.EAGLE3.value == "eagle3"
+    assert SpeculatorType.DFLASH.value == "dflash"
+    assert SpeculatorType.MTP.value == "mtp"
+    assert SpeculatorType.PEAGLE.value == "peagle"
+
+    print("test execution complete")
+
+
+def test_progression_tracking_injected_when_enabled():
+    """Test that progression tracking code is injected when enabled."""
+    print("Executing test: Progression tracking injected when enabled")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        enable_progression_tracking=True,
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    script = " ".join(trainer_crd.command) if trainer_crd.command else ""
+    assert "Speculator Progression Tracking" in script
+    assert "apply_progression_tracking" in script
+    assert "MetricsHandler" in script
+    assert "SpeculatorMetricsHTTPHandler" in script
+
+    print("test execution complete")
+
+
+def test_progression_tracking_not_injected_when_disabled():
+    """Test that progression tracking code is NOT injected when disabled."""
+    print("Executing test: Progression tracking not injected when disabled")
+
+    runtime = types.Runtime(
+        name="test-runtime",
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="pytorch",
+            image="registry.redhat.io/rhaii/model-opt-cuda-rhel9:3.5",
+        ),
+    )
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/data/hidden_states",
+        output_dir="pvc://test-pvc/output",
+        enable_progression_tracking=False,
+    )
+
+    trainer_crd = get_trainer_cr_from_speculator_trainer(runtime, trainer)
+
+    script = " ".join(trainer_crd.command) if trainer_crd.command else ""
+    assert "Speculator Progression Tracking" not in script
+    assert "apply_progression_tracking" not in script
+
+    print("test execution complete")
+
+
+def test_progression_instrumentation_returns_callable():
+    """Test that _create_speculator_progression_instrumentation returns valid tuple."""
+    print("Executing test: Progression instrumentation returns callable")
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        apply_fn, handler_class, _ = _create_speculator_progression_instrumentation(
+            metrics_port=28080,
+            num_epochs=3,
+            save_path=tmpdir,
+        )
+
+        assert callable(apply_fn)
+        assert handler_class is not None
+
+    print("test execution complete")
+
+
+def test_progression_instrumentation_schema_transform():
+    """Test that the HTTP handler transforms speculators metrics to controller schema."""
+    print("Executing test: Progression instrumentation schema transform")
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        _, handler_class, _ = _create_speculator_progression_instrumentation(
+            metrics_port=28080,
+            num_epochs=3,
+            save_path=tmpdir,
+        )
+
+        handler = handler_class.__new__(handler_class)
+        result = handler._transform(
+            {"train": {"loss": 2.5}, "epoch": 0, "lr": 1e-4, "global_step": 5}
+        )
+
+        assert result["currentEpoch"] == 1
+        assert result["totalEpochs"] == 3
+        assert result["currentStep"] == 5
+        assert result["trainMetrics"]["loss"] == "2.5000"
+        assert result["trainMetrics"]["learning_rate"] == "0.000100"
+
+    print("test execution complete")
+
+
+def test_hidden_states_path_normalization():
+    """Test that hidden_states_path is normalized."""
+    print("Executing test: hidden_states_path normalization")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="pvc://shared//hidden_states/",
+        output_dir="pvc://shared/output",
+    )
+
+    assert trainer.hidden_states_path == "pvc://shared/hidden_states"
+
+    print("test execution complete")
+
+
+def test_hidden_states_path_unsupported_scheme():
+    """Test that non-PVC URI schemes for hidden_states_path raise NotImplementedError."""
+    print("Executing test: hidden_states_path unsupported scheme")
+
+    with pytest.raises(NotImplementedError, match="hidden_states_path scheme"):
+        SpeculativeDecodingTrainer(
+            verifier_name_or_path="Qwen/Qwen3-8B",
+            hidden_states_path="s3://bucket/hidden_states",
+            output_dir="pvc://shared/output",
+        )
+
+    print("test execution complete")
+
+
+def test_hidden_states_path_direct_path_allowed():
+    """Test that direct filesystem paths for hidden_states_path are allowed."""
+    print("Executing test: hidden_states_path direct path allowed")
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="Qwen/Qwen3-8B",
+        hidden_states_path="/mnt/data/hidden_states",
+        output_dir="pvc://shared/output",
+    )
+
+    assert trainer.hidden_states_path == "/mnt/data/hidden_states"
+
+    print("test execution complete")

--- a/kubeflow/trainer/rhai/utils.py
+++ b/kubeflow/trainer/rhai/utils.py
@@ -10,6 +10,7 @@ from kubernetes.client.rest import ApiException
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.rhai import (
     RHAITrainer,
+    speculator,
     traininghub,
     transformers,
 )
@@ -80,6 +81,13 @@ def get_trainer_cr_from_rhai_trainer(
 
     elif isinstance(trainer, transformers.TransformersTrainer):
         return transformers.get_trainer_cr_from_transformers_trainer(
+            runtime,
+            trainer,
+            initializer,
+        )
+
+    elif isinstance(trainer, speculator.SpeculativeDecodingTrainer):
+        return speculator.get_trainer_cr_from_speculator_trainer(
             runtime,
             trainer,
             initializer,
@@ -489,8 +497,27 @@ def setup_rhai_trainer_storage(
     """
     resolved_output_dir = None
 
-    # Apply output_dir URI parsing and volume mounting
-    if hasattr(trainer, "output_dir") and trainer.output_dir:
+    if isinstance(trainer, speculator.SpeculativeDecodingTrainer):
+        all_paths = [trainer.output_dir, trainer.hidden_states_path]
+        pvc_paths = [p for p in all_paths if p and p.startswith(PVC_URI_SCHEME)]
+        pvc_names = {p[len(PVC_URI_SCHEME) :].split("/", 1)[0] for p in pvc_paths}
+
+        if len(pvc_names) > 1:
+            raise NotImplementedError(
+                f"Multiple different PVCs are not yet supported. "
+                f"Found PVCs: {', '.join(sorted(pvc_names))}. "
+                f"Use the same PVC for all fields, or mount additional PVCs "
+                f"manually via pod_template_overrides."
+            )
+
+        if pvc_paths:
+            _, pod_template_overrides = apply_output_dir_uri_to_pod_overrides(
+                pvc_paths[0], pod_template_overrides
+            )
+        else:
+            pod_template_overrides = pod_template_overrides or []
+
+    elif hasattr(trainer, "output_dir") and trainer.output_dir:
         resolved_output_dir, pod_template_overrides = apply_output_dir_uri_to_pod_overrides(
             trainer.output_dir, pod_template_overrides
         )

--- a/kubeflow/trainer/rhai/utils.py
+++ b/kubeflow/trainer/rhai/utils.py
@@ -498,7 +498,12 @@ def setup_rhai_trainer_storage(
     resolved_output_dir = None
 
     if isinstance(trainer, speculator.SpeculativeDecodingTrainer):
-        all_paths = [trainer.output_dir, trainer.hidden_states_path]
+        all_paths = [
+            trainer.output_dir,
+            trainer.hidden_states_path,
+            trainer.dataset_name,
+            trainer.verifier_model,
+        ]
         pvc_paths = [p for p in all_paths if p and p.startswith(PVC_URI_SCHEME)]
         pvc_names = {p[len(PVC_URI_SCHEME) :].split("/", 1)[0] for p in pvc_paths}
 
@@ -516,6 +521,11 @@ def setup_rhai_trainer_storage(
             )
         else:
             pod_template_overrides = pod_template_overrides or []
+
+        if trainer.mode == speculator.SpeculatorMode.DATA_ONLY:
+            pod_template_overrides = speculator.apply_speculator_sidecar_overrides(
+                trainer, pod_template_overrides
+            )
 
     elif hasattr(trainer, "output_dir") and trainer.output_dir:
         resolved_output_dir, pod_template_overrides = apply_output_dir_uri_to_pod_overrides(

--- a/kubeflow/trainer/rhai/utils_test.py
+++ b/kubeflow/trainer/rhai/utils_test.py
@@ -590,5 +590,110 @@ def test_setup_rhai_trainer_storage_no_output_dir():
     print("test execution complete")
 
 
+def test_speculator_same_pvc_deduplicates_mount():
+    """Test SpeculativeDecodingTrainer with same PVC for output_dir and hidden_states_path mounts once."""
+    print("Executing test: speculator_same_pvc_deduplicates_mount")
+
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer
+
+    mock_core_api = MagicMock()
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+        hidden_states_path="pvc://shared/hidden-states",
+        output_dir="pvc://shared/output",
+    )
+
+    mock_trainer_cr = MagicMock()
+    mock_trainer_cr.env = []
+
+    resolved_dir, result_cr, result_overrides = setup_rhai_trainer_storage(
+        trainer, mock_trainer_cr, None, mock_core_api, "default"
+    )
+
+    all_volumes = []
+    for override in result_overrides:
+        for vol in override.get("spec", {}).get("volumes", []):
+            all_volumes.append(vol.get("name"))
+
+    expected = {
+        "resolved_dir": None,
+        "volume_count": 1,
+        "volume_name": CHECKPOINT_VOLUME_NAME,
+    }
+    actual = {
+        "resolved_dir": resolved_dir,
+        "volume_count": all_volumes.count(CHECKPOINT_VOLUME_NAME),
+        "volume_name": all_volumes[0] if all_volumes else None,
+    }
+    assert actual == expected
+
+    print("test execution complete")
+
+
+def test_speculator_different_pvcs_raises_error():
+    """Test SpeculativeDecodingTrainer with different PVCs raises NotImplementedError."""
+    print("Executing test: speculator_different_pvcs_raises_error")
+
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer
+
+    mock_core_api = MagicMock()
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+        hidden_states_path="pvc://pvc-a/hidden-states",
+        output_dir="pvc://pvc-b/output",
+    )
+
+    mock_trainer_cr = MagicMock()
+    mock_trainer_cr.env = []
+
+    with pytest.raises(NotImplementedError, match="Multiple different PVCs"):
+        setup_rhai_trainer_storage(trainer, mock_trainer_cr, None, mock_core_api, "default")
+
+    print("test execution complete")
+
+
+def test_speculator_pvc_and_direct_path_no_conflict():
+    """Test SpeculativeDecodingTrainer with one PVC URI and one direct path mounts once."""
+    print("Executing test: speculator_pvc_and_direct_path_no_conflict")
+
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer
+
+    mock_core_api = MagicMock()
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+        hidden_states_path="/data/hidden-states",
+        output_dir="pvc://shared/output",
+    )
+
+    mock_trainer_cr = MagicMock()
+    mock_trainer_cr.env = []
+
+    resolved_dir, result_cr, result_overrides = setup_rhai_trainer_storage(
+        trainer, mock_trainer_cr, None, mock_core_api, "default"
+    )
+
+    all_volumes = []
+    for override in result_overrides:
+        for vol in override.get("spec", {}).get("volumes", []):
+            all_volumes.append(vol.get("name"))
+
+    expected = {
+        "resolved_dir": None,
+        "volume_count": 1,
+        "volume_name": CHECKPOINT_VOLUME_NAME,
+    }
+    actual = {
+        "resolved_dir": resolved_dir,
+        "volume_count": all_volumes.count(CHECKPOINT_VOLUME_NAME),
+        "volume_name": all_volumes[0] if all_volumes else None,
+    }
+    assert actual == expected
+
+    print("test execution complete")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/kubeflow/trainer/rhai/utils_test.py
+++ b/kubeflow/trainer/rhai/utils_test.py
@@ -594,12 +594,13 @@ def test_speculator_same_pvc_deduplicates_mount():
     """Test SpeculativeDecodingTrainer with same PVC for output_dir and hidden_states_path mounts once."""
     print("Executing test: speculator_same_pvc_deduplicates_mount")
 
-    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer, SpeculatorMode
 
     mock_core_api = MagicMock()
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="pvc://shared/hidden-states",
         output_dir="pvc://shared/output",
     )
@@ -635,13 +636,38 @@ def test_speculator_different_pvcs_raises_error():
     """Test SpeculativeDecodingTrainer with different PVCs raises NotImplementedError."""
     print("Executing test: speculator_different_pvcs_raises_error")
 
-    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer, SpeculatorMode
 
     mock_core_api = MagicMock()
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="pvc://pvc-a/hidden-states",
+        output_dir="pvc://pvc-b/output",
+    )
+
+    mock_trainer_cr = MagicMock()
+    mock_trainer_cr.env = []
+
+    with pytest.raises(NotImplementedError, match="Multiple different PVCs"):
+        setup_rhai_trainer_storage(trainer, mock_trainer_cr, None, mock_core_api, "default")
+
+    print("test execution complete")
+
+
+def test_speculator_different_pvcs_raises_error_data_only():
+    """Test SpeculativeDecodingTrainer DATA_ONLY with different PVCs raises NotImplementedError."""
+    print("Executing test: speculator_different_pvcs_raises_error_data_only")
+
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer, SpeculatorMode
+
+    mock_core_api = MagicMock()
+
+    trainer = SpeculativeDecodingTrainer(
+        verifier_model="pvc://pvc-a/model",
+        mode=SpeculatorMode.DATA_ONLY,
+        dataset_name="sharegpt",
         output_dir="pvc://pvc-b/output",
     )
 
@@ -658,12 +684,13 @@ def test_speculator_pvc_and_direct_path_no_conflict():
     """Test SpeculativeDecodingTrainer with one PVC URI and one direct path mounts once."""
     print("Executing test: speculator_pvc_and_direct_path_no_conflict")
 
-    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer
+    from kubeflow.trainer.rhai.speculator import SpeculativeDecodingTrainer, SpeculatorMode
 
     mock_core_api = MagicMock()
 
     trainer = SpeculativeDecodingTrainer(
-        verifier_name_or_path="meta-llama/Llama-3.1-8B-Instruct",
+        verifier_model="meta-llama/Llama-3.1-8B-Instruct",
+        mode=SpeculatorMode.TRAIN_ONLY,
         hidden_states_path="/data/hidden-states",
         output_dir="pvc://shared/output",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ extend-exclude = [
   "__pycache__",
   "docs/_build",
   "spark-operator",
+  "kubeflow/trainer/rhai/scripts",
 ]
 
 [tool.ruff.format]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:


Fixes #

**Verification steps** _(required; provide valid, reproducible steps for reviewers to verify your changes, e.g. setup, commands, expected outcome, notebooks)_:

_Example: 1. Check out this branch. 2. Run `make test-python`. 3. Confirm that …_

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added speculative-decoding (speculator) trainer support with new public exports and expanded RHAI trainer type coverage.
  * Supports configurable verifier/draft training, optional pip-install inputs, distributed execution, metrics endpoint reporting, and optional progression tracking.

* **Bug Fixes**
  * Added stricter validation for trainer configuration (mode/type, numeric ranges, allowed dtypes) and improved normalization/handling of `output_dir` and hidden-states URI schemes.
  * Updated volume mounting to deduplicate overlapping PVC mounts and error on mismatched PVCs.

* **Tests**
  * Added extensive unit tests for validation, training-script rendering, CR generation, progression instrumentation, and PVC mount behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->