### PR TITLE
chore(test): add unit tests for kubeflow/optimizer module

### DIFF
--- a/kubeflow/optimizer/api/optimizer_client_test.py
+++ b/kubeflow/optimizer/api/optimizer_client_test.py
@@ -34,8 +34,8 @@ from kubeflow.trainer.types.types import (
 
 
 @pytest.fixture
-def mock_backend():
-    """Provide an OptimizerClient whose backend is fully mocked."""
+def _kubernetes_patches():
+    """Patch kubernetes APIs and verify_backend to avoid real cluster interactions."""
     with (
         patch("kubernetes.config.load_kube_config", return_value=None),
         patch("kubernetes.client.CustomObjectsApi", return_value=Mock()),
@@ -45,9 +45,15 @@ def mock_backend():
             return_value=None,
         ),
     ):
-        client = OptimizerClient()
-        client.backend = Mock()
-        yield client
+        yield
+
+
+@pytest.fixture
+def mock_backend(_kubernetes_patches):
+    """Provide an OptimizerClient whose backend is fully mocked."""
+    client = OptimizerClient()
+    client.backend = Mock()
+    yield client
 
 
 # --- __init__ tests ---
@@ -78,25 +84,15 @@ def mock_backend():
         ),
     ],
 )
-def test_init(test_case: TestCase):
+def test_init(test_case: TestCase, _kubernetes_patches):
     """Test OptimizerClient initialization with various backend configs."""
     print("Executing test:", test_case.name)
-    try:
-        with (
-            patch("kubernetes.config.load_kube_config", return_value=None),
-            patch("kubernetes.client.CustomObjectsApi", return_value=Mock()),
-            patch("kubernetes.client.CoreV1Api", return_value=Mock()),
-            patch(
-                "kubeflow.trainer.backends.kubernetes.backend.KubernetesBackend.verify_backend",
-                return_value=None,
-            ),
-        ):
-            client = OptimizerClient(**test_case.config) if test_case.config else OptimizerClient()
-            assert test_case.expected_status == SUCCESS
-            assert client.backend is not None
-    except Exception as e:
-        assert test_case.expected_status == FAILED
-        assert isinstance(e, test_case.expected_error)
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            OptimizerClient(**test_case.config) if test_case.config else OptimizerClient()
+    else:
+        client = OptimizerClient(**test_case.config) if test_case.config else OptimizerClient()
+        assert client.backend is not None
     print("test execution complete")
 
 

--- a/kubeflow/optimizer/api/optimizer_client_test.py
+++ b/kubeflow/optimizer/api/optimizer_client_test.py
@@ -1,0 +1,197 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for kubeflow.optimizer.api.optimizer_client module."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.optimizer.api.optimizer_client import OptimizerClient
+from kubeflow.optimizer.types.algorithm_types import RandomSearch
+from kubeflow.optimizer.types.optimization_types import (
+    Objective,
+    OptimizationJob,
+)
+from kubeflow.optimizer.types.search_types import Search
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types.types import (
+    CustomTrainer,
+    TrainJobTemplate,
+)
+
+
+@pytest.fixture
+def mock_backend():
+    """Provide an OptimizerClient whose backend is fully mocked."""
+    with (
+        patch("kubernetes.config.load_kube_config", return_value=None),
+        patch("kubernetes.client.CustomObjectsApi", return_value=Mock()),
+        patch("kubernetes.client.CoreV1Api", return_value=Mock()),
+        patch(
+            "kubeflow.trainer.backends.kubernetes.backend.KubernetesBackend.verify_backend",
+            return_value=None,
+        ),
+    ):
+        client = OptimizerClient()
+        client.backend = Mock()
+        yield client
+
+
+# --- __init__ tests ---
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default config creates KubernetesBackend",
+            expected_status=SUCCESS,
+        ),
+        TestCase(
+            name="None config creates KubernetesBackend",
+            expected_status=SUCCESS,
+            config={"backend_config": None},
+        ),
+        TestCase(
+            name="explicit KubernetesBackendConfig works",
+            expected_status=SUCCESS,
+            config={"backend_config": KubernetesBackendConfig(namespace="custom")},
+        ),
+        TestCase(
+            name="invalid backend config raises ValueError",
+            expected_status=FAILED,
+            config={"backend_config": "not-a-config"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_init(test_case: TestCase):
+    """Test OptimizerClient initialization with various backend configs."""
+    print("Executing test:", test_case.name)
+    try:
+        with (
+            patch("kubernetes.config.load_kube_config", return_value=None),
+            patch("kubernetes.client.CustomObjectsApi", return_value=Mock()),
+            patch("kubernetes.client.CoreV1Api", return_value=Mock()),
+            patch(
+                "kubeflow.trainer.backends.kubernetes.backend.KubernetesBackend.verify_backend",
+                return_value=None,
+            ),
+        ):
+            client = OptimizerClient(**test_case.config) if test_case.config else OptimizerClient()
+            assert test_case.expected_status == SUCCESS
+            assert client.backend is not None
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert isinstance(e, test_case.expected_error)
+    print("test execution complete")
+
+
+# --- Delegation tests ---
+
+
+def test_optimize_delegates(mock_backend):
+    """Test that optimize() delegates to backend.optimize()."""
+    print("Executing test: optimize delegates")
+    mock_backend.backend.optimize.return_value = "exp-123"
+
+    template = TrainJobTemplate(
+        trainer=CustomTrainer(func=lambda: None, num_nodes=1),
+    )
+    search_space = {"lr": Search.uniform(min=0.001, max=0.1)}
+
+    result = mock_backend.optimize(
+        template,
+        search_space=search_space,
+        objectives=[Objective()],
+        algorithm=RandomSearch(),
+    )
+
+    assert result == "exp-123"
+    mock_backend.backend.optimize.assert_called_once()
+    print("test execution complete")
+
+
+def test_list_jobs_delegates(mock_backend):
+    """Test that list_jobs() delegates to backend.list_jobs()."""
+    print("Executing test: list_jobs delegates")
+    mock_backend.backend.list_jobs.return_value = []
+    result = mock_backend.list_jobs()
+    assert result == []
+    mock_backend.backend.list_jobs.assert_called_once()
+    print("test execution complete")
+
+
+def test_get_job_delegates(mock_backend):
+    """Test that get_job() delegates to backend.get_job()."""
+    print("Executing test: get_job delegates")
+    sentinel = Mock(spec=OptimizationJob)
+    mock_backend.backend.get_job.return_value = sentinel
+    result = mock_backend.get_job(name="test-job")
+    assert result is sentinel
+    mock_backend.backend.get_job.assert_called_once_with(name="test-job")
+    print("test execution complete")
+
+
+def test_get_job_logs_delegates(mock_backend):
+    """Test that get_job_logs() delegates to backend.get_job_logs()."""
+    print("Executing test: get_job_logs delegates")
+    mock_backend.backend.get_job_logs.return_value = iter(["line1", "line2"])
+    result = list(mock_backend.get_job_logs(name="job-1", trial_name="t-1", follow=True))
+    assert result == ["line1", "line2"]
+    mock_backend.backend.get_job_logs.assert_called_once_with(
+        name="job-1", trial_name="t-1", follow=True
+    )
+    print("test execution complete")
+
+
+def test_get_best_results_delegates(mock_backend):
+    """Test that get_best_results() delegates to backend.get_best_results()."""
+    print("Executing test: get_best_results delegates")
+    mock_backend.backend.get_best_results.return_value = None
+    result = mock_backend.get_best_results(name="job-1")
+    assert result is None
+    mock_backend.backend.get_best_results.assert_called_once_with(name="job-1")
+    print("test execution complete")
+
+
+def test_wait_for_job_status_delegates(mock_backend):
+    """Test that wait_for_job_status() delegates to backend.wait_for_job_status()."""
+    print("Executing test: wait_for_job_status delegates")
+    sentinel = Mock(spec=OptimizationJob)
+    mock_backend.backend.wait_for_job_status.return_value = sentinel
+    result = mock_backend.wait_for_job_status(name="job-1", timeout=60)
+    assert result is sentinel
+    mock_backend.backend.wait_for_job_status.assert_called_once()
+    print("test execution complete")
+
+
+def test_delete_job_delegates(mock_backend):
+    """Test that delete_job() delegates to backend.delete_job()."""
+    print("Executing test: delete_job delegates")
+    mock_backend.delete_job(name="job-1")
+    mock_backend.backend.delete_job.assert_called_once_with(name="job-1")
+    print("test execution complete")
+
+
+def test_get_job_events_delegates(mock_backend):
+    """Test that get_job_events() delegates to backend.get_job_events()."""
+    print("Executing test: get_job_events delegates")
+    mock_backend.backend.get_job_events.return_value = []
+    result = mock_backend.get_job_events(name="job-1")
+    assert result == []
+    mock_backend.backend.get_job_events.assert_called_once_with(name="job-1")
+    print("test execution complete")

--- a/kubeflow/optimizer/backends/base_test.py
+++ b/kubeflow/optimizer/backends/base_test.py
@@ -1,0 +1,339 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for kubeflow.optimizer.backends.base module."""
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+
+from kubeflow.optimizer.backends.base import RuntimeBackend
+from kubeflow.optimizer.types.algorithm_types import RandomSearch
+from kubeflow.optimizer.types.optimization_types import (
+    Objective,
+    OptimizationJob,
+    Result,
+    TrialConfig,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types.types import CustomTrainer, Event, TrainJobTemplate
+
+
+class ConcreteBackend(RuntimeBackend):
+    """Minimal concrete implementation for testing the ABC contract."""
+
+    def optimize(
+        self,
+        trial_template: TrainJobTemplate,
+        *,
+        search_space: dict[str, Any],
+        trial_config: TrialConfig | None = None,
+        objectives: list[Objective] | None = None,
+        algorithm: RandomSearch | None = None,
+    ) -> str:
+        return "test-experiment"
+
+    def list_jobs(self) -> list[OptimizationJob]:
+        return []
+
+    def get_job(self, name: str) -> OptimizationJob:
+        raise RuntimeError("not found")
+
+    def get_job_logs(
+        self,
+        name: str,
+        trial_name: str | None,
+        follow: bool,
+    ) -> Iterator[str]:
+        yield "log line 1"
+
+    def get_best_results(self, name: str) -> Result | None:
+        return None
+
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[str] | None = None,
+        timeout: int = 3600,
+        polling_interval: int = 2,
+        callbacks: list[Callable[[OptimizationJob], None]] | None = None,
+    ) -> OptimizationJob:
+        raise TimeoutError("timed out")
+
+    def get_job_events(self, name: str) -> list[Event]:
+        return []
+
+    def delete_job(self, name: str):
+        return None
+
+
+def test_cannot_instantiate_abstract_class():
+    """Test that RuntimeBackend cannot be instantiated directly."""
+    print("Executing test: cannot instantiate abstract class")
+    with pytest.raises(TypeError):
+        RuntimeBackend()
+    print("test execution complete")
+
+
+def test_concrete_subclass_instantiation():
+    """Test that a concrete subclass implementing all methods can be instantiated."""
+    print("Executing test: concrete subclass instantiation")
+    backend = ConcreteBackend()
+    assert isinstance(backend, RuntimeBackend)
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="optimize returns experiment name",
+            expected_status=SUCCESS,
+            config={"method": "optimize"},
+            expected_output="test-experiment",
+        ),
+        TestCase(
+            name="list_jobs returns empty list",
+            expected_status=SUCCESS,
+            config={"method": "list_jobs"},
+            expected_output=[],
+        ),
+        TestCase(
+            name="get_best_results returns None",
+            expected_status=SUCCESS,
+            config={"method": "get_best_results", "name": "job-1"},
+            expected_output=None,
+        ),
+        TestCase(
+            name="get_job_events returns empty list",
+            expected_status=SUCCESS,
+            config={"method": "get_job_events", "name": "job-1"},
+            expected_output=[],
+        ),
+        TestCase(
+            name="delete_job returns None",
+            expected_status=SUCCESS,
+            config={"method": "delete_job", "name": "job-1"},
+            expected_output=None,
+        ),
+        TestCase(
+            name="get_job_logs returns log lines",
+            expected_status=SUCCESS,
+            config={"method": "get_job_logs", "name": "job-1"},
+            expected_output=["log line 1"],
+        ),
+    ],
+)
+def test_concrete_backend_methods(test_case: TestCase):
+    """Test that concrete backend methods fulfill the ABC contract."""
+    print("Executing test:", test_case.name)
+    backend = ConcreteBackend()
+    method_name = test_case.config["method"]
+    name_arg = test_case.config.get("name")
+
+    if method_name == "optimize":
+        template = TrainJobTemplate(
+            trainer=CustomTrainer(func=lambda: None, num_nodes=1),
+        )
+        result = backend.optimize(trial_template=template, search_space={"lr": None})
+        assert result == test_case.expected_output
+    elif method_name == "list_jobs":
+        result = backend.list_jobs()
+        assert result == test_case.expected_output
+    elif method_name == "get_best_results":
+        result = backend.get_best_results(name_arg)
+        assert result is test_case.expected_output
+    elif method_name == "get_job_events":
+        result = backend.get_job_events(name_arg)
+        assert result == test_case.expected_output
+    elif method_name == "delete_job":
+        result = backend.delete_job(name_arg)
+        assert result is test_case.expected_output
+    elif method_name == "get_job_logs":
+        result = list(backend.get_job_logs(name_arg, trial_name=None, follow=False))
+        assert result == test_case.expected_output
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_job raises RuntimeError",
+            expected_status=FAILED,
+            config={"method": "get_job", "name": "missing"},
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="wait_for_job_status raises TimeoutError",
+            expected_status=FAILED,
+            config={"method": "wait_for_job_status", "name": "job-1"},
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_concrete_backend_error_cases(test_case: TestCase):
+    """Test that concrete backend methods raise expected errors."""
+    print("Executing test:", test_case.name)
+    backend = ConcreteBackend()
+    method_name = test_case.config["method"]
+    name_arg = test_case.config.get("name")
+
+    with pytest.raises(test_case.expected_error):
+        if method_name == "get_job":
+            backend.get_job(name_arg)
+        elif method_name == "wait_for_job_status":
+            backend.wait_for_job_status(name_arg)
+
+    print("test execution complete")
+
+
+class PartialBackend(RuntimeBackend):
+    """Backend that delegates all methods to super() to verify NotImplementedError."""
+
+    def optimize(
+        self,
+        trial_template: TrainJobTemplate,
+        *,
+        search_space: dict[str, Any],
+        trial_config: TrialConfig | None = None,
+        objectives: list[Objective] | None = None,
+        algorithm: RandomSearch | None = None,
+    ) -> str:
+        return super().optimize(
+            trial_template,
+            search_space=search_space,
+            trial_config=trial_config,
+            objectives=objectives,
+            algorithm=algorithm,
+        )
+
+    def list_jobs(self) -> list[OptimizationJob]:
+        return super().list_jobs()
+
+    def get_job(self, name: str) -> OptimizationJob:
+        return super().get_job(name)
+
+    def get_job_logs(
+        self,
+        name: str,
+        trial_name: str | None,
+        follow: bool,
+    ) -> Iterator[str]:
+        return super().get_job_logs(name, trial_name, follow)
+
+    def get_best_results(self, name: str) -> Result | None:
+        return super().get_best_results(name)
+
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[str] | None = None,
+        timeout: int = 3600,
+        polling_interval: int = 2,
+        callbacks: list[Callable[[OptimizationJob], None]] | None = None,
+    ) -> OptimizationJob:
+        return super().wait_for_job_status(name, status, timeout, polling_interval, callbacks)
+
+    def get_job_events(self, name: str) -> list[Event]:
+        return super().get_job_events(name)
+
+    def delete_job(self, name: str):
+        return super().delete_job(name)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="optimize raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "optimize"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="list_jobs raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "list_jobs"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="get_job raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "get_job", "name": "j"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="get_job_logs raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "get_job_logs", "name": "j"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="get_best_results raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "get_best_results", "name": "j"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="wait_for_job_status raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "wait_for_job_status", "name": "j"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="get_job_events raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "get_job_events", "name": "j"},
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="delete_job raises NotImplementedError via super",
+            expected_status=FAILED,
+            config={"method": "delete_job", "name": "j"},
+            expected_error=NotImplementedError,
+        ),
+    ],
+)
+def test_super_raises_not_implemented(test_case: TestCase):
+    """Test that calling super() on each abstract method raises NotImplementedError."""
+    print("Executing test:", test_case.name)
+    backend = PartialBackend()
+    method_name = test_case.config["method"]
+    name_arg = test_case.config.get("name")
+
+    with pytest.raises(test_case.expected_error):
+        if method_name == "optimize":
+            template = TrainJobTemplate(
+                trainer=CustomTrainer(func=lambda: None, num_nodes=1),
+            )
+            backend.optimize(template, search_space={"lr": None})
+        elif method_name == "list_jobs":
+            backend.list_jobs()
+        elif method_name == "get_job":
+            backend.get_job(name_arg)
+        elif method_name == "get_job_logs":
+            backend.get_job_logs(name_arg, None, False)
+        elif method_name == "get_best_results":
+            backend.get_best_results(name_arg)
+        elif method_name == "wait_for_job_status":
+            backend.wait_for_job_status(name_arg)
+        elif method_name == "get_job_events":
+            backend.get_job_events(name_arg)
+        elif method_name == "delete_job":
+            backend.delete_job(name_arg)
+
+    print("test execution complete")

--- a/kubeflow/optimizer/types/algorithm_types_test.py
+++ b/kubeflow/optimizer/types/algorithm_types_test.py
@@ -1,0 +1,161 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for kubeflow.optimizer.types.algorithm_types module."""
+
+import pytest
+
+from kubeflow.optimizer.types.algorithm_types import (
+    ALGORITHM_REGISTRY,
+    BaseAlgorithm,
+    GridSearch,
+    RandomSearch,
+    algorithm_to_katib_spec,
+)
+from kubeflow.trainer.test.common import SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="grid search algorithm name",
+            expected_status=SUCCESS,
+            expected_output="grid",
+        ),
+        TestCase(
+            name="random search algorithm name",
+            expected_status=SUCCESS,
+            expected_output="random",
+        ),
+    ],
+)
+def test_algorithm_name(test_case: TestCase):
+    """Test that algorithm classes return correct algorithm_name."""
+    print("Executing test:", test_case.name)
+
+    algo = GridSearch() if test_case.expected_output == "grid" else RandomSearch()
+
+    assert algo.algorithm_name == test_case.expected_output
+    print("test execution complete")
+
+
+def test_base_algorithm_cannot_be_instantiated():
+    """Test that BaseAlgorithm ABC cannot be instantiated directly."""
+    print("Executing test: base algorithm cannot be instantiated")
+    with pytest.raises(TypeError):
+        BaseAlgorithm()
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="grid search has no settings",
+            expected_status=SUCCESS,
+            config={"algo": GridSearch()},
+            expected_output={"algorithm_name": "grid", "algorithm_settings": None},
+        ),
+        TestCase(
+            name="random search with no random_state",
+            expected_status=SUCCESS,
+            config={"algo": RandomSearch()},
+            expected_output={"algorithm_name": "random", "algorithm_settings": None},
+        ),
+        TestCase(
+            name="random search with random_state set",
+            expected_status=SUCCESS,
+            config={"algo": RandomSearch(random_state=42)},
+            expected_output={
+                "algorithm_name": "random",
+                "has_settings": True,
+                "setting_name": "random_state",
+                "setting_value": "42",
+            },
+        ),
+    ],
+)
+def test_algorithm_to_katib_spec(test_case: TestCase):
+    """Test that algorithm_to_katib_spec converts algorithms to Katib AlgorithmSpec."""
+    print("Executing test:", test_case.name)
+
+    spec = algorithm_to_katib_spec(test_case.config["algo"])
+
+    assert spec.algorithm_name == test_case.expected_output["algorithm_name"]
+
+    if test_case.expected_output.get("has_settings"):
+        assert spec.algorithm_settings is not None
+        assert len(spec.algorithm_settings) == 1
+        assert spec.algorithm_settings[0].name == test_case.expected_output["setting_name"]
+        assert spec.algorithm_settings[0].value == test_case.expected_output["setting_value"]
+    else:
+        assert spec.algorithm_settings == test_case.expected_output["algorithm_settings"]
+
+    print("test execution complete")
+
+
+def test_to_katib_spec_delegates_to_helper():
+    """Test that _to_katib_spec on concrete classes produces matching output."""
+    print("Executing test: _to_katib_spec delegates to helper")
+    algo = RandomSearch(random_state=7)
+    spec_via_method = algo._to_katib_spec()
+    spec_via_helper = algorithm_to_katib_spec(algo)
+
+    assert spec_via_method.algorithm_name == spec_via_helper.algorithm_name
+    assert len(spec_via_method.algorithm_settings) == len(spec_via_helper.algorithm_settings)
+    assert spec_via_method.algorithm_settings[0].name == spec_via_helper.algorithm_settings[0].name
+    assert (
+        spec_via_method.algorithm_settings[0].value == spec_via_helper.algorithm_settings[0].value
+    )
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="registry maps grid to GridSearch",
+            expected_status=SUCCESS,
+            config={"key": "grid"},
+            expected_output=GridSearch,
+        ),
+        TestCase(
+            name="registry maps random to RandomSearch",
+            expected_status=SUCCESS,
+            config={"key": "random"},
+            expected_output=RandomSearch,
+        ),
+    ],
+)
+def test_algorithm_registry(test_case: TestCase):
+    """Test that ALGORITHM_REGISTRY maps algorithm names to correct classes."""
+    print("Executing test:", test_case.name)
+    assert ALGORITHM_REGISTRY[test_case.config["key"]] is test_case.expected_output
+    print("test execution complete")
+
+
+def test_algorithm_registry_completeness():
+    """Test that ALGORITHM_REGISTRY contains exactly the expected algorithms."""
+    print("Executing test: algorithm registry completeness")
+    assert set(ALGORITHM_REGISTRY.keys()) == {"grid", "random"}
+    print("test execution complete")
+
+
+def test_random_search_default_random_state():
+    """Test that RandomSearch defaults random_state to None."""
+    print("Executing test: random search default random_state")
+    algo = RandomSearch()
+    assert algo.random_state is None
+    print("test execution complete")

--- a/kubeflow/optimizer/types/optimization_types_test.py
+++ b/kubeflow/optimizer/types/optimization_types_test.py
@@ -1,0 +1,254 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for kubeflow.optimizer.types.optimization_types module."""
+
+from datetime import datetime
+
+import pytest
+
+import kubeflow.common.constants as common_constants
+from kubeflow.optimizer.types.algorithm_types import GridSearch, RandomSearch
+from kubeflow.optimizer.types.optimization_types import (
+    Direction,
+    Metric,
+    Objective,
+    OptimizationJob,
+    Result,
+    Trial,
+    TrialConfig,
+)
+from kubeflow.optimizer.types.search_types import (
+    CategoricalSearchSpace,
+    ContinuousSearchSpace,
+    Distribution as SearchDistribution,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types.types import Runtime, RuntimeTrainer, TrainerType, TrainJob
+
+# --- Direction enum ---
+
+
+def test_direction_enum_values():
+    """Test that Direction enum has correct string values."""
+    print("Executing test: direction enum values")
+    assert Direction.MAXIMIZE.value == "maximize"
+    assert Direction.MINIMIZE.value == "minimize"
+    print("test execution complete")
+
+
+def test_direction_enum_from_value():
+    """Test that Direction enum can be constructed from string values."""
+    print("Executing test: direction enum from value")
+    assert Direction("maximize") is Direction.MAXIMIZE
+    assert Direction("minimize") is Direction.MINIMIZE
+    print("test execution complete")
+
+
+def test_direction_enum_invalid_value():
+    """Test that Direction enum raises ValueError for unknown strings."""
+    print("Executing test: direction enum invalid value")
+    with pytest.raises(ValueError):
+        Direction("invalid")
+    print("test execution complete")
+
+
+# --- Objective ---
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default objective",
+            expected_status=SUCCESS,
+            expected_output={"metric": "loss", "direction": Direction.MINIMIZE},
+        ),
+        TestCase(
+            name="custom objective with enum direction",
+            expected_status=SUCCESS,
+            config={"metric": "accuracy", "direction": Direction.MAXIMIZE},
+            expected_output={"metric": "accuracy", "direction": Direction.MAXIMIZE},
+        ),
+        TestCase(
+            name="objective with string direction coercion",
+            expected_status=SUCCESS,
+            config={"metric": "f1", "direction": "maximize"},
+            expected_output={"metric": "f1", "direction": Direction.MAXIMIZE},
+        ),
+        TestCase(
+            name="objective with invalid string direction",
+            expected_status=FAILED,
+            config={"metric": "loss", "direction": "unknown"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_objective(test_case: TestCase):
+    """Test Objective dataclass construction and direction coercion."""
+    print("Executing test:", test_case.name)
+    try:
+        obj = Objective(**test_case.config) if test_case.config else Objective()
+        assert test_case.expected_status == SUCCESS
+        assert obj.metric == test_case.expected_output["metric"]
+        assert obj.direction == test_case.expected_output["direction"]
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert isinstance(e, test_case.expected_error)
+    print("test execution complete")
+
+
+# --- TrialConfig ---
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default trial config",
+            expected_status=SUCCESS,
+            expected_output={"num_trials": 10, "parallel_trials": 1, "max_failed_trials": None},
+        ),
+        TestCase(
+            name="custom trial config",
+            expected_status=SUCCESS,
+            config={"num_trials": 50, "parallel_trials": 5, "max_failed_trials": 3},
+            expected_output={"num_trials": 50, "parallel_trials": 5, "max_failed_trials": 3},
+        ),
+    ],
+)
+def test_trial_config(test_case: TestCase):
+    """Test TrialConfig dataclass defaults and custom values."""
+    print("Executing test:", test_case.name)
+    tc = TrialConfig(**test_case.config) if test_case.config else TrialConfig()
+    assert tc.num_trials == test_case.expected_output["num_trials"]
+    assert tc.parallel_trials == test_case.expected_output["parallel_trials"]
+    assert tc.max_failed_trials == test_case.expected_output["max_failed_trials"]
+    print("test execution complete")
+
+
+# --- Metric ---
+
+
+def test_metric_construction():
+    """Test Metric dataclass stores all fields."""
+    print("Executing test: metric construction")
+    m = Metric(name="loss", min="0.01", max="0.99", latest="0.15")
+    assert m.name == "loss"
+    assert m.min == "0.01"
+    assert m.max == "0.99"
+    assert m.latest == "0.15"
+    print("test execution complete")
+
+
+# --- Result ---
+
+
+def test_result_construction():
+    """Test Result dataclass stores parameters and metrics."""
+    print("Executing test: result construction")
+    metrics = [Metric(name="loss", min="0.01", max="0.5", latest="0.1")]
+    r = Result(parameters={"lr": "0.01", "epochs": "10"}, metrics=metrics)
+    assert r.parameters == {"lr": "0.01", "epochs": "10"}
+    assert len(r.metrics) == 1
+    assert r.metrics[0].name == "loss"
+    print("test execution complete")
+
+
+# --- Trial ---
+
+
+def _make_trainjob(name: str = "test-job", status: str = common_constants.UNKNOWN) -> TrainJob:
+    """Build a minimal valid TrainJob for testing."""
+    runtime = Runtime(
+        name="test-runtime",
+        trainer=RuntimeTrainer(
+            trainer_type=TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image="test:latest",
+        ),
+    )
+    return TrainJob(
+        name=name,
+        runtime=runtime,
+        steps=[],
+        num_nodes=1,
+        creation_timestamp=datetime(2026, 1, 1),
+        status=status,
+    )
+
+
+def test_trial_default_metrics():
+    """Test Trial defaults to empty metrics list."""
+    print("Executing test: trial default metrics")
+    trainjob = _make_trainjob()
+    t = Trial(name="trial-1", parameters={"lr": "0.01"}, trainjob=trainjob)
+    assert t.name == "trial-1"
+    assert t.parameters == {"lr": "0.01"}
+    assert t.metrics == []
+    print("test execution complete")
+
+
+def test_trial_with_metrics():
+    """Test Trial with explicit metrics."""
+    print("Executing test: trial with metrics")
+    trainjob = _make_trainjob(status="Running")
+    metrics = [Metric(name="accuracy", min="0.5", max="0.95", latest="0.9")]
+    t = Trial(name="trial-2", parameters={"lr": "0.1"}, trainjob=trainjob, metrics=metrics)
+    assert len(t.metrics) == 1
+    assert t.metrics[0].latest == "0.9"
+    print("test execution complete")
+
+
+# --- OptimizationJob ---
+
+
+def test_optimization_job_default_status():
+    """Test OptimizationJob defaults status to UNKNOWN."""
+    print("Executing test: optimization job default status")
+    job = OptimizationJob(
+        name="job-1",
+        search_space={
+            "lr": ContinuousSearchSpace(
+                min=0.001, max=0.1, distribution=SearchDistribution.UNIFORM
+            ),
+        },
+        objectives=[Objective()],
+        algorithm=RandomSearch(),
+        trial_config=TrialConfig(),
+        trials=[],
+        creation_timestamp=datetime(2026, 1, 1),
+    )
+    assert job.status == common_constants.UNKNOWN
+    print("test execution complete")
+
+
+def test_optimization_job_custom_status():
+    """Test OptimizationJob with explicit status."""
+    print("Executing test: optimization job custom status")
+    job = OptimizationJob(
+        name="job-2",
+        search_space={"opt": CategoricalSearchSpace(choices=["adam", "sgd"])},
+        objectives=[Objective(metric="accuracy", direction=Direction.MAXIMIZE)],
+        algorithm=GridSearch(),
+        trial_config=TrialConfig(num_trials=5),
+        trials=[],
+        creation_timestamp=datetime(2026, 7, 1),
+        status="Running",
+    )
+    assert job.name == "job-2"
+    assert job.status == "Running"
+    assert job.algorithm.algorithm_name == "grid"
+    assert job.trial_config.num_trials == 5
+    print("test execution complete")

--- a/kubeflow/optimizer/types/optimization_types_test.py
+++ b/kubeflow/optimizer/types/optimization_types_test.py
@@ -98,14 +98,13 @@ def test_direction_enum_invalid_value():
 def test_objective(test_case: TestCase):
     """Test Objective dataclass construction and direction coercion."""
     print("Executing test:", test_case.name)
-    try:
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            Objective(**test_case.config) if test_case.config else Objective()
+    else:
         obj = Objective(**test_case.config) if test_case.config else Objective()
-        assert test_case.expected_status == SUCCESS
         assert obj.metric == test_case.expected_output["metric"]
         assert obj.direction == test_case.expected_output["direction"]
-    except Exception as e:
-        assert test_case.expected_status == FAILED
-        assert isinstance(e, test_case.expected_error)
     print("test execution complete")
 
 

--- a/kubeflow/optimizer/types/search_types_test.py
+++ b/kubeflow/optimizer/types/search_types_test.py
@@ -1,0 +1,158 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for kubeflow.optimizer.types.search_types module."""
+
+import pytest
+
+import kubeflow.optimizer.constants.constants as constants
+from kubeflow.optimizer.types.search_types import (
+    CategoricalSearchSpace,
+    ContinuousSearchSpace,
+    Distribution,
+    Search,
+)
+from kubeflow.trainer.test.common import SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="uniform creates double parameter with uniform distribution",
+            expected_status=SUCCESS,
+            config={"min": 0.001, "max": 0.1},
+            expected_output={
+                "parameterType": constants.DOUBLE_PARAMETER,
+                "min": "0.001",
+                "max": "0.1",
+                "distribution": "uniform",
+            },
+        ),
+        TestCase(
+            name="uniform with integer boundaries",
+            expected_status=SUCCESS,
+            config={"min": 1, "max": 100},
+            expected_output={
+                "parameterType": constants.DOUBLE_PARAMETER,
+                "min": "1",
+                "max": "100",
+                "distribution": "uniform",
+            },
+        ),
+    ],
+)
+def test_search_uniform(test_case: TestCase):
+    """Test that Search.uniform() produces correct ParameterSpec."""
+    print("Executing test:", test_case.name)
+    result = Search.uniform(min=test_case.config["min"], max=test_case.config["max"])
+    assert result.parameter_type == test_case.expected_output["parameterType"]
+    assert result.feasible_space.min == test_case.expected_output["min"]
+    assert result.feasible_space.max == test_case.expected_output["max"]
+    assert result.feasible_space.distribution == test_case.expected_output["distribution"]
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="loguniform creates double parameter with logUniform distribution",
+            expected_status=SUCCESS,
+            config={"min": 1e-5, "max": 1e-1},
+            expected_output={
+                "parameterType": constants.DOUBLE_PARAMETER,
+                "min": str(1e-5),
+                "max": str(1e-1),
+                "distribution": "logUniform",
+            },
+        ),
+    ],
+)
+def test_search_loguniform(test_case: TestCase):
+    """Test that Search.loguniform() produces correct ParameterSpec."""
+    print("Executing test:", test_case.name)
+    result = Search.loguniform(min=test_case.config["min"], max=test_case.config["max"])
+    assert result.parameter_type == test_case.expected_output["parameterType"]
+    assert result.feasible_space.min == test_case.expected_output["min"]
+    assert result.feasible_space.max == test_case.expected_output["max"]
+    assert result.feasible_space.distribution == test_case.expected_output["distribution"]
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="choice with string values",
+            expected_status=SUCCESS,
+            config={"values": ["adam", "sgd", "rmsprop"]},
+            expected_output={
+                "parameterType": constants.CATEGORICAL_PARAMETERS,
+                "list": ["adam", "sgd", "rmsprop"],
+            },
+        ),
+        TestCase(
+            name="choice with integer values stringifies them",
+            expected_status=SUCCESS,
+            config={"values": [10, 20, 30]},
+            expected_output={
+                "parameterType": constants.CATEGORICAL_PARAMETERS,
+                "list": ["10", "20", "30"],
+            },
+        ),
+        TestCase(
+            name="choice with mixed types",
+            expected_status=SUCCESS,
+            config={"values": [0.01, "auto", 5]},
+            expected_output={
+                "parameterType": constants.CATEGORICAL_PARAMETERS,
+                "list": ["0.01", "auto", "5"],
+            },
+        ),
+    ],
+)
+def test_search_choice(test_case: TestCase):
+    """Test that Search.choice() produces correct ParameterSpec with stringified values."""
+    print("Executing test:", test_case.name)
+    result = Search.choice(values=test_case.config["values"])
+    assert result.parameter_type == test_case.expected_output["parameterType"]
+    assert result.feasible_space.list == test_case.expected_output["list"]
+    print("test execution complete")
+
+
+def test_distribution_enum_values():
+    """Test that Distribution enum has correct string values."""
+    print("Executing test: distribution enum values")
+    assert Distribution.UNIFORM.value == "uniform"
+    assert Distribution.LOG_UNIFORM.value == "logUniform"
+    print("test execution complete")
+
+
+def test_continuous_search_space():
+    """Test ContinuousSearchSpace dataclass construction."""
+    print("Executing test: continuous search space")
+    space = ContinuousSearchSpace(min=0.0, max=1.0, distribution=Distribution.UNIFORM)
+    assert space.min == 0.0
+    assert space.max == 1.0
+    assert space.distribution == Distribution.UNIFORM
+    print("test execution complete")
+
+
+def test_categorical_search_space():
+    """Test CategoricalSearchSpace dataclass construction."""
+    print("Executing test: categorical search space")
+    space = CategoricalSearchSpace(choices=["a", "b", "c"])
+    assert space.choices == ["a", "b", "c"]
+    print("test execution complete")


### PR DESCRIPTION
## Summary
- Adds `_test.py` files for the 5 untested source files in `kubeflow/optimizer/`: `api/optimizer_client.py`, `backends/base.py`, `types/algorithm_types.py`, `types/optimization_types.py`, `types/search_types.py`
- 76 tests total covering ABC contracts, delegation, dataclass defaults/coercion, Katib spec conversion, and search space helpers
- Follows existing test patterns from `backends/kubernetes/backend_test.py` and `kubeflow/trainer/test/common.py`

Resolves RHOAIENG-72964

## Test plan
- [x] `uv run pytest -v kubeflow/optimizer/` — 76/76 passed
- [x] `make verify` — ruff check + format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for optimizer client initialization and backend method delegation.
  * Added tests validating runtime backend contracts, including abstract behavior, successful operations, and error handling.
  * Added coverage for algorithm registration, conversion, and default settings.
  * Added tests for optimization models, enums, defaults, validation, and search-space construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->